### PR TITLE
Add two-node E2E connectivity test

### DIFF
--- a/internal/engine/connectivity_test.go
+++ b/internal/engine/connectivity_test.go
@@ -1,0 +1,726 @@
+package engine_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/netip"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/enboxorg/dwn-mesh/internal/control"
+	"github.com/enboxorg/dwn-mesh/internal/did"
+	"github.com/enboxorg/dwn-mesh/internal/dwn"
+	dwncrypto "github.com/enboxorg/dwn-mesh/internal/dwn/crypto"
+	"github.com/enboxorg/dwn-mesh/internal/engine"
+	"github.com/enboxorg/dwn-mesh/internal/mesh"
+	"github.com/enboxorg/dwn-mesh/protocols"
+)
+
+// TestTwoNodeConnectivity is a full end-to-end integration test that:
+//
+//  1. Creates two DID identities (node A = anchor, node B = joiner)
+//  2. Registers both as tenants on the DWN server
+//  3. Node A creates a network with encrypted protocols
+//  4. Node B joins the network
+//  5. Node A delivers context key to node B
+//  6. Both nodes create real engines (UserspaceEngine + netstack)
+//  7. Both engines start, poll DWN, and discover each other
+//  8. Node A listens for TCP on its mesh IP via netstack
+//  9. Node B dials node A's mesh IP via netstack
+//  10. Verifies bidirectional data transfer through the WireGuard tunnel
+//
+// Requires DWN_ENDPOINT environment variable.
+// Run with: DWN_ENDPOINT=https://dev.aws.dwn.enbox.id go test ./internal/engine/ -run TestTwoNodeConnectivity -v -timeout 300s
+func TestTwoNodeConnectivity(t *testing.T) {
+	endpoint := os.Getenv("DWN_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("DWN_ENDPOINT not set, skipping integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 240*time.Second)
+	defer cancel()
+
+	// ================================================================
+	// Step 1: Create two node identities
+	// ================================================================
+	t.Log("Step 1: Creating two node identities")
+	nodeA := newTestNode(t, endpoint)
+	nodeB := newTestNode(t, endpoint)
+	t.Logf("  Node A (anchor): %s", nodeA.identity.URI)
+	t.Logf("  Node B (joiner): %s", nodeB.identity.URI)
+
+	// ================================================================
+	// Step 2: Node A installs wireguard-mesh protocol with encryption
+	// ================================================================
+	t.Log("Step 2: Node A installs wireguard-mesh protocol")
+	protocolDef, err := dwncrypto.InjectEncryptionDirectives(
+		protocols.MeshProtocolJSON,
+		nodeA.identity.EncryptionPrivateKey,
+		nodeA.identity.EncryptionKeyID(),
+	)
+	if err != nil {
+		t.Fatalf("injecting encryption directives: %v", err)
+	}
+
+	status, err := nodeA.api.ConfigureProtocol(ctx, nodeA.identity.URI, protocolDef)
+	if err != nil {
+		t.Fatalf("ConfigureProtocol: %v", err)
+	}
+	if status.Code >= 300 && status.Code != 409 {
+		t.Fatalf("ConfigureProtocol: %d %s", status.Code, status.Detail)
+	}
+	t.Logf("  Protocol installed: %d", status.Code)
+
+	// Also install key-delivery protocol.
+	err = mesh.EnsureKeyDeliveryProtocol(ctx, endpoint, nodeA.identity.URI, nodeA.signer,
+		nodeA.identity.EncryptionPrivateKey, nodeA.identity.EncryptionKeyID())
+	if err != nil {
+		t.Fatalf("EnsureKeyDeliveryProtocol: %v", err)
+	}
+	t.Log("  Key delivery protocol installed")
+
+	// ================================================================
+	// Step 3: Node A creates the network record
+	// ================================================================
+	t.Log("Step 3: Node A creates network record")
+	meshCIDR := "10.200.0.0/16"
+	networkData, _ := json.Marshal(map[string]any{
+		"name":     "e2e-connectivity-test",
+		"meshCIDR": meshCIDR,
+		"created":  time.Now().UTC().Format(time.RFC3339),
+	})
+
+	networkRecord, writeStatus, err := nodeA.api.Write(ctx, nodeA.identity.URI, dwn.WriteParams{
+		Protocol:     protocols.MeshProtocolURI,
+		ProtocolPath: "network",
+		Schema:       "https://enbox.org/schemas/wireguard-mesh/network",
+		DataFormat:   "application/json",
+		Data:         networkData,
+	})
+	if err != nil {
+		t.Fatalf("creating network record: %v", err)
+	}
+	if writeStatus.Code >= 300 {
+		t.Fatalf("network create: %d %s", writeStatus.Code, writeStatus.Detail)
+	}
+
+	networkRecordID := networkRecord.ID
+	if networkRecordID == "" {
+		// Fall back to query.
+		records, qs, err := nodeA.api.Query(ctx, nodeA.identity.URI, dwn.QueryParams{
+			Filter: dwn.RecordsFilter{
+				Protocol:     protocols.MeshProtocolURI,
+				ProtocolPath: "network",
+			},
+		}, "")
+		if err != nil || qs.Code != 200 || len(records) == 0 {
+			t.Fatalf("could not get network record ID: err=%v, status=%v, records=%d", err, qs, len(records))
+		}
+		networkRecordID = records[0].ID
+	}
+	t.Logf("  Network record: %s", networkRecordID)
+
+	// ================================================================
+	// Step 4: Node A creates admin member + nodeInfo (encrypted)
+	// ================================================================
+	t.Log("Step 4: Node A creates admin member and nodeInfo records")
+
+	memberRecipients, err := nodeA.encMgr.DeriveWriteEncryption("network/member")
+	if err != nil {
+		t.Fatalf("deriving member encryption: %v", err)
+	}
+
+	memberData, _ := json.Marshal(map[string]any{
+		"joinedAt": time.Now().UTC().Format(time.RFC3339),
+		"label":    "admin",
+	})
+	_, memberStatus, err := nodeA.api.Write(ctx, nodeA.identity.URI, dwn.WriteParams{
+		Protocol:             protocols.MeshProtocolURI,
+		ProtocolPath:         "network/member",
+		Schema:               "https://enbox.org/schemas/wireguard-mesh/member",
+		DataFormat:           "application/json",
+		Recipient:            nodeA.identity.URI,
+		ParentID:             networkRecordID,
+		ContextID:            networkRecordID,
+		Data:                 memberData,
+		Tags:                 map[string]any{"status": "active"},
+		EncryptionRecipients: memberRecipients,
+	})
+	if err != nil {
+		t.Fatalf("creating admin member: %v", err)
+	}
+	if memberStatus.Code >= 300 {
+		t.Fatalf("admin member: %d %s", memberStatus.Code, memberStatus.Detail)
+	}
+
+	wgKeysA, err := mesh.GenerateWireGuardKeyPair()
+	if err != nil {
+		t.Fatalf("generating WG keys for A: %v", err)
+	}
+	meshIPA, err := mesh.AllocateMeshIP(meshCIDR, nodeA.identity.URI)
+	if err != nil {
+		t.Fatalf("allocating mesh IP for A: %v", err)
+	}
+
+	regA, err := mesh.RegisterNode(ctx, mesh.RegisterNodeParams{
+		AnchorEndpoint:       endpoint,
+		AnchorDID:            nodeA.identity.URI,
+		NetworkRecordID:      networkRecordID,
+		SelfDID:              nodeA.identity.URI,
+		Signer:               nodeA.signer,
+		EncryptionKeyManager: nodeA.encMgr,
+		WireGuardPubKey:      wgKeysA.PublicKeyBase64(),
+		MeshIP:               meshIPA.String(),
+		Hostname:             "node-a",
+	})
+	if err != nil {
+		t.Fatalf("registering node A: %v", err)
+	}
+	t.Logf("  Node A: IP=%s, nodeInfo=%s", meshIPA, regA.NodeInfoRecordID)
+
+	// Write endpoint record for node A.
+	err = mesh.WriteEndpoint(ctx, mesh.WriteEndpointParams{
+		AnchorEndpoint:       endpoint,
+		AnchorDID:            nodeA.identity.URI,
+		NetworkRecordID:      networkRecordID,
+		NodeInfoRecordID:     regA.NodeInfoRecordID,
+		Signer:               nodeA.signer,
+		EncryptionKeyManager: nodeA.encMgr,
+		LocalEndpoints:       mesh.DiscoverLocalEndpoints(0),
+		NATType:              "unknown",
+	})
+	if err != nil {
+		t.Logf("  Warning: Node A endpoint write failed: %v", err)
+	}
+
+	// ================================================================
+	// Step 5: Node B joins the network
+	// ================================================================
+	t.Log("Step 5: Node B joins the network")
+
+	// Node B creates a member record on anchor's DWN.
+	err = mesh.CreateMember(ctx, mesh.CreateMemberParams{
+		AnchorEndpoint:       endpoint,
+		AnchorDID:            nodeA.identity.URI,
+		NetworkRecordID:      networkRecordID,
+		MemberDID:            nodeB.identity.URI,
+		Label:                "member",
+		Signer:               nodeB.signer,
+		EncryptionKeyManager: nodeB.encMgr,
+	})
+	if err != nil {
+		t.Logf("  Warning: Node B member creation failed: %v (may be expected)", err)
+	}
+
+	wgKeysB, err := mesh.GenerateWireGuardKeyPair()
+	if err != nil {
+		t.Fatalf("generating WG keys for B: %v", err)
+	}
+	meshIPB, err := mesh.AllocateMeshIP(meshCIDR, nodeB.identity.URI)
+	if err != nil {
+		t.Fatalf("allocating mesh IP for B: %v", err)
+	}
+
+	regB, err := mesh.RegisterNode(ctx, mesh.RegisterNodeParams{
+		AnchorEndpoint:       endpoint,
+		AnchorDID:            nodeA.identity.URI,
+		NetworkRecordID:      networkRecordID,
+		SelfDID:              nodeB.identity.URI,
+		Signer:               nodeB.signer,
+		EncryptionKeyManager: nodeB.encMgr,
+		WireGuardPubKey:      wgKeysB.PublicKeyBase64(),
+		MeshIP:               meshIPB.String(),
+		Hostname:             "node-b",
+	})
+	if err != nil {
+		t.Logf("  Warning: Node B nodeInfo registration failed: %v", err)
+	} else {
+		t.Logf("  Node B: IP=%s, nodeInfo=%s", meshIPB, regB.NodeInfoRecordID)
+	}
+
+	// Write endpoint record for node B.
+	if regB != nil && regB.NodeInfoRecordID != "" {
+		err = mesh.WriteEndpoint(ctx, mesh.WriteEndpointParams{
+			AnchorEndpoint:       endpoint,
+			AnchorDID:            nodeA.identity.URI,
+			NetworkRecordID:      networkRecordID,
+			NodeInfoRecordID:     regB.NodeInfoRecordID,
+			Signer:               nodeB.signer,
+			EncryptionKeyManager: nodeB.encMgr,
+			LocalEndpoints:       mesh.DiscoverLocalEndpoints(0),
+			NATType:              "unknown",
+		})
+		if err != nil {
+			t.Logf("  Warning: Node B endpoint write failed: %v", err)
+		}
+	}
+
+	if meshIPA == meshIPB {
+		t.Fatalf("IP collision: both nodes got %s", meshIPA)
+	}
+	t.Logf("  Mesh IPs: A=%s, B=%s", meshIPA, meshIPB)
+
+	// ================================================================
+	// Step 6: Node A delivers context key to Node B
+	// ================================================================
+	t.Log("Step 6: Node A delivers context key to Node B")
+
+	kdm := &mesh.KeyDeliveryManager{
+		Endpoint:             endpoint,
+		Signer:               nodeA.signer,
+		EncryptionKeyManager: nodeA.encMgr,
+	}
+
+	err = kdm.DeliverContextKey(ctx, mesh.DeliverContextKeyParams{
+		AnchorDID:      nodeA.identity.URI,
+		RecipientDID:   nodeA.identity.URI, // self
+		SourceProtocol: protocols.MeshProtocolURI,
+		ContextID:      networkRecordID,
+	})
+	if err != nil {
+		t.Logf("  Warning: self key delivery failed: %v", err)
+	}
+
+	err = kdm.DeliverContextKey(ctx, mesh.DeliverContextKeyParams{
+		AnchorDID:      nodeA.identity.URI,
+		RecipientDID:   nodeB.identity.URI,
+		SourceProtocol: protocols.MeshProtocolURI,
+		ContextID:      networkRecordID,
+	})
+	if err != nil {
+		t.Logf("  Warning: key delivery to B failed: %v", err)
+	} else {
+		t.Log("  Context key delivered to Node B")
+	}
+
+	// ================================================================
+	// Step 7: Create engines for both nodes
+	// ================================================================
+	t.Log("Step 7: Creating engines for both nodes")
+
+	engA, err := engine.New(engine.Config{
+		AnchorEndpoint:       endpoint,
+		AnchorTenant:         nodeA.identity.URI,
+		NetworkRecordID:      networkRecordID,
+		SelfDID:              nodeA.identity.URI,
+		Signer:               nodeA.signer,
+		EncryptionKeyManager: nodeA.encMgr,
+		Domain:               "e2e-test",
+		PollInterval:         5 * time.Second,
+		ListenPort:           0,
+	})
+	if err != nil {
+		t.Fatalf("creating engine A: %v", err)
+	}
+	defer engA.Stop()
+	t.Log("  Engine A created")
+
+	engB, err := engine.New(engine.Config{
+		AnchorEndpoint:       endpoint,
+		AnchorTenant:         nodeA.identity.URI,
+		NetworkRecordID:      networkRecordID,
+		SelfDID:              nodeB.identity.URI,
+		Signer:               nodeB.signer,
+		EncryptionKeyManager: nodeB.encMgr,
+		Domain:               "e2e-test",
+		PollInterval:         5 * time.Second,
+		ListenPort:           0,
+	})
+	if err != nil {
+		t.Fatalf("creating engine B: %v", err)
+	}
+	defer engB.Stop()
+	t.Log("  Engine B created")
+
+	// ================================================================
+	// Step 8: Start both engines
+	// ================================================================
+	t.Log("Step 8: Starting both engines")
+
+	if err := engA.Start(ctx); err != nil {
+		t.Fatalf("starting engine A: %v", err)
+	}
+	t.Log("  Engine A started")
+
+	if err := engB.Start(ctx); err != nil {
+		t.Fatalf("starting engine B: %v", err)
+	}
+	t.Log("  Engine B started")
+
+	// ================================================================
+	// Step 9: Wait for engines to discover each other via DWN polling
+	// ================================================================
+	t.Log("Step 9: Waiting for engines to discover peers via DWN")
+
+	// Give the engines time to poll DWN and build their NetworkMaps.
+	// The polling interval is 5s, so we wait up to 30s for both to
+	// have at least one peer in their network map.
+	deadline := time.Now().Add(30 * time.Second)
+	var nmA, nmB *netmapInfo
+	for time.Now().Before(deadline) {
+		nmA = getNetmapInfo(engA)
+		nmB = getNetmapInfo(engB)
+
+		if nmA != nil && nmB != nil && nmA.peerCount > 0 && nmB.peerCount > 0 {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+
+	if nmA == nil || nmA.peerCount == 0 {
+		t.Logf("  Engine A network map: %v", nmA)
+		t.Fatal("Engine A did not discover any peers within 30s")
+	}
+	if nmB == nil || nmB.peerCount == 0 {
+		t.Logf("  Engine B network map: %v", nmB)
+		t.Fatal("Engine B did not discover any peers within 30s")
+	}
+
+	t.Logf("  Engine A: self=%s, peers=%d", nmA.selfAddr, nmA.peerCount)
+	t.Logf("  Engine B: self=%s, peers=%d", nmB.selfAddr, nmB.peerCount)
+
+	// ================================================================
+	// Step 10: TCP connectivity through the mesh
+	// ================================================================
+	t.Log("Step 10: Testing TCP connectivity through WireGuard mesh")
+
+	nsA := engA.Netstack()
+	nsB := engB.Netstack()
+
+	if nsA == nil || nsB == nil {
+		t.Fatal("netstack is nil on one or both engines")
+	}
+
+	// Node A listens for TCP on port 9999 via netstack.
+	// Use 0.0.0.0 (wildcard) since netstack handles all mesh IPs.
+	listener, err := nsA.ListenTCP("tcp4", "0.0.0.0:9999")
+	if err != nil {
+		t.Fatalf("Node A ListenTCP: %v", err)
+	}
+	defer listener.Close()
+	t.Logf("  Node A listening on %s:9999 (via netstack)", meshIPA)
+
+	// Server goroutine: accept one connection, echo data back.
+	serverDone := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverDone <- fmt.Errorf("accept: %w", err)
+			return
+		}
+		defer conn.Close()
+
+		// Read whatever the client sends.
+		buf := make([]byte, 1024)
+		n, err := conn.Read(buf)
+		if err != nil && err != io.EOF {
+			serverDone <- fmt.Errorf("read: %w", err)
+			return
+		}
+
+		// Echo it back.
+		if _, err := conn.Write(buf[:n]); err != nil {
+			serverDone <- fmt.Errorf("write: %w", err)
+			return
+		}
+
+		serverDone <- nil
+	}()
+
+	// Give the listener a moment to start.
+	time.Sleep(100 * time.Millisecond)
+
+	// Node B dials Node A's mesh IP through netstack.
+	dialCtx, dialCancel := context.WithTimeout(ctx, 15*time.Second)
+	defer dialCancel()
+
+	dst := netip.AddrPortFrom(meshIPA, 9999)
+	conn, err := nsB.DialContextTCP(dialCtx, dst)
+	if err != nil {
+		t.Fatalf("Node B DialContextTCP to %s: %v", dst, err)
+	}
+	defer conn.Close()
+	t.Log("  Node B connected to Node A")
+
+	// Send test data.
+	testMsg := []byte("hello from node B through the WireGuard mesh!")
+	if _, err := conn.Write(testMsg); err != nil {
+		t.Fatalf("Node B write: %v", err)
+	}
+
+	// Read echo back.
+	conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+	buf := make([]byte, 1024)
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("Node B read echo: %v", err)
+	}
+
+	if string(buf[:n]) != string(testMsg) {
+		t.Fatalf("echo mismatch: got %q, want %q", buf[:n], testMsg)
+	}
+	t.Logf("  Echo verified: %q", string(buf[:n]))
+
+	// Wait for server to finish.
+	select {
+	case err := <-serverDone:
+		if err != nil {
+			t.Fatalf("server error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not finish within 5s")
+	}
+
+	// ================================================================
+	// Step 11: Clean shutdown
+	// ================================================================
+	t.Log("Step 11: Shutting down")
+
+	if err := engB.Stop(); err != nil {
+		t.Errorf("stopping engine B: %v", err)
+	}
+	if err := engA.Stop(); err != nil {
+		t.Errorf("stopping engine A: %v", err)
+	}
+
+	t.Log("=== Two-Node Connectivity Test PASSED ===")
+	t.Logf("  Network: e2e-connectivity-test (%s)", networkRecordID)
+	t.Logf("  Node A: %s → %s", nodeA.identity.URI[:30]+"...", meshIPA)
+	t.Logf("  Node B: %s → %s", nodeB.identity.URI[:30]+"...", meshIPB)
+	t.Log("  Engine: real UserspaceEngine + netstack (no root)")
+	t.Log("  Connectivity: TCP echo through WireGuard tunnel verified")
+}
+
+// TestTwoNodeNetworkMapDiscovery is a lighter version that verifies engines
+// discover each other via DWN polling without testing TCP connectivity.
+// This is useful when debugging the DWN → NetworkMap pipeline.
+func TestTwoNodeNetworkMapDiscovery(t *testing.T) {
+	endpoint := os.Getenv("DWN_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("DWN_ENDPOINT not set, skipping integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	t.Log("Creating two node identities")
+	nodeA := newTestNode(t, endpoint)
+	nodeB := newTestNode(t, endpoint)
+
+	// Set up network (same as full test but abbreviated).
+	protocolDef, err := dwncrypto.InjectEncryptionDirectives(
+		protocols.MeshProtocolJSON,
+		nodeA.identity.EncryptionPrivateKey,
+		nodeA.identity.EncryptionKeyID(),
+	)
+	if err != nil {
+		t.Fatalf("InjectEncryptionDirectives: %v", err)
+	}
+
+	status, err := nodeA.api.ConfigureProtocol(ctx, nodeA.identity.URI, protocolDef)
+	if err != nil || (status.Code >= 300 && status.Code != 409) {
+		t.Fatalf("ConfigureProtocol: err=%v, status=%v", err, status)
+	}
+
+	meshCIDR := "10.200.0.0/16"
+	networkData, _ := json.Marshal(map[string]any{
+		"name":     "discovery-test",
+		"meshCIDR": meshCIDR,
+	})
+	networkRecord, ws, err := nodeA.api.Write(ctx, nodeA.identity.URI, dwn.WriteParams{
+		Protocol:     protocols.MeshProtocolURI,
+		ProtocolPath: "network",
+		Schema:       "https://enbox.org/schemas/wireguard-mesh/network",
+		DataFormat:   "application/json",
+		Data:         networkData,
+	})
+	if err != nil || ws.Code >= 300 {
+		t.Fatalf("creating network: err=%v, status=%v", err, ws)
+	}
+	networkRecordID := networkRecord.ID
+	if networkRecordID == "" {
+		records, _, _ := nodeA.api.Query(ctx, nodeA.identity.URI, dwn.QueryParams{
+			Filter: dwn.RecordsFilter{Protocol: protocols.MeshProtocolURI, ProtocolPath: "network"},
+		}, "")
+		if len(records) > 0 {
+			networkRecordID = records[0].ID
+		}
+	}
+
+	// Register both nodes.
+	wgA, _ := mesh.GenerateWireGuardKeyPair()
+	ipA, _ := mesh.AllocateMeshIP(meshCIDR, nodeA.identity.URI)
+	mesh.RegisterNode(ctx, mesh.RegisterNodeParams{
+		AnchorEndpoint: endpoint, AnchorDID: nodeA.identity.URI,
+		NetworkRecordID: networkRecordID, SelfDID: nodeA.identity.URI,
+		Signer: nodeA.signer, EncryptionKeyManager: nodeA.encMgr,
+		WireGuardPubKey: wgA.PublicKeyBase64(), MeshIP: ipA.String(),
+		Hostname: "disc-a",
+	})
+
+	wgB, _ := mesh.GenerateWireGuardKeyPair()
+	ipB, _ := mesh.AllocateMeshIP(meshCIDR, nodeB.identity.URI)
+	mesh.RegisterNode(ctx, mesh.RegisterNodeParams{
+		AnchorEndpoint: endpoint, AnchorDID: nodeA.identity.URI,
+		NetworkRecordID: networkRecordID, SelfDID: nodeB.identity.URI,
+		Signer: nodeB.signer, EncryptionKeyManager: nodeB.encMgr,
+		WireGuardPubKey: wgB.PublicKeyBase64(), MeshIP: ipB.String(),
+		Hostname: "disc-b",
+	})
+
+	// Create member records.
+	memberRecipients, _ := nodeA.encMgr.DeriveWriteEncryption("network/member")
+	mData, _ := json.Marshal(map[string]any{"joinedAt": time.Now().UTC().Format(time.RFC3339)})
+	nodeA.api.Write(ctx, nodeA.identity.URI, dwn.WriteParams{
+		Protocol: protocols.MeshProtocolURI, ProtocolPath: "network/member",
+		Schema: "https://enbox.org/schemas/wireguard-mesh/member", DataFormat: "application/json",
+		Recipient: nodeA.identity.URI, ParentID: networkRecordID, ContextID: networkRecordID,
+		Data: mData, Tags: map[string]any{"status": "active"}, EncryptionRecipients: memberRecipients,
+	})
+
+	// Create engine A.
+	engA, err := engine.New(engine.Config{
+		AnchorEndpoint:       endpoint,
+		AnchorTenant:         nodeA.identity.URI,
+		NetworkRecordID:      networkRecordID,
+		SelfDID:              nodeA.identity.URI,
+		Signer:               nodeA.signer,
+		EncryptionKeyManager: nodeA.encMgr,
+		Domain:               "disc-test",
+		PollInterval:         3 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("creating engine A: %v", err)
+	}
+	defer engA.Stop()
+
+	if err := engA.Start(ctx); err != nil {
+		t.Fatalf("starting engine A: %v", err)
+	}
+
+	// Wait for engine A to load network map.
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		nm := engA.Backend().NetMap()
+		if nm != nil {
+			t.Logf("  Engine A NetMap: domain=%s, selfNode=%v, peers=%d",
+				nm.Domain, nm.SelfNode.Valid(), len(nm.Peers))
+
+			// Check if we see at least 1 nodeInfo (ourselves).
+			if nm.SelfNode.Valid() {
+				t.Log("  Engine A successfully loaded network map from DWN")
+				return
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+
+	t.Fatal("Engine A did not load network map within 20s")
+}
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+// testNode holds all identity and API state for a test node.
+type testNode struct {
+	identity *did.DID
+	signer   *dwn.Signer
+	encMgr   *dwncrypto.EncryptionKeyManager
+	api      *dwn.DwnAPI
+}
+
+// newTestNode creates a fresh DID identity, registers it as a tenant, and
+// returns a fully wired test node.
+func newTestNode(t *testing.T, endpoint string) *testNode {
+	t.Helper()
+
+	identity, err := did.Generate()
+	if err != nil {
+		t.Fatalf("generating DID: %v", err)
+	}
+
+	signer := &dwn.Signer{
+		DID:        identity.URI,
+		PrivateKey: identity.SigningKey,
+	}
+
+	// Register tenant.
+	regCtx, regCancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer regCancel()
+
+	err = dwn.RegisterTenant(regCtx, endpoint, signer.DID)
+	if err != nil {
+		if err == dwn.ErrRegistrationNotAvailable {
+			// Try a simple query to see if the server allows open access.
+			client := dwn.NewClient(endpoint, signer)
+			qCtx, qCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer qCancel()
+			reply, qErr := client.ProtocolsQuery(qCtx, signer.DID, "")
+			if qErr != nil || reply.Status.Code == 401 {
+				t.Skipf("Server requires tenant registration but PoW endpoints unavailable")
+			}
+		} else {
+			t.Fatalf("RegisterTenant: %v", err)
+		}
+	}
+
+	agent := dwn.NewSimpleAgent(endpoint, signer)
+	api := dwn.NewDwnAPI(agent)
+
+	encMgr := &dwncrypto.EncryptionKeyManager{
+		RootPrivateKey: identity.EncryptionPrivateKey,
+		RootKeyID:      identity.EncryptionKeyID(),
+		ProtocolURI:    protocols.MeshProtocolURI,
+	}
+
+	return &testNode{
+		identity: identity,
+		signer:   signer,
+		encMgr:   encMgr,
+		api:      api,
+	}
+}
+
+// netmapInfo summarizes a NetworkMap for test assertions.
+type netmapInfo struct {
+	selfAddr  netip.Addr
+	peerCount int
+	peerAddrs []netip.Addr
+}
+
+// getNetmapInfo extracts NetworkMap info from a running engine.
+func getNetmapInfo(eng *engine.Engine) *netmapInfo {
+	nm := eng.Backend().NetMap()
+	if nm == nil {
+		return nil
+	}
+
+	info := &netmapInfo{
+		peerCount: len(nm.Peers),
+	}
+
+	if nm.SelfNode.Valid() {
+		addrs := nm.SelfNode.Addresses()
+		if addrs.Len() > 0 {
+			info.selfAddr = addrs.At(0).Addr()
+		}
+	}
+
+	for _, p := range nm.Peers {
+		paddrs := p.Addresses()
+		if paddrs.Len() > 0 {
+			info.peerAddrs = append(info.peerAddrs, paddrs.At(0).Addr())
+		}
+	}
+
+	return info
+}
+
+// Ensure testNode fields are used to satisfy the compiler.
+var _ net.Conn
+var _ = control.ProtocolMesh

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -352,6 +352,12 @@ func (e *Engine) Backend() *ipnlocal.LocalBackend {
 	return e.backend
 }
 
+// Netstack returns the underlying netstack implementation.
+// Use this for userspace TCP/UDP listening and dialing through the mesh.
+func (e *Engine) Netstack() *netstack.Impl {
+	return e.ns
+}
+
 // slogToLogf adapts a *slog.Logger to meshnet's printf-style logger.Logf.
 func slogToLogf(l *slog.Logger) logger.Logf {
 	if l == nil {


### PR DESCRIPTION
## Summary

- Add `TestTwoNodeConnectivity` — the definitive end-to-end test that exercises the **entire dwn-mesh stack**: DID generation → tenant registration → network creation with encrypted protocols → member join → context key delivery → two real engines (UserspaceEngine + netstack) → peer discovery via DWN polling → **TCP echo through the WireGuard tunnel**
- Add `TestTwoNodeNetworkMapDiscovery` — lighter version that verifies the DWN → NetworkMap pipeline without TCP connectivity
- Add `Engine.Netstack()` accessor for userspace TCP/UDP listen/dial through the mesh

## Test Flow (TestTwoNodeConnectivity)

1. Create two DID identities (node A = anchor, node B = joiner)
2. Register both as tenants on the DWN server
3. Node A creates network with encrypted wireguard-mesh + key-delivery protocols
4. Node A creates admin member + nodeInfo records (encrypted)
5. Node B joins: creates member + nodeInfo records
6. Node A delivers context key to Node B
7. Both nodes create real engines (UserspaceEngine + gVisor netstack, no root required)
8. Both engines start, poll DWN, discover each other in the NetworkMap
9. Node A listens for TCP on port 9999 via netstack
10. Node B dials Node A's mesh IP:9999 through netstack → WireGuard tunnel
11. Bidirectional TCP echo verified
12. Clean shutdown

## Running

```bash
DWN_ENDPOINT=https://your-dwn-server go test ./internal/engine/ -run TestTwoNodeConnectivity -v -timeout 300s
```

Both tests skip when `DWN_ENDPOINT` is not set. Currently skips on the dev server (`dev.aws.dwn.enbox.id`) because it requires tenant registration but doesn't expose PoW endpoints — will work with any open-access DWN server or one with PoW registration available.

## All tests pass (no DWN_ENDPOINT)

```
ok  internal/engine  0.139s  (22 tests, 2 skipped)
```