### PR TITLE
feat(dwn): add provider-auth-v0 registration and auto-detect registration method

### DIFF
--- a/internal/dwn/register.go
+++ b/internal/dwn/register.go
@@ -15,22 +15,208 @@ import (
 	"time"
 )
 
+// serverInfo represents the response from GET /info.
+type serverInfo struct {
+	RegistrationRequirements []string         `json:"registrationRequirements"`
+	ProviderAuth             *providerAuthInfo `json:"providerAuth,omitempty"`
+}
+
+// providerAuthInfo mirrors the ProviderAuthInfo type from dwn-clients.
+type providerAuthInfo struct {
+	AuthorizeURL string `json:"authorizeUrl"`
+	TokenURL     string `json:"tokenUrl"`
+	RefreshURL   string `json:"refreshUrl,omitempty"`
+}
+
 // RegisterTenant registers a DID as a tenant on a DWN server.
 //
-// This implements the DWN server's proof-of-work registration flow:
-//  1. Fetch terms of service from GET /registration/terms-of-service (optional)
-//  2. Fetch proof-of-work challenge from GET /registration/proof-of-work
-//  3. Compute a qualifying response nonce (SHA-256 hashcash-style)
-//  4. POST /registration with the registration data + proof-of-work
+// The function queries GET /info to discover available registration methods and
+// dispatches to the appropriate flow:
 //
-// If proof-of-work or terms-of-service endpoints are not available (404),
-// this returns ErrRegistrationNotAvailable.
+//   - provider-auth-v0: exchanges an authorization code for a registration token
+//     via the server's built-in open-auth endpoints.
+//   - proof-of-work-sha256-v0: solves a hashcash-style proof-of-work challenge.
 //
-// This is required before writing to a DWN that has tenant registration enabled.
+// If no registration method is available (empty registrationRequirements), the
+// server is either open for all or misconfigured — this returns nil (no
+// registration needed) or ErrRegistrationNotAvailable respectively.
 func RegisterTenant(ctx context.Context, endpoint string, did string) error {
 	client := &http.Client{Timeout: 60 * time.Second}
 	baseURL := strings.TrimRight(endpoint, "/")
 
+	// 1. Query /info to discover registration requirements.
+	info, err := fetchServerInfo(ctx, client, baseURL)
+	if err != nil {
+		return fmt.Errorf("fetching server info: %w", err)
+	}
+
+	// Determine which registration method to use.
+	hasProviderAuth := false
+	hasProofOfWork := false
+	for _, req := range info.RegistrationRequirements {
+		switch req {
+		case "provider-auth-v0":
+			hasProviderAuth = true
+		case "proof-of-work-sha256-v0":
+			hasProofOfWork = true
+		}
+	}
+
+	// No registration requirements — server is open for all.
+	if len(info.RegistrationRequirements) == 0 {
+		return nil
+	}
+
+	// Prefer provider-auth when available.
+	if hasProviderAuth {
+		if info.ProviderAuth == nil || info.ProviderAuth.AuthorizeURL == "" || info.ProviderAuth.TokenURL == "" {
+			return fmt.Errorf("server advertises provider-auth-v0 but /info is missing providerAuth URLs")
+		}
+		return registerViaProviderAuth(ctx, client, baseURL, did, info.ProviderAuth)
+	}
+
+	if hasProofOfWork {
+		return registerViaProofOfWork(ctx, client, baseURL, did)
+	}
+
+	return ErrRegistrationNotAvailable
+}
+
+// ErrRegistrationNotAvailable is returned when the DWN server doesn't expose
+// any supported registration method.
+var ErrRegistrationNotAvailable = errors.New("registration endpoints not available on this server")
+
+// fetchServerInfo calls GET /info and parses the server info response.
+func fetchServerInfo(ctx context.Context, client *http.Client, baseURL string) (*serverInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/info", nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating /info request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET /info: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("GET /info returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var info serverInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return nil, fmt.Errorf("decoding /info response: %w", err)
+	}
+	return &info, nil
+}
+
+// registerViaProviderAuth implements the provider-auth-v0 registration flow:
+//  1. GET {authorizeUrl}?redirect_uri=urn:ietf:wg:oauth:2.0:oob&state=<random> → { code }
+//  2. POST {tokenUrl} with { code, redirectUri } → { registrationToken }
+//  3. POST /registration with { providerAuth: { registrationToken }, registrationData: { did } }
+func registerViaProviderAuth(ctx context.Context, client *http.Client, baseURL, did string, auth *providerAuthInfo) error {
+	// Use the OOB redirect URI since this is a non-interactive CLI flow.
+	const redirectURI = "urn:ietf:wg:oauth:2.0:oob"
+	state := generateNonce()
+
+	// Step 1: Get authorization code.
+	authorizeURL := auth.AuthorizeURL + "?redirect_uri=" + redirectURI + "&state=" + state
+	authReq, err := http.NewRequestWithContext(ctx, "GET", authorizeURL, nil)
+	if err != nil {
+		return fmt.Errorf("creating authorize request: %w", err)
+	}
+
+	authResp, err := client.Do(authReq)
+	if err != nil {
+		return fmt.Errorf("GET authorize: %w", err)
+	}
+	defer authResp.Body.Close()
+
+	if authResp.StatusCode != 200 {
+		body, _ := io.ReadAll(authResp.Body)
+		return fmt.Errorf("authorize endpoint returned %d: %s", authResp.StatusCode, string(body))
+	}
+
+	var authResult struct {
+		Code  string `json:"code"`
+		State string `json:"state"`
+	}
+	if err := json.NewDecoder(authResp.Body).Decode(&authResult); err != nil {
+		return fmt.Errorf("decoding authorize response: %w", err)
+	}
+	if authResult.Code == "" {
+		return fmt.Errorf("authorize response missing code")
+	}
+
+	// Step 2: Exchange code for registration token.
+	tokenBody, _ := json.Marshal(map[string]string{
+		"code":        authResult.Code,
+		"redirectUri": redirectURI,
+	})
+	tokenReq, err := http.NewRequestWithContext(ctx, "POST", auth.TokenURL, strings.NewReader(string(tokenBody)))
+	if err != nil {
+		return fmt.Errorf("creating token request: %w", err)
+	}
+	tokenReq.Header.Set("Content-Type", "application/json")
+
+	tokenResp, err := client.Do(tokenReq)
+	if err != nil {
+		return fmt.Errorf("POST token: %w", err)
+	}
+	defer tokenResp.Body.Close()
+
+	if tokenResp.StatusCode != 200 {
+		body, _ := io.ReadAll(tokenResp.Body)
+		return fmt.Errorf("token endpoint returned %d: %s", tokenResp.StatusCode, string(body))
+	}
+
+	var tokenResult struct {
+		RegistrationToken string `json:"registrationToken"`
+	}
+	if err := json.NewDecoder(tokenResp.Body).Decode(&tokenResult); err != nil {
+		return fmt.Errorf("decoding token response: %w", err)
+	}
+	if tokenResult.RegistrationToken == "" {
+		return fmt.Errorf("token response missing registrationToken")
+	}
+
+	// Step 3: Register the DID with the registration token.
+	regBody, _ := json.Marshal(map[string]any{
+		"providerAuth": map[string]string{
+			"registrationToken": tokenResult.RegistrationToken,
+		},
+		"registrationData": map[string]string{
+			"did": did,
+		},
+	})
+
+	regReq, err := http.NewRequestWithContext(ctx, "POST", baseURL+"/registration", strings.NewReader(string(regBody)))
+	if err != nil {
+		return fmt.Errorf("creating registration request: %w", err)
+	}
+	regReq.Header.Set("Content-Type", "application/json")
+
+	regResp, err := client.Do(regReq)
+	if err != nil {
+		return fmt.Errorf("POST /registration: %w", err)
+	}
+	defer regResp.Body.Close()
+
+	if regResp.StatusCode != 200 {
+		body, _ := io.ReadAll(regResp.Body)
+		return fmt.Errorf("registration failed: %d %s", regResp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// registerViaProofOfWork implements the proof-of-work-sha256-v0 registration flow:
+//  1. GET /registration/terms-of-service (optional)
+//  2. GET /registration/proof-of-work → { challengeNonce, maximumAllowedHashValue }
+//  3. Solve hashcash: SHA-256(challengeNonce + responseNonce + requestData) <= max
+//  4. POST /registration with proofOfWork credentials
+func registerViaProofOfWork(ctx context.Context, client *http.Client, baseURL, did string) error {
 	// 1. Fetch terms of service (optional — server may not have ToS configured).
 	var tosHash string
 	tosReq, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/registration/terms-of-service", nil)
@@ -120,10 +306,6 @@ func RegisterTenant(ctx context.Context, endpoint string, did string) error {
 
 	return nil
 }
-
-// ErrRegistrationNotAvailable is returned when the DWN server doesn't expose
-// registration endpoints (proof-of-work or provider auth may not be enabled).
-var ErrRegistrationNotAvailable = errors.New("registration endpoints not available on this server")
 
 // hashHex computes SHA-256 of a string and returns it as lowercase hex.
 func hashHex(input string) string {


### PR DESCRIPTION
## Summary

- Refactor `RegisterTenant` to query `GET /info` first and auto-detect the server's registration method instead of hardcoding proof-of-work
- Add full `provider-auth-v0` flow: `GET /provider-auth/authorize` → `POST /provider-auth/token` → `POST /registration`
- Preserve `proof-of-work-sha256-v0` as fallback when that's the only method available

This unblocks E2E tests against the dev DWN server once [enboxorg/enbox#518](https://github.com/enboxorg/enbox/pull/518) is deployed (which enables provider-auth on `dev.aws.dwn.enbox.id`).