### PR TITLE
fix: E2E integration against live DWN server

### DIFF
--- a/internal/did/publish.go
+++ b/internal/did/publish.go
@@ -61,7 +61,7 @@ func WithPublishLogger(l *slog.Logger) PublishOption {
 // If empty, the DID Document will not include a DWN service endpoint.
 func (d *DID) Publish(ctx context.Context, dwnEndpoint string, opts ...PublishOption) error {
 	options := &PublishOptions{
-		GatewayURL: "https://diddht.tbddev.org",
+		GatewayURL: "https://enbox-did-dht.fly.dev",
 		HTTPClient: http.DefaultClient,
 		Logger:     slog.Default(),
 	}

--- a/internal/dwn/cid.go
+++ b/internal/dwn/cid.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	codecDAGCBOR = 0x71 // DAG-CBOR multicodec
-	codecDAGPB   = 0x70 // DAG-PB (UnixFS) multicodec
+	codecRaw     = 0x55 // raw multicodec (UnixFS leaf blocks)
 )
 
 // dagCBOREncMode uses deterministic CBOR encoding (canonical key sorting)
@@ -48,17 +48,18 @@ func ComputeCID(obj any) (string, error) {
 	return c.String(), nil
 }
 
-// ComputeDataCID computes a CIDv1 (DAG-PB codec, SHA-256) for raw data bytes.
+// ComputeDataCID computes a CIDv1 (raw codec, SHA-256) for data bytes.
 //
-// NOTE: A full implementation should use UnixFS DAG-PB encoding (chunking).
-// This simplified version hashes the raw bytes directly, which is correct
-// for data ≤ 256KiB (single-chunk UnixFS).
+// UnixFS uses raw codec (0x55) for leaf blocks. For single-chunk data
+// (≤ 256KiB), the root CID is the leaf CID itself. This matches the
+// JS SDK's `Cid.computeDagPbCidFromBytes` which uses the UnixFS importer
+// and produces a raw-codec CID for single-block data.
 func ComputeDataCID(data []byte) (string, error) {
 	mh, err := multihash.Sum(data, multihash.SHA2_256, -1)
 	if err != nil {
 		return "", fmt.Errorf("multihash: %w", err)
 	}
 
-	c := gocid.NewCidV1(codecDAGPB, mh)
+	c := gocid.NewCidV1(codecRaw, mh)
 	return c.String(), nil
 }

--- a/internal/dwn/client.go
+++ b/internal/dwn/client.go
@@ -64,7 +64,7 @@ type RecordsWriteResult struct {
 // RecordsWrite creates or updates a record on the target DWN.
 //
 // For data payloads:
-//   - Data ≤ 30KB is inlined as base64url encodedData in the message
+//   - Data is always sent in the HTTP body as application/octet-stream
 //   - Data > 30KB is sent as binary in the HTTP body
 //
 // When encryption is enabled (via EncryptionRecipients), the plaintext is
@@ -79,11 +79,10 @@ func (c *Client) RecordsWrite(ctx context.Context, target string, opts RecordsWr
 	}
 	msg := built.Message
 
-	// Determine if data should go in the body (large payloads)
-	// or inline in the message (small payloads, already base64url encoded).
+	// Data always goes in the HTTP body as application/octet-stream.
+	// encodedData is a read-side optimization only (query/subscribe responses).
 	var bodyData []byte
-	if msg.EncodedData == "" && len(built.WireData) > 0 {
-		// Large data: send as binary body.
+	if len(built.WireData) > 0 {
 		bodyData = built.WireData
 	}
 

--- a/internal/dwn/dwn_test.go
+++ b/internal/dwn/dwn_test.go
@@ -169,8 +169,8 @@ func TestBuildRecordsWrite(t *testing.T) {
 		if msg.Authorization == nil || msg.Authorization.Signature == nil {
 			t.Fatal("missing authorization")
 		}
-		if msg.EncodedData == "" {
-			t.Error("missing encodedData for small payload")
+		if msg.EncodedData != "" {
+			t.Error("encodedData should not be set on writes (data goes in HTTP body)")
 		}
 	})
 
@@ -415,16 +415,16 @@ func TestBuildRecordsWriteEncrypted(t *testing.T) {
 		}
 	})
 
-	t.Run("encodedData contains ciphertext", func(t *testing.T) {
-		if msg.EncodedData == "" {
-			t.Fatal("small payload should be inlined")
+	t.Run("encodedData not set on writes", func(t *testing.T) {
+		if msg.EncodedData != "" {
+			t.Fatal("encodedData should not be set on writes (data goes in HTTP body)")
 		}
-		decoded, err := base64.RawURLEncoding.DecodeString(msg.EncodedData)
-		if err != nil {
-			t.Fatalf("decoding encodedData: %v", err)
-		}
+	})
+
+	t.Run("wireData contains ciphertext", func(t *testing.T) {
+		decoded := result.WireData
 		if bytes.Equal(decoded, plaintext) {
-			t.Fatal("encodedData should contain ciphertext, not plaintext")
+			t.Fatal("wireData should contain ciphertext, not plaintext")
 		}
 	})
 

--- a/internal/dwn/integration_test.go
+++ b/internal/dwn/integration_test.go
@@ -29,13 +29,29 @@ func testEndpoint(t *testing.T) string {
 	return endpoint
 }
 
-func testSigner(t *testing.T) *dwn.Signer {
+// testIdentity generates a new did:dht identity and publishes it to the DHT
+// so the DWN server can resolve the DID Document for JWS verification.
+func testIdentity(t *testing.T, endpoint string) *did.DID {
 	t.Helper()
-	// Use the full did package for proper did:dht generation.
 	identity, err := did.Generate()
 	if err != nil {
 		t.Fatalf("generating DID: %v", err)
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := identity.Publish(ctx, endpoint); err != nil {
+		t.Fatalf("publishing DID to DHT: %v", err)
+	}
+	t.Logf("Published DID: %s", identity.URI)
+
+	return identity
+}
+
+func testSigner(t *testing.T, endpoint string) *dwn.Signer {
+	t.Helper()
+	identity := testIdentity(t, endpoint)
 	return &dwn.Signer{
 		DID:        identity.URI,
 		PrivateKey: identity.SigningKey,
@@ -43,31 +59,14 @@ func testSigner(t *testing.T) *dwn.Signer {
 }
 
 // registerTenant registers the signer's DID as a tenant on the DWN server.
-// This is required before any write operations on servers with tenant registration.
-//
-// Returns true if registration succeeded or wasn't needed.
-// Returns false and skips the test if registration isn't available.
+// RegisterTenant auto-detects the registration method (provider-auth or PoW)
+// via GET /info and returns nil if the server is open for all.
 func registerTenant(t *testing.T, endpoint string, signer *dwn.Signer) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	err := dwn.RegisterTenant(ctx, endpoint, signer.DID)
-	if err != nil {
-		if err == dwn.ErrRegistrationNotAvailable {
-			// Check if the server allows open access by trying a simple query.
-			client := dwn.NewClient(endpoint, signer)
-			queryCtx, queryCancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer queryCancel()
-			reply, qErr := client.ProtocolsQuery(queryCtx, signer.DID, "")
-			if qErr != nil || reply.Status.Code == 401 {
-				t.Skipf("Server requires tenant registration but PoW endpoints unavailable. "+
-					"Set up open-access DWN or pre-register tenant. (query: %d)", reply.Status.Code)
-			}
-			// Server allowed the query — open access.
-			t.Logf("Registration not available but server allows open access")
-			return
-		}
+	if err := dwn.RegisterTenant(ctx, endpoint, signer.DID); err != nil {
 		t.Fatalf("RegisterTenant: %v", err)
 	}
 	t.Logf("Registered tenant: %s", signer.DID)
@@ -75,7 +74,7 @@ func registerTenant(t *testing.T, endpoint string, signer *dwn.Signer) {
 
 func TestIntegrationProtocolsConfigure(t *testing.T) {
 	endpoint := testEndpoint(t)
-	signer := testSigner(t)
+	signer := testSigner(t, endpoint)
 	registerTenant(t, endpoint, signer)
 
 	agent := dwn.NewSimpleAgent(endpoint, signer)
@@ -114,7 +113,7 @@ func TestIntegrationProtocolsConfigure(t *testing.T) {
 
 func TestIntegrationRecordsWriteReadQuery(t *testing.T) {
 	endpoint := testEndpoint(t)
-	signer := testSigner(t)
+	signer := testSigner(t, endpoint)
 	registerTenant(t, endpoint, signer)
 
 	agent := dwn.NewSimpleAgent(endpoint, signer)
@@ -237,7 +236,7 @@ func TestIntegrationRecordsWriteReadQuery(t *testing.T) {
 
 func TestIntegrationRecordsDelete(t *testing.T) {
 	endpoint := testEndpoint(t)
-	signer := testSigner(t)
+	signer := testSigner(t, endpoint)
 	registerTenant(t, endpoint, signer)
 
 	agent := dwn.NewSimpleAgent(endpoint, signer)
@@ -308,7 +307,7 @@ func TestIntegrationRecordsDelete(t *testing.T) {
 
 func TestIntegrationEncryptedRecordsWrite(t *testing.T) {
 	endpoint := testEndpoint(t)
-	signer := testSigner(t)
+	signer := testSigner(t, endpoint)
 	registerTenant(t, endpoint, signer)
 
 	agent := dwn.NewSimpleAgent(endpoint, signer)
@@ -458,7 +457,7 @@ func TestIntegrationEncryptedRecordsWrite(t *testing.T) {
 
 func TestIntegrationEncryptedWriteQueryDelete(t *testing.T) {
 	endpoint := testEndpoint(t)
-	signer := testSigner(t)
+	signer := testSigner(t, endpoint)
 	registerTenant(t, endpoint, signer)
 
 	agent := dwn.NewSimpleAgent(endpoint, signer)
@@ -569,7 +568,7 @@ func TestIntegrationEncryptedWriteQueryDelete(t *testing.T) {
 
 func TestIntegrationEncryptedMultiRecipient(t *testing.T) {
 	endpoint := testEndpoint(t)
-	signer := testSigner(t)
+	signer := testSigner(t, endpoint)
 	registerTenant(t, endpoint, signer)
 
 	agent := dwn.NewSimpleAgent(endpoint, signer)
@@ -698,7 +697,7 @@ func TestIntegrationHTTPWireProtocol(t *testing.T) {
 	// Verify the wire protocol is correct by checking that the server
 	// accepts our dwn-request header format.
 	endpoint := testEndpoint(t)
-	signer := testSigner(t)
+	signer := testSigner(t, endpoint)
 	registerTenant(t, endpoint, signer)
 
 	client := dwn.NewClient(endpoint, signer)

--- a/internal/dwn/message.go
+++ b/internal/dwn/message.go
@@ -2,7 +2,6 @@ package dwn
 
 import (
 	"crypto/ed25519"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -170,10 +169,9 @@ type BuildRecordsWriteResult struct {
 	// Message is the signed DWN message.
 	Message *Message
 
-	// WireData is the data bytes to send on the wire (ciphertext if encrypted,
-	// plaintext otherwise). This is what dataCid/dataSize in the descriptor
-	// reference. For data ≤ 30KB, this is already inlined as msg.EncodedData.
-	// For larger data, the caller must send it as the HTTP body.
+	// WireData is the data bytes to send in the HTTP body as
+	// application/octet-stream (ciphertext if encrypted, plaintext otherwise).
+	// This is what dataCid/dataSize in the descriptor reference.
 	WireData []byte
 }
 
@@ -317,10 +315,9 @@ func BuildRecordsWrite(s *Signer, opts RecordsWriteOptions) (*BuildRecordsWriteR
 		},
 	}
 
-	// Inline data if ≤ 30KB.
-	if len(wireData) <= 30000 {
-		msg.EncodedData = base64.RawURLEncoding.EncodeToString(wireData)
-	}
+	// NOTE: encodedData is a read-side optimization — the server inlines small
+	// data in query/subscribe responses. On the write side, data always goes in
+	// the HTTP body as application/octet-stream regardless of size.
 
 	return &BuildRecordsWriteResult{
 		Message:  msg,

--- a/internal/dwn/record_test.go
+++ b/internal/dwn/record_test.go
@@ -24,7 +24,9 @@ func TestRecordFromWrite(t *testing.T) {
 	msg := result.Message
 
 	agent := NewSimpleAgent("http://localhost:8080", s)
-	record := RecordFromWrite(agent, s.DID, msg, msg.EncodedData)
+	// After a write the caller has the wire data; encode it for the local Record.
+	encoded := base64.RawURLEncoding.EncodeToString(result.WireData)
+	record := RecordFromWrite(agent, s.DID, msg, encoded)
 
 	t.Run("record ID", func(t *testing.T) {
 		if record.ID == "" {
@@ -80,7 +82,8 @@ func TestRecordDataLazyAccess(t *testing.T) {
 	})
 	msg := writeResult.Message
 
-	record := RecordFromWrite(agent, s.DID, msg, msg.EncodedData)
+	encoded := base64.RawURLEncoding.EncodeToString(writeResult.WireData)
+	record := RecordFromWrite(agent, s.DID, msg, encoded)
 
 	t.Run("JSON", func(t *testing.T) {
 		var result map[string]string
@@ -97,7 +100,7 @@ func TestRecordDataLazyAccess(t *testing.T) {
 		// Data was consumed by JSON call above. Since there's no server
 		// to re-fetch from, and no raw data, this should fail.
 		// But we can set up a new record for this test.
-		record2 := RecordFromWrite(agent, s.DID, msg, msg.EncodedData)
+		record2 := RecordFromWrite(agent, s.DID, msg, encoded)
 		text, err := record2.Data().Text(context.Background())
 		if err != nil {
 			t.Fatalf("Data().Text: %v", err)
@@ -108,7 +111,7 @@ func TestRecordDataLazyAccess(t *testing.T) {
 	})
 
 	t.Run("Bytes", func(t *testing.T) {
-		record3 := RecordFromWrite(agent, s.DID, msg, msg.EncodedData)
+		record3 := RecordFromWrite(agent, s.DID, msg, encoded)
 		data, err := record3.Data().Bytes(context.Background())
 		if err != nil {
 			t.Fatalf("Data().Bytes: %v", err)

--- a/internal/dwn/transport_test.go
+++ b/internal/dwn/transport_test.go
@@ -291,7 +291,6 @@ func TestHTTPTransportSend(t *testing.T) {
 			Data:         make([]byte, 50000), // > 30KB threshold
 		})
 		msg := writeResult.Message
-		msg.EncodedData = "" // large data, not inlined
 
 		largeData := make([]byte, 50000)
 		for i := range largeData {

--- a/internal/engine/connectivity_test.go
+++ b/internal/engine/connectivity_test.go
@@ -634,14 +634,21 @@ type testNode struct {
 	api      *dwn.DwnAPI
 }
 
-// newTestNode creates a fresh DID identity, registers it as a tenant, and
-// returns a fully wired test node.
+// newTestNode creates a fresh DID identity, publishes it to the DHT,
+// registers it as a tenant, and returns a fully wired test node.
 func newTestNode(t *testing.T, endpoint string) *testNode {
 	t.Helper()
 
 	identity, err := did.Generate()
 	if err != nil {
 		t.Fatalf("generating DID: %v", err)
+	}
+
+	// Publish DID to DHT so the server can resolve it for JWS verification.
+	pubCtx, pubCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer pubCancel()
+	if err := identity.Publish(pubCtx, endpoint); err != nil {
+		t.Fatalf("publishing DID: %v", err)
 	}
 
 	signer := &dwn.Signer{
@@ -653,20 +660,8 @@ func newTestNode(t *testing.T, endpoint string) *testNode {
 	regCtx, regCancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer regCancel()
 
-	err = dwn.RegisterTenant(regCtx, endpoint, signer.DID)
-	if err != nil {
-		if err == dwn.ErrRegistrationNotAvailable {
-			// Try a simple query to see if the server allows open access.
-			client := dwn.NewClient(endpoint, signer)
-			qCtx, qCancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer qCancel()
-			reply, qErr := client.ProtocolsQuery(qCtx, signer.DID, "")
-			if qErr != nil || reply.Status.Code == 401 {
-				t.Skipf("Server requires tenant registration but PoW endpoints unavailable")
-			}
-		} else {
-			t.Fatalf("RegisterTenant: %v", err)
-		}
+	if err := dwn.RegisterTenant(regCtx, endpoint, signer.DID); err != nil {
+		t.Fatalf("RegisterTenant: %v", err)
 	}
 
 	agent := dwn.NewSimpleAgent(endpoint, signer)

--- a/internal/mesh/e2e_test.go
+++ b/internal/mesh/e2e_test.go
@@ -30,26 +30,12 @@ func testEndpoint(t *testing.T) string {
 }
 
 // registerTenant registers a DID as a tenant on the DWN server.
-// Skips the test if registration is not available.
 func registerTenant(t *testing.T, endpoint string, signer *dwn.Signer) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	err := dwn.RegisterTenant(ctx, endpoint, signer.DID)
-	if err != nil {
-		if err == dwn.ErrRegistrationNotAvailable {
-			// Check if the server allows open access.
-			client := dwn.NewClient(endpoint, signer)
-			queryCtx, queryCancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer queryCancel()
-			reply, qErr := client.ProtocolsQuery(queryCtx, signer.DID, "")
-			if qErr != nil || reply.Status.Code == 401 {
-				t.Skipf("Server requires tenant registration but PoW endpoints unavailable")
-			}
-			t.Logf("Registration not available but server allows open access")
-			return
-		}
+	if err := dwn.RegisterTenant(ctx, endpoint, signer.DID); err != nil {
 		t.Fatalf("RegisterTenant: %v", err)
 	}
 	t.Logf("Registered tenant: %s", signer.DID)
@@ -64,13 +50,21 @@ type nodeIdentity struct {
 	API    *dwn.DwnAPI
 }
 
-// newNode creates a fresh node identity and registers it on the DWN.
+// newNode creates a fresh node identity, publishes it to the DHT,
+// registers it as a tenant, and returns a fully wired node.
 func newNode(t *testing.T, endpoint string) *nodeIdentity {
 	t.Helper()
 
 	identity, err := did.Generate()
 	if err != nil {
 		t.Fatalf("generating DID: %v", err)
+	}
+
+	// Publish DID to DHT so the server can resolve it for JWS verification.
+	pubCtx, pubCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer pubCancel()
+	if err := identity.Publish(pubCtx, endpoint); err != nil {
+		t.Fatalf("publishing DID: %v", err)
 	}
 
 	signer := &dwn.Signer{

--- a/pkg/dids/diddht/diddht.go
+++ b/pkg/dids/diddht/diddht.go
@@ -10,7 +10,7 @@ import (
 	"github.com/enboxorg/dwn-mesh/pkg/dids/diddht/internal/pkarr"
 )
 
-const defaultGatewayURL = "https://diddht.tbddev.org"
+const defaultGatewayURL = "https://enbox-did-dht.fly.dev"
 
 // gateway is the internal interface used to publish Pakrr messages to the DHT
 type gateway interface {


### PR DESCRIPTION
## Summary

Five fixes to get all integration tests passing against `dev.aws.dwn.enbox.id`:

- **Remove `encodedData` inlining on writes** — data always goes in the HTTP body. `encodedData` is a read-side optimization (query/subscribe responses), not valid in write requests
- **Fix data CID codec** — use raw (0x55) instead of DAG-PB (0x70) for single-block data, matching the JS SDK's UnixFS importer
- **Publish DIDs to DHT** before use so the server can resolve DID Documents for JWS verification
- **Update default DHT gateway** from defunct `diddht.tbddev.org` to `enbox-did-dht.fly.dev`
- **Simplify registration helpers** — `RegisterTenant` now auto-detects method via `/info` (from #5)

### Test results
All 7 `TestIntegration*` tests pass against the live dev server. The mesh `TestE2ENetworkCreateJoinQueryDecrypt` has a separate protocol schema issue (`$squash` property) unrelated to these changes.