### PR TITLE
feat: populate record IDs from write responses and re-add $squash

### DIFF
--- a/internal/dwn/agent.go
+++ b/internal/dwn/agent.go
@@ -88,6 +88,11 @@ type DwnResponse struct {
 
 	// Data is binary record data (for RecordsRead responses).
 	Data []byte
+
+	// BuiltMessage is the constructed Message from a write operation.
+	// Contains the computed recordId, contextId, and full descriptor.
+	// Only populated for RecordsWrite responses.
+	BuiltMessage *Message
 }
 
 //
@@ -257,8 +262,9 @@ func (a *SimpleAgent) sendRecordsWrite(ctx context.Context, target string, req D
 	}
 
 	return &DwnResponse{
-		Status: result.Reply.Status,
-		Reply:  result.Reply,
+		Status:       result.Reply.Status,
+		Reply:        result.Reply,
+		BuiltMessage: result.Message,
 	}, nil
 }
 

--- a/internal/dwn/client.go
+++ b/internal/dwn/client.go
@@ -59,6 +59,8 @@ func NewClient(endpoint string, signer *Signer, opts ...ClientOption) *Client {
 type RecordsWriteResult struct {
 	Reply    *DwnReply
 	RecordID string
+	// Message is the built DWN message with computed recordId, contextId, etc.
+	Message *Message
 }
 
 // RecordsWrite creates or updates a record on the target DWN.
@@ -94,6 +96,7 @@ func (c *Client) RecordsWrite(ctx context.Context, target string, opts RecordsWr
 	return &RecordsWriteResult{
 		Reply:    result.Reply,
 		RecordID: msg.RecordID,
+		Message:  msg,
 	}, nil
 }
 

--- a/internal/dwn/dwnapi.go
+++ b/internal/dwn/dwnapi.go
@@ -53,33 +53,41 @@ func (api *DwnAPI) Write(ctx context.Context, target string, params WriteParams)
 
 	status := resp.Status
 
-	// Construct a Record from the response.
-	// For writes, we build the record from the params since the response
-	// doesn't echo back the full message.
-	record := &Record{
-		ID:           "", // will be set from the write response or params
-		Protocol:     params.Protocol,
-		ProtocolPath: params.ProtocolPath,
-		Schema:       params.Schema,
-		Recipient:    params.Recipient,
-		DataFormat:   params.DataFormat,
-		Tags:         params.Tags,
-		agent:        api.agent,
-		target:       target,
-	}
-
-	if params.RecordID != "" {
-		record.ID = params.RecordID
-	}
-
-	// Store data for lazy access.
-	if len(params.Data) > 0 {
-		if len(params.Data) <= maxInlineDataSize {
-			record.encodedData = encodeData(params.Data)
-		} else {
+	// Construct a Record from the built message which has the computed
+	// recordId, contextId, timestamps, and full descriptor.
+	var record *Record
+	if resp.BuiltMessage != nil {
+		var encoded string
+		if len(params.Data) > 0 && len(params.Data) <= maxInlineDataSize {
+			encoded = encodeData(params.Data)
+		}
+		record = RecordFromWrite(api.agent, target, resp.BuiltMessage, encoded)
+		record.Author = api.agent.DID()
+		// Store raw data for large payloads.
+		if len(params.Data) > maxInlineDataSize {
 			record.rawData = params.Data
 		}
-		record.DataSize = len(params.Data)
+	} else {
+		// Fallback: construct manually if built message is not available.
+		record = &Record{
+			ID:           params.RecordID,
+			Protocol:     params.Protocol,
+			ProtocolPath: params.ProtocolPath,
+			Schema:       params.Schema,
+			Recipient:    params.Recipient,
+			DataFormat:   params.DataFormat,
+			Tags:         params.Tags,
+			agent:        api.agent,
+			target:       target,
+		}
+		if len(params.Data) > 0 {
+			if len(params.Data) <= maxInlineDataSize {
+				record.encodedData = encodeData(params.Data)
+			} else {
+				record.rawData = params.Data
+			}
+			record.DataSize = len(params.Data)
+		}
 	}
 
 	return record, &status, nil

--- a/internal/dwn/integration_test.go
+++ b/internal/dwn/integration_test.go
@@ -950,3 +950,45 @@ func TestIntegrationProtocolRoleWrite(t *testing.T) {
 	}
 	t.Logf("Step 8: Bob's nested role write succeeded: %d %s", postStatus.Code, postStatus.Detail)
 }
+
+// TestIntegrationSquashDirective verifies the server accepts $squash in protocol definitions.
+func TestIntegrationSquashDirective(t *testing.T) {
+	endpoint := testEndpoint(t)
+	signer := testSigner(t, endpoint)
+	registerTenant(t, endpoint, signer)
+
+	agent := dwn.NewSimpleAgent(endpoint, signer)
+	api := dwn.NewDwnAPI(agent)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	protocolURI := fmt.Sprintf("https://example.com/squash-test/%d", time.Now().UnixNano())
+	def := json.RawMessage(fmt.Sprintf(`{
+		"protocol": %q,
+		"published": true,
+		"types": {
+			"status": {
+				"dataFormats": ["application/json"]
+			}
+		},
+		"structure": {
+			"status": {
+				"$squash": true,
+				"$actions": [
+					{ "who": "anyone", "can": ["read"] }
+				]
+			}
+		}
+	}`, protocolURI))
+
+	status, err := api.ConfigureProtocol(ctx, signer.DID, def)
+	if err != nil {
+		t.Fatalf("ConfigureProtocol with $squash: %v", err)
+	}
+	t.Logf("ConfigureProtocol status: %d %s", status.Code, status.Detail)
+	if status.Code >= 300 {
+		t.Fatalf("Server rejected $squash: %d %s", status.Code, status.Detail)
+	}
+	t.Log("Server accepted $squash!")
+}

--- a/internal/dwn/record.go
+++ b/internal/dwn/record.go
@@ -350,33 +350,46 @@ func (r *Record) Update(ctx context.Context, data []byte, opts ...RecordUpdateOp
 		return nil, fmt.Errorf("update failed: %d %s", resp.Status.Code, resp.Status.Detail)
 	}
 
-	// Return a new record with updated metadata.
-	// Construct explicitly to avoid copying the mutex.
-	updated := &Record{
-		ID:            r.ID,
-		ContextID:     r.ContextID,
-		DateCreated:   r.DateCreated,
-		Protocol:      r.Protocol,
-		ProtocolPath:  r.ProtocolPath,
-		Schema:        r.Schema,
-		ParentID:      r.ParentID,
-		Recipient:     r.Recipient,
-		DataFormat:    r.DataFormat,
-		DataCID:       r.DataCID,
-		Published:     r.Published,
-		DatePublished: r.DatePublished,
-		Tags:          r.Tags,
-		Timestamp:     r.Timestamp,
-		Author:        r.Author,
-		agent:         r.agent,
-		target:        r.target,
-		DataSize:      len(data),
-	}
-
-	if len(data) <= maxInlineDataSize {
-		updated.encodedData = base64.RawURLEncoding.EncodeToString(data)
+	// Build updated record from the built message if available (has accurate
+	// dataCid, messageTimestamp, dataSize from the computed descriptor).
+	var updated *Record
+	if resp.BuiltMessage != nil {
+		var encoded string
+		if len(data) <= maxInlineDataSize {
+			encoded = base64.RawURLEncoding.EncodeToString(data)
+		}
+		updated = RecordFromWrite(r.agent, r.target, resp.BuiltMessage, encoded)
+		updated.Author = r.Author
+		if len(data) > maxInlineDataSize {
+			updated.rawData = data
+		}
 	} else {
-		updated.rawData = data
+		// Fallback: construct manually.
+		updated = &Record{
+			ID:            r.ID,
+			ContextID:     r.ContextID,
+			DateCreated:   r.DateCreated,
+			Protocol:      r.Protocol,
+			ProtocolPath:  r.ProtocolPath,
+			Schema:        r.Schema,
+			ParentID:      r.ParentID,
+			Recipient:     r.Recipient,
+			DataFormat:    r.DataFormat,
+			DataCID:       r.DataCID,
+			Published:     r.Published,
+			DatePublished: r.DatePublished,
+			Tags:          r.Tags,
+			Timestamp:     r.Timestamp,
+			Author:        r.Author,
+			agent:         r.agent,
+			target:        r.target,
+			DataSize:      len(data),
+		}
+		if len(data) <= maxInlineDataSize {
+			updated.encodedData = base64.RawURLEncoding.EncodeToString(data)
+		} else {
+			updated.rawData = data
+		}
 	}
 
 	return updated, nil

--- a/protocols/wireguard-mesh.json
+++ b/protocols/wireguard-mesh.json
@@ -94,6 +94,7 @@
       },
 
       "nodeInfo": {
+        "$squash": true,
         "$size": { "max": 10000 },
         "$encryption": {
           "rootKeyId": "#dwn-enc",
@@ -114,6 +115,7 @@
         ],
 
         "endpoint": {
+          "$squash": true,
           "$size": { "max": 2000 },
           "$encryption": {
             "rootKeyId": "#dwn-enc",


### PR DESCRIPTION
## Summary

- Fix `DwnAPI.Write()` to return records with populated IDs, contextIds, timestamps, and all computed fields
- Fix `Record.Update()` to return accurate metadata from the built message
- Re-add `$squash: true` to `nodeInfo` and `endpoint` in `wireguard-mesh.json`

## Background

**Record ID fix:** The DWN server doesn't echo back the full message in write responses (only `{"status":{...}}`). Previously, `Write()` returned records with empty IDs, forcing callers to issue a follow-up query to get the ID. The fix propagates the client-side built `*Message` (which has all computed fields like `recordId`, `contextId`, `dateCreated`, `dataCid`) through `DwnResponse` and uses the existing `RecordFromWrite()` function.

**$squash fix:** Issue #528 was a stale `generated/precompiled-validators.js` in a previous Docker build, not a schema bug. The current deployed server (sha-b331838) accepts `$squash`. Verified via `TestIntegrationSquashDirective`. Closed #528.

## Changes

**Record ID plumbing (3 files):**
- `internal/dwn/agent.go` — Add `BuiltMessage *Message` to `DwnResponse`, propagate from `sendRecordsWrite`
- `internal/dwn/client.go` — Add `Message *Message` to `RecordsWriteResult`
- `internal/dwn/dwnapi.go` — `Write()` uses `RecordFromWrite()` when BuiltMessage available; sets Author from agent DID
- `internal/dwn/record.go` — `Update()` uses `RecordFromWrite()` for accurate DataCID/Timestamp

**Protocol:**
- `protocols/wireguard-mesh.json` — `$squash: true` on `nodeInfo` and `endpoint`

**Tests:**
- `internal/dwn/integration_test.go` — New `TestIntegrationSquashDirective`

## Verification

E2E test now shows populated IDs directly from writes:
```
Step 3: Network record: bafyreif35... (status: 202)    ← was empty before
Step 5: Node A registered: nodeInfo=bafyreihyjy...     ← was empty before
```