### PR TITLE
feat: two-node mesh demo (DERP relay, endpoint writeback, multi-party encryption)

### DIFF
--- a/cmd/dwn-mesh/main.go
+++ b/cmd/dwn-mesh/main.go
@@ -824,16 +824,69 @@ func cmdUp(ctx context.Context, args []string) error {
 
 	encMgr := newEncryptionKeyManager(identity)
 
+	// For non-anchor nodes: fetch the context key from the anchor so we
+	// can encrypt records with Protocol Context scheme (which the anchor
+	// can decrypt using the shared context key).
+	useContextEncryption := false
+	if ns.AnchorDID != identity.URI {
+		contextKey, err := fetchContextKey(ctx, identity, ns)
+		if err != nil {
+			slog.Warn("context key fetch failed (will retry on next up)",
+				slog.Any("error", err),
+			)
+		} else if contextKey != nil {
+			privBytes, err := contextKey.PrivateKeyBytes()
+			if err != nil {
+				return fmt.Errorf("extracting context key bytes: %w", err)
+			}
+			encMgr.StoreContextKey(ns.NetworkRecordID, privBytes)
+			useContextEncryption = true
+			fmt.Printf("  Context key: received (Protocol Context encryption enabled)\n")
+		} else {
+			fmt.Printf("  Context key: not yet delivered (run 'peer approve' on anchor)\n")
+			fmt.Printf("  Records will be written with Protocol Path encryption.\n")
+		}
+	}
+
 	fmt.Printf("Starting dwn-mesh...\n")
 	fmt.Printf("  Network: %s\n", ns.NetworkName)
 	fmt.Printf("  DID: %s\n", identity.URI)
 	fmt.Printf("  Mesh IP: %s\n", ns.MeshIP)
 	fmt.Printf("  Anchor: %s\n", ns.AnchorEndpoint)
 
+	// If we have a context key, re-register nodeInfo with Protocol Context
+	// encryption. The initial registration during "network join" used Protocol
+	// Path encryption (our own key) which the anchor can't decrypt. Re-writing
+	// with Protocol Context encryption allows the anchor to read our nodeInfo.
+	// The $squash directive means this overwrites the existing record.
+	if useContextEncryption && ns.NodeInfoRecordID != "" {
+		reg, err := mesh.RegisterNode(ctx, mesh.RegisterNodeParams{
+			AnchorEndpoint:       ns.AnchorEndpoint,
+			AnchorDID:            ns.AnchorDID,
+			NetworkRecordID:      ns.NetworkRecordID,
+			SelfDID:              identity.URI,
+			Signer:               signer,
+			EncryptionKeyManager: encMgr,
+			WireGuardPubKey:      ns.WireGuardPublicKey,
+			MeshIP:               ns.MeshIP,
+			ProtocolRole:         "network/member",
+			UseContextEncryption: true,
+			ExistingNodeInfoRecordID: ns.NodeInfoRecordID,
+		})
+		if err != nil {
+			logger.Warn("nodeInfo re-registration with context encryption failed",
+				slog.Any("error", err),
+			)
+		} else {
+			fmt.Printf("  NodeInfo re-encrypted with context key.\n")
+			_ = reg // recordID unchanged due to $squash
+		}
+	}
+
 	// Write/update endpoint record (encrypted) before starting the engine.
 	if ns.NodeInfoRecordID != "" {
 		localEndpoints := mesh.DiscoverLocalEndpoints(listenPort)
-		err = mesh.WriteEndpoint(ctx, mesh.WriteEndpointParams{
+		wpParams := mesh.WriteEndpointParams{
 			AnchorEndpoint:       ns.AnchorEndpoint,
 			AnchorDID:            ns.AnchorDID,
 			NetworkRecordID:      ns.NetworkRecordID,
@@ -842,7 +895,13 @@ func cmdUp(ctx context.Context, args []string) error {
 			EncryptionKeyManager: encMgr,
 			LocalEndpoints:       localEndpoints,
 			NATType:              "unknown",
-		})
+			UseContextEncryption: useContextEncryption,
+		}
+		// Non-anchor nodes must invoke their role for authorization.
+		if ns.AnchorDID != identity.URI {
+			wpParams.ProtocolRole = "network/member"
+		}
+		err = mesh.WriteEndpoint(ctx, wpParams)
 		if err != nil {
 			logger.Warn("endpoint write failed (non-fatal)", slog.Any("error", err))
 		} else {
@@ -875,7 +934,9 @@ func cmdUp(ctx context.Context, args []string) error {
 		Signer:               signer,
 		Resolver:             universalResolver{},
 		EncryptionKeyManager: encMgr,
+		NodeInfoRecordID:     ns.NodeInfoRecordID,
 		AutoKeyDelivery:      autoKeyDelivery,
+		UseContextEncryption: useContextEncryption,
 		Domain:               ns.NetworkName,
 		ListenPort:           listenPort,
 		PollInterval:         pollInterval,
@@ -942,6 +1003,41 @@ func newEncryptionKeyManager(identity *did.DID) *dwncrypto.EncryptionKeyManager 
 		RootKeyID:      identity.EncryptionKeyID(),
 		ProtocolURI:    "https://enbox.org/protocols/wireguard-mesh",
 	}
+}
+
+// fetchContextKey fetches the Protocol Context key from the anchor's DWN
+// for the current network. This allows a non-anchor node to encrypt records
+// using the Protocol Context scheme, which the anchor can decrypt.
+//
+// Returns nil (no error) if no context key has been delivered yet.
+func fetchContextKey(ctx context.Context, identity *did.DID, ns *state.NetworkState) (*dwncrypto.DerivedPrivateJwk, error) {
+	signer := &dwn.Signer{
+		DID:        identity.URI,
+		PrivateKey: identity.SigningKey,
+	}
+
+	// Derive the decryption key for the key-delivery protocol's contextKey
+	// path. The anchor encrypted the contextKey record using Protocol Path
+	// scheme for the key-delivery protocol, so we need our own root key to
+	// derive the key-delivery decryption key.
+	decryptionKey, err := dwncrypto.DeriveKeyDeliveryDecryptionKey(
+		identity.EncryptionPrivateKey,
+		protocols.KeyDeliveryProtocolURI,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("deriving key-delivery decryption key: %w", err)
+	}
+
+	return mesh.FetchContextKey(ctx, mesh.FetchContextKeyParams{
+		AnchorEndpoint:       ns.AnchorEndpoint,
+		AnchorDID:            ns.AnchorDID,
+		SelfDID:              identity.URI,
+		Signer:               signer,
+		SourceProtocol:       protocols.MeshProtocolURI,
+		ContextID:            ns.NetworkRecordID,
+		DecryptionPrivateKey: decryptionKey,
+		DecryptionKeyID:      identity.EncryptionKeyID(),
+	})
 }
 
 // universalResolver adapts the pkg/dids universal resolver to the

--- a/internal/control/control_test.go
+++ b/internal/control/control_test.go
@@ -146,6 +146,61 @@ func TestNodeInfoToNode(t *testing.T) {
 	})
 }
 
+func TestDefaultDERPRegions(t *testing.T) {
+	regions := defaultDERPRegions()
+
+	t.Run("has bootstrap regions", func(t *testing.T) {
+		if len(regions) == 0 {
+			t.Fatal("no default DERP regions")
+		}
+		if len(regions) < 2 {
+			t.Errorf("want at least 2 regions, got %d", len(regions))
+		}
+	})
+
+	t.Run("each region has nodes", func(t *testing.T) {
+		for id, r := range regions {
+			if len(r.Nodes) == 0 {
+				t.Errorf("region %d has no nodes", id)
+			}
+			for _, n := range r.Nodes {
+				if n.HostName == "" {
+					t.Errorf("region %d node %q has no hostname", id, n.Name)
+				}
+				if n.DERPPort == 0 {
+					t.Errorf("region %d node %q has no DERP port", id, n.Name)
+				}
+				if n.STUNPort == 0 {
+					t.Errorf("region %d node %q has no STUN port", id, n.Name)
+				}
+			}
+		}
+	})
+}
+
+func TestBuildDERPMapFallback(t *testing.T) {
+	// A client with no relays should fall back to default DERP regions.
+	c := &DWNClient{
+		relays: nil,
+	}
+	dm := c.buildDERPMap()
+	if len(dm.Regions) == 0 {
+		t.Fatal("expected default DERP regions when no relays configured")
+	}
+
+	// A client with custom relays should NOT use defaults.
+	c.relays = []*RelayData{
+		{URL: "relay.example.com", Region: "custom", STUNPort: 3478},
+	}
+	dm = c.buildDERPMap()
+	if len(dm.Regions) != 1 {
+		t.Fatalf("want 1 custom region, got %d", len(dm.Regions))
+	}
+	if dm.Regions[1].Nodes[0].HostName != "relay.example.com" {
+		t.Errorf("hostname = %q", dm.Regions[1].Nodes[0].HostName)
+	}
+}
+
 func TestDefaultFilterRules(t *testing.T) {
 	rules := defaultFilterRules()
 	if len(rules) != 1 {
@@ -159,6 +214,119 @@ func TestDefaultFilterRules(t *testing.T) {
 	}
 	if rules[0].DstPorts[0].Ports.First != 0 || rules[0].DstPorts[0].Ports.Last != 65535 {
 		t.Error("should allow all ports")
+	}
+}
+
+func TestExtractEntryMetadata(t *testing.T) {
+	t.Run("wrapped format with tags and recipient", func(t *testing.T) {
+		entry := json.RawMessage(`{
+			"recordsWrite": {
+				"recordId": "bafyreiabc123",
+				"descriptor": {
+					"interface": "Records",
+					"method": "Write",
+					"protocol": "https://enbox.org/protocols/wireguard-mesh",
+					"protocolPath": "network/nodeInfo",
+					"recipient": "did:dht:anchor123",
+					"tags": {
+						"did": "did:dht:node456",
+						"hostname": "myhost",
+						"os": "linux"
+					}
+				},
+				"encodedData": "dGVzdA"
+			}
+		}`)
+
+		meta := extractEntryMetadata(entry)
+
+		if meta.RecordID != "bafyreiabc123" {
+			t.Errorf("RecordID = %q, want %q", meta.RecordID, "bafyreiabc123")
+		}
+		if meta.Recipient != "did:dht:anchor123" {
+			t.Errorf("Recipient = %q, want %q", meta.Recipient, "did:dht:anchor123")
+		}
+		if did, ok := meta.Tags["did"].(string); !ok || did != "did:dht:node456" {
+			t.Errorf("Tags[did] = %v, want %q", meta.Tags["did"], "did:dht:node456")
+		}
+	})
+
+	t.Run("flat format", func(t *testing.T) {
+		entry := json.RawMessage(`{
+			"recordId": "bafyreiflat",
+			"descriptor": {
+				"recipient": "did:dht:member789",
+				"tags": {"did": "did:dht:member789"}
+			}
+		}`)
+
+		meta := extractEntryMetadata(entry)
+
+		if meta.RecordID != "bafyreiflat" {
+			t.Errorf("RecordID = %q, want %q", meta.RecordID, "bafyreiflat")
+		}
+		if meta.Recipient != "did:dht:member789" {
+			t.Errorf("Recipient = %q, want %q", meta.Recipient, "did:dht:member789")
+		}
+	})
+
+	t.Run("empty entry", func(t *testing.T) {
+		meta := extractEntryMetadata(json.RawMessage(`{}`))
+		if meta.RecordID != "" || meta.Recipient != "" {
+			t.Errorf("expected empty metadata, got %+v", meta)
+		}
+	})
+
+	t.Run("nil entry", func(t *testing.T) {
+		meta := extractEntryMetadata(nil)
+		if meta.RecordID != "" || meta.Recipient != "" {
+			t.Errorf("expected empty metadata, got %+v", meta)
+		}
+	})
+}
+
+func TestDetectDerivationScheme(t *testing.T) {
+	tests := map[string]struct {
+		enc  *dwncrypto.Encryption
+		want string
+	}{
+		"nil encryption": {
+			enc:  nil,
+			want: "",
+		},
+		"protocolPath scheme": {
+			enc: &dwncrypto.Encryption{
+				Recipients: []dwncrypto.Recipient{
+					{Header: dwncrypto.RecipientHeader{DerivationScheme: "protocolPath"}},
+				},
+			},
+			want: "protocolPath",
+		},
+		"protocolContext scheme": {
+			enc: &dwncrypto.Encryption{
+				Recipients: []dwncrypto.Recipient{
+					{Header: dwncrypto.RecipientHeader{DerivationScheme: "protocolContext"}},
+				},
+			},
+			want: "protocolContext",
+		},
+		"no scheme defaults to protocolPath": {
+			enc: &dwncrypto.Encryption{
+				Recipients: []dwncrypto.Recipient{
+					{Header: dwncrypto.RecipientHeader{}},
+				},
+			},
+			want: "protocolPath",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := detectDerivationScheme(tc.enc)
+			if got != tc.want {
+				t.Errorf("detectDerivationScheme = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/control/dwnclient.go
+++ b/internal/control/dwnclient.go
@@ -178,12 +178,30 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 	memberDecryptor := c.makeDecryptor("network/member")
 	c.mu.Lock()
 	for _, entry := range entries {
+		// Extract DID from descriptor metadata (not encrypted).
+		meta := extractEntryMetadata(entry)
+		memberDID := meta.Recipient // member records use recipient as the member DID
+
 		var member MemberInfo
 		if err := parseEntryData(entry, &member, memberDecryptor); err != nil {
-			c.logger.WarnContext(ctx, "parsing member entry", slog.Any("error", err))
+			c.logger.WarnContext(ctx, "parsing member entry",
+				slog.Any("error", err),
+				slog.String("memberDID", memberDID),
+			)
+			// Even if we can't decrypt the data, we can still track the member
+			// by DID from the unencrypted descriptor fields.
+			if memberDID != "" {
+				member.DID = memberDID
+				member.RecordID = meta.RecordID
+				c.members[memberDID] = &member
+			}
 			continue
 		}
-		c.members[member.DID] = &member
+		member.DID = memberDID
+		member.RecordID = meta.RecordID
+		if memberDID != "" {
+			c.members[memberDID] = &member
+		}
 	}
 	c.mu.Unlock()
 
@@ -206,12 +224,34 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 	nodeDecryptor := c.makeDecryptor("network/nodeInfo")
 	c.mu.Lock()
 	for _, entry := range nodeEntries {
+		// Extract DID from descriptor tags (not encrypted).
+		meta := extractEntryMetadata(entry)
+		nodeDID := ""
+		if did, ok := meta.Tags["did"].(string); ok {
+			nodeDID = did
+		}
+
 		var node NodeInfoData
 		if err := parseEntryData(entry, &node, nodeDecryptor); err != nil {
-			c.logger.WarnContext(ctx, "parsing node entry", slog.Any("error", err))
+			c.logger.WarnContext(ctx, "parsing node entry",
+				slog.Any("error", err),
+				slog.String("nodeDID", nodeDID),
+			)
+			// Even if we can't decrypt the data payload, track the node DID
+			// from the unencrypted tags. This allows peer discovery and auto
+			// key delivery to work even before context key exchange completes.
+			if nodeDID != "" {
+				node.DID = nodeDID
+				node.RecordID = meta.RecordID
+				c.nodes[nodeDID] = &node
+			}
 			continue
 		}
-		c.nodes[node.DID] = &node
+		node.DID = nodeDID
+		node.RecordID = meta.RecordID
+		if nodeDID != "" {
+			c.nodes[nodeDID] = &node
+		}
 	}
 	c.mu.Unlock()
 
@@ -383,7 +423,59 @@ func (c *DWNClient) buildDERPMap() *DERPMap {
 		}
 	}
 
+	// If no custom relays are configured, inject bootstrap DERP regions
+	// so peers behind NAT have a relay path. These use Tailscale's public
+	// DERP servers which speak the same protocol meshnet expects.
+	if len(dm.Regions) == 0 {
+		dm.Regions = defaultDERPRegions()
+	}
+
 	return dm
+}
+
+// defaultDERPRegions returns a set of bootstrap DERP relay regions.
+// These are Tailscale's publicly available DERP servers which use the
+// same protocol as meshnet. They provide relay connectivity (for NAT
+// traversal) and STUN (for endpoint discovery) out of the box.
+//
+// Operators can override these by registering custom relay records
+// on the anchor DWN. Once any relay record exists, these defaults
+// are not used.
+func defaultDERPRegions() map[int]*DERPRegion {
+	return map[int]*DERPRegion{
+		1: {
+			RegionID:   1,
+			RegionCode: "nyc",
+			RegionName: "New York City",
+			Nodes: []DERPNode{
+				{Name: "1a", RegionID: 1, HostName: "derp1.tailscale.com", DERPPort: 443, STUNPort: 3478},
+			},
+		},
+		2: {
+			RegionID:   2,
+			RegionCode: "sfo",
+			RegionName: "San Francisco",
+			Nodes: []DERPNode{
+				{Name: "2a", RegionID: 2, HostName: "derp2.tailscale.com", DERPPort: 443, STUNPort: 3478},
+			},
+		},
+		3: {
+			RegionID:   3,
+			RegionCode: "sin",
+			RegionName: "Singapore",
+			Nodes: []DERPNode{
+				{Name: "3a", RegionID: 3, HostName: "derp3.tailscale.com", DERPPort: 443, STUNPort: 3478},
+			},
+		},
+		4: {
+			RegionID:   4,
+			RegionCode: "fra",
+			RegionName: "Frankfurt",
+			Nodes: []DERPNode{
+				{Name: "4a", RegionID: 4, HostName: "derp4.tailscale.com", DERPPort: 443, STUNPort: 3478},
+			},
+		},
+	}
 }
 
 func (c *DWNClient) buildDNSConfig() *DNSConfig {
@@ -431,6 +523,59 @@ func defaultFilterRules() []FilterRule {
 			},
 		},
 	}
+}
+
+// entryMetadata holds descriptor-level fields extracted from a DWN record
+// entry. These fields are NOT encrypted and are always accessible.
+type entryMetadata struct {
+	RecordID  string         `json:"recordId"`
+	Recipient string         `json:"recipient"`
+	Tags      map[string]any `json:"tags"`
+}
+
+// extractEntryMetadata extracts non-encrypted descriptor metadata from
+// a DWN record entry. This works even when the data payload is encrypted
+// and cannot be decrypted.
+//
+// The function inspects both wrapped format (recordsWrite.descriptor)
+// and flat format (descriptor) entries.
+func extractEntryMetadata(entry json.RawMessage) entryMetadata {
+	var meta entryMetadata
+
+	// Try wrapped format: {"recordsWrite": {"descriptor": {...}}}
+	var wrapped struct {
+		RecordsWrite struct {
+			RecordID   string `json:"recordId"`
+			Descriptor struct {
+				Recipient string         `json:"recipient"`
+				Tags      map[string]any `json:"tags"`
+			} `json:"descriptor"`
+		} `json:"recordsWrite"`
+	}
+	if err := json.Unmarshal(entry, &wrapped); err == nil {
+		meta.RecordID = wrapped.RecordsWrite.RecordID
+		meta.Recipient = wrapped.RecordsWrite.Descriptor.Recipient
+		meta.Tags = wrapped.RecordsWrite.Descriptor.Tags
+		if meta.RecordID != "" || meta.Recipient != "" {
+			return meta
+		}
+	}
+
+	// Try flat format: {"recordId": "...", "descriptor": {...}}
+	var flat struct {
+		RecordID   string `json:"recordId"`
+		Descriptor struct {
+			Recipient string         `json:"recipient"`
+			Tags      map[string]any `json:"tags"`
+		} `json:"descriptor"`
+	}
+	if err := json.Unmarshal(entry, &flat); err == nil {
+		meta.RecordID = flat.RecordID
+		meta.Recipient = flat.Descriptor.Recipient
+		meta.Tags = flat.Descriptor.Tags
+	}
+
+	return meta
 }
 
 // parseEntryData extracts the data from a DWN read response entry.

--- a/internal/dwn/crypto/crypto_test.go
+++ b/internal/dwn/crypto/crypto_test.go
@@ -1861,6 +1861,172 @@ func TestSplitProtocolPath(t *testing.T) {
 	}
 }
 
+// =============================================================================
+// Multi-party encryption (Protocol Context) tests
+// =============================================================================
+
+// TestContextEncryptionMultiParty verifies the full multi-party flow:
+// 1. A record encrypted with Protocol Context scheme can be decrypted by the owner
+// 2. A non-owner with a delivered context key can also decrypt it
+// 3. A non-owner encrypts and the anchor can decrypt
+// 4. A non-owner WITHOUT the context key CANNOT decrypt it
+func TestContextEncryptionMultiParty(t *testing.T) {
+	// Simulate the anchor (DWN owner).
+	anchorPriv, _, err := GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("generating anchor key: %v", err)
+	}
+
+	anchorMgr := &EncryptionKeyManager{
+		RootPrivateKey: anchorPriv,
+		RootKeyID:      "did:dht:anchor#enc",
+		ProtocolURI:    "https://enbox.org/protocols/wireguard-mesh",
+	}
+
+	contextID := "bafyreiabc123networkrecordid"
+
+	// 1. Encrypt data with Protocol Context scheme (as a non-anchor would).
+	recipients, err := anchorMgr.DeriveContextWriteEncryption(contextID)
+	if err != nil {
+		t.Fatalf("DeriveContextWriteEncryption: %v", err)
+	}
+
+	plaintext := []byte(`{"wireguardPublicKey":"abc==","meshIP":"10.200.0.5"}`)
+	ciphertext, enc, err := EncryptData(plaintext, recipients)
+	if err != nil {
+		t.Fatalf("EncryptData: %v", err)
+	}
+
+	// 2. Anchor (owner) decrypts using context key derived from root.
+	t.Run("owner can decrypt", func(t *testing.T) {
+		contextKey, err := anchorMgr.DeriveContextDecryptionKey(contextID)
+		if err != nil {
+			t.Fatalf("DeriveContextDecryptionKey: %v", err)
+		}
+		decrypted, err := DecryptDataWithScheme(ciphertext, enc, contextKey, DerivationSchemeProtocolContext)
+		if err != nil {
+			t.Fatalf("DecryptDataWithScheme: %v", err)
+		}
+		if !bytes.Equal(decrypted, plaintext) {
+			t.Errorf("decrypted = %q, want %q", decrypted, plaintext)
+		}
+	})
+
+	// 3. Non-owner with delivered context key can also decrypt.
+	t.Run("non-owner with context key can decrypt", func(t *testing.T) {
+		nonOwnerPriv, _, err := GenerateX25519KeyPair()
+		if err != nil {
+			t.Fatalf("generating non-owner key: %v", err)
+		}
+
+		nonOwnerMgr := &EncryptionKeyManager{
+			RootPrivateKey: nonOwnerPriv,
+			RootKeyID:      "did:dht:joiner#enc",
+			ProtocolURI:    "https://enbox.org/protocols/wireguard-mesh",
+		}
+
+		// Simulate key delivery: anchor derives context key and delivers it.
+		contextKeyJwk, err := anchorMgr.DeriveContextKeyJwk(contextID)
+		if err != nil {
+			t.Fatalf("DeriveContextKeyJwk: %v", err)
+		}
+		contextKeyBytes, err := contextKeyJwk.PrivateKeyBytes()
+		if err != nil {
+			t.Fatalf("PrivateKeyBytes: %v", err)
+		}
+		nonOwnerMgr.StoreContextKey(contextID, contextKeyBytes)
+
+		// Non-owner decrypts.
+		decryptKey, err := nonOwnerMgr.DeriveContextDecryptionKey(contextID)
+		if err != nil {
+			t.Fatalf("DeriveContextDecryptionKey: %v", err)
+		}
+		decrypted, err := DecryptDataWithScheme(ciphertext, enc, decryptKey, DerivationSchemeProtocolContext)
+		if err != nil {
+			t.Fatalf("DecryptDataWithScheme: %v", err)
+		}
+		if !bytes.Equal(decrypted, plaintext) {
+			t.Errorf("decrypted = %q, want %q", decrypted, plaintext)
+		}
+	})
+
+	// 4. Non-owner encrypts with delivered context key, anchor can decrypt.
+	t.Run("non-owner encrypts anchor decrypts", func(t *testing.T) {
+		nonOwnerPriv, _, err := GenerateX25519KeyPair()
+		if err != nil {
+			t.Fatalf("generating non-owner key: %v", err)
+		}
+
+		nonOwnerMgr := &EncryptionKeyManager{
+			RootPrivateKey: nonOwnerPriv,
+			RootKeyID:      "did:dht:joiner#enc",
+			ProtocolURI:    "https://enbox.org/protocols/wireguard-mesh",
+		}
+
+		// Deliver context key to non-owner.
+		contextKeyJwk, err := anchorMgr.DeriveContextKeyJwk(contextID)
+		if err != nil {
+			t.Fatalf("DeriveContextKeyJwk: %v", err)
+		}
+		contextKeyBytes, err := contextKeyJwk.PrivateKeyBytes()
+		if err != nil {
+			t.Fatalf("PrivateKeyBytes: %v", err)
+		}
+		nonOwnerMgr.StoreContextKey(contextID, contextKeyBytes)
+
+		// Non-owner encrypts with context scheme.
+		nonOwnerRecipients, err := nonOwnerMgr.DeriveContextWriteEncryption(contextID)
+		if err != nil {
+			t.Fatalf("DeriveContextWriteEncryption: %v", err)
+		}
+
+		data := []byte(`{"meshIP":"10.200.0.6","hostname":"joiner-node"}`)
+		ct, encMeta, err := EncryptData(data, nonOwnerRecipients)
+		if err != nil {
+			t.Fatalf("EncryptData: %v", err)
+		}
+
+		// Anchor decrypts.
+		anchorContextKey, err := anchorMgr.DeriveContextDecryptionKey(contextID)
+		if err != nil {
+			t.Fatalf("anchor DeriveContextDecryptionKey: %v", err)
+		}
+		decrypted, err := DecryptDataWithScheme(ct, encMeta, anchorContextKey, DerivationSchemeProtocolContext)
+		if err != nil {
+			t.Fatalf("anchor DecryptDataWithScheme: %v", err)
+		}
+		if !bytes.Equal(decrypted, data) {
+			t.Errorf("decrypted = %q, want %q", decrypted, data)
+		}
+	})
+
+	// 5. Outsider with wrong root key cannot decrypt (wrong context key derived).
+	t.Run("outsider with wrong key fails to decrypt", func(t *testing.T) {
+		outsiderPriv, _, err := GenerateX25519KeyPair()
+		if err != nil {
+			t.Fatalf("generating outsider key: %v", err)
+		}
+
+		outsiderMgr := &EncryptionKeyManager{
+			RootPrivateKey: outsiderPriv,
+			RootKeyID:      "did:dht:outsider#enc",
+			ProtocolURI:    "https://enbox.org/protocols/wireguard-mesh",
+		}
+
+		// Outsider derives a context key from their own (wrong) root key.
+		wrongContextKey, err := outsiderMgr.DeriveContextDecryptionKey(contextID)
+		if err != nil {
+			t.Fatalf("DeriveContextDecryptionKey: %v", err)
+		}
+
+		// Decryption should fail because the wrong key unwraps the wrong CEK.
+		_, err = DecryptDataWithScheme(ciphertext, enc, wrongContextKey, DerivationSchemeProtocolContext)
+		if err == nil {
+			t.Error("expected decryption to fail with wrong context key")
+		}
+	})
+}
+
 // RFC 3394 Section 4.3 — AES-192 KEK with 192-bit key data.
 func TestAESKeyWrapRFC3394Vector192(t *testing.T) {
 	kek, _ := hex.DecodeString("000102030405060708090A0B0C0D0E0F1011121314151617")

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -13,6 +13,7 @@ import (
 	"github.com/enboxorg/dwn-mesh/internal/control"
 	"github.com/enboxorg/dwn-mesh/internal/dwn"
 	dwncrypto "github.com/enboxorg/dwn-mesh/internal/dwn/crypto"
+	"github.com/enboxorg/dwn-mesh/internal/mesh"
 
 	"github.com/enboxorg/meshnet/control/controlclient"
 	"github.com/enboxorg/meshnet/ipn"
@@ -20,6 +21,7 @@ import (
 	"github.com/enboxorg/meshnet/ipn/store/mem"
 	"github.com/enboxorg/meshnet/net/netmon"
 	"github.com/enboxorg/meshnet/net/tsdial"
+	"github.com/enboxorg/meshnet/tailcfg"
 	"github.com/enboxorg/meshnet/tsd"
 	"github.com/enboxorg/meshnet/types/logid"
 	"github.com/enboxorg/meshnet/types/logger"
@@ -86,10 +88,20 @@ type Config struct {
 	// protocol records. If nil, encrypted records cannot be read.
 	EncryptionKeyManager *dwncrypto.EncryptionKeyManager
 
+	// NodeInfoRecordID is this node's nodeInfo record ID on the anchor DWN.
+	// Required for writing endpoint updates back to DWN.
+	NodeInfoRecordID string
+
 	// AutoKeyDelivery enables automatic context key delivery to new members.
 	// Only active when this node is the anchor and has the root private key.
 	// If nil, auto delivery is disabled.
 	AutoKeyDelivery *AutoKeyDelivery
+
+	// UseContextEncryption enables Protocol Context encryption for writes.
+	// Non-anchor nodes MUST set this to true so the anchor can decrypt their
+	// records using the shared context key. The EncryptionKeyManager must
+	// have the context key stored (via StoreContextKey) for NetworkRecordID.
+	UseContextEncryption bool
 
 	// Logger is the structured logger. Nil = default.
 	Logger *slog.Logger
@@ -260,6 +272,12 @@ func New(cfg Config) (*Engine, error) {
 		PollInterval:    pollInterval,
 		Logf:            logf,
 	}
+
+	// Wire endpoint writeback: when magicsock discovers STUN endpoints,
+	// publish them to the anchor DWN so peers can find us.
+	if cfg.NodeInfoRecordID != "" && cfg.EncryptionKeyManager != nil {
+		dwnControlConfig.EndpointUpdateFunc = makeEndpointUpdateFunc(cfg, l)
+	}
 	lb.SetControlClientGetterForTesting(
 		controlclient.NewDWNControlFactory(dwnControlConfig),
 	)
@@ -366,6 +384,62 @@ func slogToLogf(l *slog.Logger) logger.Logf {
 	return func(format string, args ...any) {
 		msg := fmt.Sprintf(format, args...)
 		l.Debug(msg, slog.String("source", "meshnet"))
+	}
+}
+
+// makeEndpointUpdateFunc creates a callback that writes STUN-discovered
+// endpoints back to the anchor DWN as an endpoint record update.
+func makeEndpointUpdateFunc(cfg Config, l *slog.Logger) func(context.Context, []tailcfg.Endpoint) {
+	return func(ctx context.Context, endpoints []tailcfg.Endpoint) {
+		var publicEPs []mesh.PublicEndpoint
+		var localEPs []string
+
+		for _, ep := range endpoints {
+			ap := ep.Addr
+			if !ap.IsValid() {
+				continue
+			}
+			addr := ap.Addr()
+
+			// Classify endpoints: publicly routable vs local/private.
+			if addr.IsPrivate() || addr.IsLoopback() || addr.IsLinkLocalUnicast() {
+				localEPs = append(localEPs, ap.String())
+			} else {
+				publicEPs = append(publicEPs, mesh.PublicEndpoint{
+					Address:  addr.String(),
+					Port:     int(ap.Port()),
+					Source:   "stun",
+				})
+			}
+		}
+
+		if len(publicEPs) == 0 && len(localEPs) == 0 {
+			return
+		}
+
+		l.Info("publishing discovered endpoints to DWN",
+			slog.Int("public", len(publicEPs)),
+			slog.Int("local", len(localEPs)),
+		)
+
+		err := mesh.WriteEndpoint(ctx, mesh.WriteEndpointParams{
+			AnchorEndpoint:       cfg.AnchorEndpoint,
+			AnchorDID:            cfg.AnchorTenant,
+			NetworkRecordID:      cfg.NetworkRecordID,
+			NodeInfoRecordID:     cfg.NodeInfoRecordID,
+			Signer:               cfg.Signer,
+			EncryptionKeyManager: cfg.EncryptionKeyManager,
+			PublicEndpoints:      publicEPs,
+			LocalEndpoints:       localEPs,
+			NATType:              "unknown",
+			ProtocolRole:         "network/member",
+			UseContextEncryption: cfg.UseContextEncryption,
+		})
+		if err != nil {
+			l.Warn("failed to publish endpoints to DWN",
+				slog.Any("error", err),
+			)
+		}
 	}
 }
 

--- a/internal/mesh/register.go
+++ b/internal/mesh/register.go
@@ -65,6 +65,13 @@ type RegisterNodeParams struct {
 	// ProtocolRole is the role to invoke for authorization (e.g., "network/member").
 	// Required when writing to another party's DWN as a non-owner.
 	ProtocolRole string
+
+	// UseContextEncryption enables Protocol Context encryption instead of
+	// Protocol Path encryption. Non-anchor nodes MUST set this to true so
+	// the anchor can decrypt their records using the shared context key.
+	// When true, the EncryptionKeyManager must have the context key stored
+	// (via StoreContextKey) for the NetworkRecordID.
+	UseContextEncryption bool
 }
 
 // RegisterNode writes or updates the node's nodeInfo record (encrypted) on
@@ -93,10 +100,21 @@ func RegisterNode(ctx context.Context, params RegisterNodeParams) (*NodeRegistra
 		return nil, fmt.Errorf("marshaling nodeInfo: %w", err)
 	}
 
-	// Derive encryption recipients for "network/nodeInfo" path.
-	recipients, err := params.EncryptionKeyManager.DeriveWriteEncryption("network/nodeInfo")
-	if err != nil {
-		return nil, fmt.Errorf("deriving nodeInfo encryption: %w", err)
+	// Derive encryption recipients.
+	// Non-anchor nodes use Protocol Context scheme (shared context key) so the
+	// anchor can decrypt. The anchor uses Protocol Path scheme (derived from
+	// its own root key).
+	var recipients []dwncrypto.KeyEncryptionInput
+	if params.UseContextEncryption {
+		recipients, err = params.EncryptionKeyManager.DeriveContextWriteEncryption(params.NetworkRecordID)
+		if err != nil {
+			return nil, fmt.Errorf("deriving nodeInfo context encryption: %w", err)
+		}
+	} else {
+		recipients, err = params.EncryptionKeyManager.DeriveWriteEncryption("network/nodeInfo")
+		if err != nil {
+			return nil, fmt.Errorf("deriving nodeInfo encryption: %w", err)
+		}
 	}
 
 	agent := dwn.NewSimpleAgent(params.AnchorEndpoint, params.Signer)
@@ -158,10 +176,18 @@ func WriteEndpoint(ctx context.Context, params WriteEndpointParams) error {
 		return fmt.Errorf("marshaling endpoint: %w", err)
 	}
 
-	// Derive encryption recipients for "network/nodeInfo/endpoint" path.
-	recipients, err := params.EncryptionKeyManager.DeriveWriteEncryption("network/nodeInfo/endpoint")
-	if err != nil {
-		return fmt.Errorf("deriving endpoint encryption: %w", err)
+	// Derive encryption recipients.
+	var recipients []dwncrypto.KeyEncryptionInput
+	if params.UseContextEncryption {
+		recipients, err = params.EncryptionKeyManager.DeriveContextWriteEncryption(params.NetworkRecordID)
+		if err != nil {
+			return fmt.Errorf("deriving endpoint context encryption: %w", err)
+		}
+	} else {
+		recipients, err = params.EncryptionKeyManager.DeriveWriteEncryption("network/nodeInfo/endpoint")
+		if err != nil {
+			return fmt.Errorf("deriving endpoint encryption: %w", err)
+		}
 	}
 
 	agent := dwn.NewSimpleAgent(params.AnchorEndpoint, params.Signer)
@@ -202,6 +228,10 @@ type WriteEndpointParams struct {
 	LocalEndpoints       []string
 	NATType              string
 	ProtocolRole         string
+
+	// UseContextEncryption enables Protocol Context encryption instead of
+	// Protocol Path encryption. See RegisterNodeParams.UseContextEncryption.
+	UseContextEncryption bool
 }
 
 // PublicEndpoint describes a publicly reachable endpoint.
@@ -226,9 +256,17 @@ func CreateMember(ctx context.Context, params CreateMemberParams) error {
 		return fmt.Errorf("marshaling member: %w", err)
 	}
 
-	recipients, err := params.EncryptionKeyManager.DeriveWriteEncryption("network/member")
-	if err != nil {
-		return fmt.Errorf("deriving member encryption: %w", err)
+	var recipients []dwncrypto.KeyEncryptionInput
+	if params.UseContextEncryption {
+		recipients, err = params.EncryptionKeyManager.DeriveContextWriteEncryption(params.NetworkRecordID)
+		if err != nil {
+			return fmt.Errorf("deriving member context encryption: %w", err)
+		}
+	} else {
+		recipients, err = params.EncryptionKeyManager.DeriveWriteEncryption("network/member")
+		if err != nil {
+			return fmt.Errorf("deriving member encryption: %w", err)
+		}
 	}
 
 	agent := dwn.NewSimpleAgent(params.AnchorEndpoint, params.Signer)
@@ -264,6 +302,10 @@ type CreateMemberParams struct {
 	Label                string
 	Signer               *dwn.Signer
 	EncryptionKeyManager *dwncrypto.EncryptionKeyManager
+
+	// UseContextEncryption enables Protocol Context encryption instead of
+	// Protocol Path encryption. See RegisterNodeParams.UseContextEncryption.
+	UseContextEncryption bool
 }
 
 // DiscoverLocalEndpoints discovers local network endpoints for this node.

--- a/vendor/github.com/enboxorg/meshnet/control/controlclient/dwn.go
+++ b/vendor/github.com/enboxorg/meshnet/control/controlclient/dwn.go
@@ -33,6 +33,14 @@ type DWNControlConfig struct {
 	//   - When explicitly triggered via Notify()
 	MapResponseFunc func(ctx context.Context) (*netmap.NetworkMap, error)
 
+	// EndpointUpdateFunc is called when magicsock discovers new endpoints
+	// (via STUN, local interface enumeration, etc). The DWN control
+	// integration should write these back to the anchor DWN so peers
+	// can discover this node's reachable addresses.
+	//
+	// If nil, endpoint updates are not published.
+	EndpointUpdateFunc func(ctx context.Context, endpoints []tailcfg.Endpoint)
+
 	// PollInterval is how often to re-read DWN state.
 	// Default: 30 seconds.
 	PollInterval time.Duration
@@ -271,8 +279,16 @@ func (cc *DWNControl) UpdateEndpoints(endpoints []tailcfg.Endpoint) {
 	cc.mu.Lock()
 	cc.endpoints = endpoints
 	cc.mu.Unlock()
-	// TODO: publish endpoints to DWN as an endpoint record update.
-	// After publishing, trigger a Notify() so other peers pick up the change.
+
+	if cc.config.EndpointUpdateFunc != nil {
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			cc.config.EndpointUpdateFunc(ctx, endpoints)
+			// Trigger re-poll so peers pick up the new endpoints.
+			cc.Notify()
+		}()
+	}
 }
 
 func (cc *DWNControl) SetDiscoPublicKey(k key.DiscoPublic) {


### PR DESCRIPTION
## Summary

Enable a working 2-node mesh network by implementing three critical features that were blocking the end-to-end demo.

### Step 1: Default DERP relay regions
- Add `defaultDERPRegions()` returning 4 Tailscale public DERP servers (NYC, SFO, SIN, FRA)
- `buildDERPMap()` falls back to these when no custom relay records exist on the anchor DWN
- Provides out-of-the-box relay connectivity for NAT traversal without requiring custom relay infrastructure

### Step 2: Endpoint writeback via `EndpointUpdateFunc`
- Add `EndpointUpdateFunc` callback to `DWNControlConfig` in vendored meshnet
- `UpdateEndpoints()` now calls the func in a goroutine + triggers `Notify()` for re-poll
- `makeEndpointUpdateFunc()` classifies STUN-discovered endpoints (public vs local) and writes them as encrypted endpoint records to the anchor DWN

### Step 3: Multi-party encryption fix (the big one)
**Problem:** Non-anchor nodes encrypted records with Protocol Path scheme using their own root key. The anchor derives different keys from its own root, so it couldn't decrypt records written by non-anchor nodes.

**Solution:**
- Add `UseContextEncryption` flag to `RegisterNodeParams`, `WriteEndpointParams`, `CreateMemberParams`
- Non-anchor nodes fetch the shared context key from the anchor on `up` via `FetchContextKey()`
- Re-register nodeInfo with Protocol Context encryption so the anchor can decrypt
- Fix peer discovery: extract DID from unencrypted descriptor metadata (tags for nodeInfo, recipient for member) so peer discovery and auto key delivery work even before context key exchange completes
- Wire `UseContextEncryption` through `engine.Config` to endpoint writeback callback

### New Tests
- `TestDefaultDERPRegions` — validates bootstrap DERP region structure
- `TestBuildDERPMapFallback` — verifies fallback behavior
- `TestExtractEntryMetadata` — wrapped/flat/empty/nil entry formats
- `TestDetectDerivationScheme` — protocolPath/protocolContext/nil/default
- `TestContextEncryptionMultiParty` — full multi-party round-trip (owner decrypt, non-owner with delivered key, non-owner encrypts + anchor decrypts, outsider fails)

### Files changed
- `cmd/dwn-mesh/main.go` — context key fetch on `up`, nodeInfo re-encryption, endpoint writeback with role/context encryption
- `internal/control/dwnclient.go` — DID extraction from descriptors, default DERP regions, `extractEntryMetadata()`
- `internal/control/control_test.go` — new tests for metadata extraction, derivation scheme detection, DERP regions
- `internal/dwn/crypto/crypto_test.go` — `TestContextEncryptionMultiParty`
- `internal/engine/engine.go` — `UseContextEncryption` in Config, `makeEndpointUpdateFunc()`
- `internal/mesh/register.go` — `UseContextEncryption` support in all write functions
- `vendor/.../meshnet/control/controlclient/dwn.go` — `EndpointUpdateFunc` callback