### PR TITLE
docs: fix comparison table alignment and add release platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,16 @@ jobs:
             goos: windows
             goarch: amd64
             ext: zip
+          - os: windows
+            arch: arm64
+            goos: windows
+            goarch: arm64
+            ext: zip
+          - os: freebsd
+            arch: x64
+            goos: freebsd
+            goarch: amd64
+            ext: tar.gz
 
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -56,14 +56,12 @@ meshd up
 
 ## How is this different?
 
-```
-                You give up         You manage          You trust
-               ─────────────      ─────────────       ───────────
-Tailscale       control            nothing             Tailscale Inc.
-Headscale       less control       a server            your server
-WireGuard       nothing            everything          yourself
-meshd        nothing            nothing             cryptography
-```
+|             | You give up    | You manage  | You trust      |
+|-------------|----------------|-------------|----------------|
+| Tailscale   | control        | nothing     | Tailscale Inc. |
+| Headscale   | less control   | a server    | your server    |
+| WireGuard   | nothing        | everything  | yourself       |
+| **meshd**   | nothing        | nothing     | cryptography   |
 
 **vs Tailscale / Headscale:** No account. No server. No company in the
 loop. Your coordination data is encrypted -- even if someone compromises

--- a/install.sh
+++ b/install.sh
@@ -77,6 +77,7 @@ detect_os() {
   case "$(uname -s)" in
     Linux) printf 'linux' ;;
     Darwin) printf 'darwin' ;;
+    FreeBSD) printf 'freebsd' ;;
     CYGWIN*|MINGW*|MSYS*) printf 'windows' ;;
     *) fail 'unsupported operating system' ;;
   esac


### PR DESCRIPTION
## Summary

- Fixed the "How is this different" comparison table — the ASCII-art table broke during the dwn-mesh → meshd rename. Converted to a proper markdown table.
- Added `windows/arm64` and `freebsd/amd64` to the release artifact matrix in `.github/workflows/release.yml` (5 → 7 targets).
- Added FreeBSD detection to `install.sh`.