### PR TITLE
fix: inline binary builds into release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,8 +12,99 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           release-type: go
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  build-artifacts:
+    name: Build ${{ matrix.os }}-${{ matrix.arch }}
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: linux
+            arch: x64
+            goos: linux
+            goarch: amd64
+            ext: tar.gz
+          - os: linux
+            arch: arm64
+            goos: linux
+            goarch: arm64
+            ext: tar.gz
+          - os: darwin
+            arch: x64
+            goos: darwin
+            goarch: amd64
+            ext: tar.gz
+          - os: darwin
+            arch: arm64
+            goos: darwin
+            goarch: arm64
+            ext: tar.gz
+          - os: windows
+            arch: x64
+            goos: windows
+            goarch: amd64
+            ext: zip
+          - os: windows
+            arch: arm64
+            goos: windows
+            goarch: arm64
+            ext: zip
+          - os: freebsd
+            arch: x64
+            goos: freebsd
+            goarch: amd64
+            ext: tar.gz
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.x'
+
+      - name: Build binary
+        env:
+          CGO_ENABLED: '0'
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          mkdir -p dist/release
+          out='dist/release/meshd'
+          if [ "${{ matrix.os }}" = 'windows' ]; then
+            out='dist/release/meshd.exe'
+          fi
+          version="${{ needs.release-please.outputs.tag_name }}"
+          version="${version#v}"
+          go build -trimpath -ldflags="-s -w -X main.version=${version}" -o "$out" ./cmd/meshd
+
+      - name: Package artifact
+        run: |
+          artifact="meshd-${{ matrix.os }}-${{ matrix.arch }}.${{ matrix.ext }}"
+          if [ "${{ matrix.ext }}" = 'zip' ]; then
+            (cd dist/release && zip -q "../../${artifact}" meshd.exe)
+          else
+            (cd dist/release && tar -czf "../../${artifact}" meshd)
+          fi
+          echo "artifact=${artifact}" >> "$GITHUB_ENV"
+
+      - name: Upload artifact to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.release-please.outputs.tag_name }}
+          files: ${{ env.artifact }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Release Artifacts
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v0.0.2)'
+        required: true
 
 permissions:
   contents: write
@@ -40,10 +45,22 @@ jobs:
             goos: windows
             goarch: amd64
             ext: zip
+          - os: windows
+            arch: arm64
+            goos: windows
+            goarch: arm64
+            ext: zip
+          - os: freebsd
+            arch: x64
+            goos: freebsd
+            goarch: amd64
+            ext: tar.gz
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -61,7 +78,8 @@ jobs:
           if [ "${{ matrix.os }}" = 'windows' ]; then
             out='dist/release/meshd.exe'
           fi
-          version="${GITHUB_REF_NAME#v}"
+          tag="${{ github.event.inputs.tag || github.event.release.tag_name }}"
+          version="${tag#v}"
           go build -trimpath -ldflags="-s -w -X main.version=${version}" -o "$out" ./cmd/meshd
 
       - name: Package artifact
@@ -77,4 +95,5 @@ jobs:
       - name: Upload artifact to release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.event.inputs.tag || github.event.release.tag_name }}
           files: ${{ env.artifact }}


### PR DESCRIPTION
## Summary

- **Problem**: `release-please-action` creates GitHub Releases using `GITHUB_TOKEN`, which does not trigger other workflows (GitHub's anti-loop policy). This meant `release.yml` never ran for release-please-created releases — e.g. v0.0.2 has no binary artifacts.
- **Fix**: Added a `build-artifacts` job to `release-please.yml` that runs after release-please creates a release (`if: needs.release-please.outputs.release_created == 'true'`). It builds all 7 platform binaries and uploads them to the release.
- **Bonus**: Added `workflow_dispatch` to `release.yml` with a `tag` input for manual re-triggering (backfill artifacts on existing releases like v0.0.2). Also added `windows/arm64` and `freebsd/amd64` targets to `release.yml` to keep it in sync.

Build, vet, test: workflow-only changes (YAML), no Go code modified.

**Note**: This PR overlaps with #18 on `release.yml` platform targets. If #18 merges first, this will have a minor merge conflict on the matrix entries (easy to resolve). Recommend merging this first since it's the more critical fix.