### PR TITLE
chore: restrict integration tests to main pushes and quiet log chatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     needs: test
-    # Only run integration tests on push to main (not on PRs from forks).
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    # Only run integration tests on push to main (requires DWN_ENDPOINT secret).
+    if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v4
 

--- a/internal/control/dwnclient.go
+++ b/internal/control/dwnclient.go
@@ -186,7 +186,7 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 
 		var member MemberInfo
 		if err := parseEntryData(entry, &member, memberDecryptor); err != nil {
-			c.logger.WarnContext(ctx, "parsing member entry",
+			c.logger.DebugContext(ctx, "parsing member entry",
 				slog.Any("error", err),
 				slog.String("memberDID", memberDID),
 			)
@@ -236,7 +236,7 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 
 		var node NodeInfoData
 		if err := parseEntryData(entry, &node, nodeDecryptor); err != nil {
-			c.logger.WarnContext(ctx, "parsing node entry",
+			c.logger.DebugContext(ctx, "parsing node entry",
 				slog.Any("error", err),
 				slog.String("nodeDID", nodeDID),
 			)
@@ -280,14 +280,14 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 	for _, entry := range relayEntries {
 		var relay RelayData
 		if err := parseEntryData(entry, &relay, relayDecryptor); err != nil {
-			c.logger.WarnContext(ctx, "parsing relay entry", slog.Any("error", err))
+			c.logger.DebugContext(ctx, "parsing relay entry", slog.Any("error", err))
 			continue
 		}
 		c.relays = append(c.relays, &relay)
 	}
 	c.mu.Unlock()
 
-	c.logger.InfoContext(ctx, "mesh state loaded",
+	c.logger.DebugContext(ctx, "mesh state loaded",
 		slog.String("network", network.Name),
 		slog.Int("members", len(c.members)),
 		slog.Int("nodes", len(c.nodes)),


### PR DESCRIPTION
## Summary

- **CI**: Tighten the integration job `if` condition from `github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository` to just `github.event_name == 'push'`, so integration tests only run on pushes to main — not on PRs. This matches the documented intent in CLAUDE.md.

- **Log levels**: Demote noisy `LoadState` log messages that fire on every poll cycle:
  - `WARN "parsing member entry"` / `"parsing node entry"` / `"parsing relay entry"` → `Debug`. These decryption failures are expected when a node hasn't received the context key for records encrypted for other members.
  - `INFO "mesh state loaded"` → `Debug`. This summary fires every poll iteration and floods output at Info level.

## Verification

- `go build ./...` — zero errors
- `go vet ./...` — zero warnings
- `go test ./... -count=1 -race` — all pass, no data races