### PR TITLE
feat: real TUN device support for kernel-level mesh networking

### DIFF
--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -47,6 +47,12 @@ Network:
   up                Start the mesh agent daemon
   down              Stop the mesh agent daemon
 
+Up flags:
+  --tun [name]      Create a real TUN device (default: meshd0, requires root)
+  --port <n>        WireGuard UDP listen port (default: auto)
+  --poll-interval   DWN poll interval (default: 30s)
+  -v, --verbose     Enable debug logging
+
 Global flags:
   --profile <name>  Use a specific identity profile
   -h, --help        Show this help message
@@ -929,6 +935,7 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 	// Parse optional flags.
 	var listenPort uint16
 	var pollInterval time.Duration
+	var tunName string
 	verbose := false
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
@@ -946,6 +953,15 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 					pollInterval = d
 				}
 				i++
+			}
+		case "--tun":
+			// --tun enables real TUN device mode.
+			// Optionally accepts a device name; defaults to "meshd0".
+			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				tunName = args[i+1]
+				i++
+			} else {
+				tunName = "meshd0"
 			}
 		case "-v", "--verbose":
 			verbose = true
@@ -1102,6 +1118,7 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 		AutoKeyDelivery:      autoKeyDelivery,
 		UseContextEncryption: useContextEncryption,
 		WireGuardPrivateKey:  wgPrivKey,
+		TUNName:             tunName,
 		Domain:               ns.NetworkName,
 		ListenPort:           listenPort,
 		PollInterval:         pollInterval,
@@ -1117,6 +1134,11 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 	}
 
 	fmt.Printf("  Status: running\n")
+	if devName := eng.TUNDeviceName(); devName != "" {
+		fmt.Printf("  TUN device: %s\n", devName)
+	} else {
+		fmt.Printf("  Mode: userspace (use --tun for kernel routing)\n")
+	}
 	if ns.MeshIP != "" {
 		fmt.Printf("  Mesh IP: %s\n", ns.MeshIP)
 	}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -16,12 +16,15 @@ import (
 	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
 	"github.com/enboxorg/meshd/internal/mesh"
 
+	"github.com/tailscale/wireguard-go/tun"
+
 	"github.com/enboxorg/meshnet/control/controlclient"
 	"github.com/enboxorg/meshnet/ipn"
 	"github.com/enboxorg/meshnet/ipn/ipnlocal"
 	"github.com/enboxorg/meshnet/ipn/store/mem"
 	"github.com/enboxorg/meshnet/net/netmon"
 	"github.com/enboxorg/meshnet/net/tsdial"
+	"github.com/enboxorg/meshnet/net/tstun"
 	"github.com/enboxorg/meshnet/tailcfg"
 	"github.com/enboxorg/meshnet/tsd"
 	"github.com/enboxorg/meshnet/types/key"
@@ -29,6 +32,7 @@ import (
 	"github.com/enboxorg/meshnet/types/logger"
 	"github.com/enboxorg/meshnet/wgengine"
 	"github.com/enboxorg/meshnet/wgengine/netstack"
+	"github.com/enboxorg/meshnet/wgengine/router"
 	go4mem "go4.org/mem"
 )
 
@@ -48,6 +52,11 @@ type Engine struct {
 	ns              *netstack.Impl
 	autoKeyDelivery *AutoKeyDelivery
 	logger          *slog.Logger
+
+	// tunDev is the real TUN device when running in TUN mode.
+	// nil in userspace-only (netstack) mode.
+	tunDev  tun.Device
+	tunName string
 
 	mu      sync.Mutex
 	running bool
@@ -117,6 +126,17 @@ type Config struct {
 	// registry fills that role. If nil, a no-op registry is used (disco keys
 	// won't be exchanged, which prevents DERP relay between peers).
 	DiscoKeyRegistry controlclient.DiscoKeyRegistry
+
+	// TUNName, if non-empty, creates a real OS TUN device with this name
+	// (e.g., "meshd0") instead of using a fake TUN. This enables regular
+	// applications (ping, ssh, curl) to route through the mesh tunnel.
+	//
+	// Requires root or CAP_NET_ADMIN. If the TUN device cannot be created,
+	// the engine falls back to userspace-only mode with a warning.
+	//
+	// When empty (default), the engine runs in userspace-only mode where
+	// only netstack-internal code can communicate through the mesh.
+	TUNName string
 
 	// Logger is the structured logger. Nil = default.
 	Logger *slog.Logger
@@ -208,11 +228,44 @@ func New(cfg Config) (*Engine, error) {
 	// can't become active without being in the WG config.
 	sys.ControlKnobs().KeepFullWGConfig.Store(true)
 
-	// Create the real userspace WireGuard engine.
-	// Tun: nil triggers fake-TUN mode — no real TUN device, no root required.
-	// magicsock is still real: UDP hole punching, DERP relay, STUN all work.
-	eng, err := wgengine.NewUserspaceEngine(logf, wgengine.Config{
-		Tun:           nil, // fake TUN; netstack handles all packets in userspace
+	// Create the WireGuard engine.
+	//
+	// Two modes:
+	//   1. Real TUN mode (cfg.TUNName set): creates a kernel TUN device so
+	//      regular applications can route through the mesh. Requires root
+	//      or CAP_NET_ADMIN. Falls back to userspace mode on failure.
+	//   2. Userspace mode (default): fake TUN + netstack. Only code using
+	//      the netstack dialer can communicate through the mesh tunnel.
+	var tunDev tun.Device
+	var tunName string
+	var osRouter router.Router
+	userspaceOnly := true
+
+	if cfg.TUNName != "" {
+		dev, devName, tunErr := tstun.New(logf, cfg.TUNName)
+		if tunErr != nil {
+			l.Warn("failed to create TUN device, falling back to userspace mode",
+				slog.String("tunName", cfg.TUNName),
+				slog.Any("error", tunErr),
+			)
+		} else {
+			tunDev = dev
+			tunName = devName
+			userspaceOnly = false
+			l.Info("created TUN device", slog.String("name", tunName))
+
+			// Create a Linux router to manage addresses and routes on the
+			// TUN interface. On non-Linux platforms, newLinuxRouter returns
+			// nil and we fall back to the fake router (no OS routing).
+			if rtr := newLinuxRouter(logf, tunName); rtr != nil {
+				osRouter = rtr
+			}
+		}
+	}
+
+	wgConfig := wgengine.Config{
+		Tun:           tunDev, // nil = fake TUN (userspace only)
+		Router:        osRouter,
 		EventBus:      sys.Bus.Get(),
 		ListenPort:    cfg.ListenPort,
 		NetMon:        nm,
@@ -221,15 +274,21 @@ func New(cfg Config) (*Engine, error) {
 		ControlKnobs:  sys.ControlKnobs(),
 		HealthTracker: sys.HealthTracker.Get(),
 		Metrics:       sys.UserMetricsRegistry(),
-	})
+	}
+
+	eng, err := wgengine.NewUserspaceEngine(logf, wgConfig)
 	if err != nil {
+		if tunDev != nil {
+			tunDev.Close()
+		}
 		nm.Close()
 		return nil, fmt.Errorf("creating WireGuard engine: %w", err)
 	}
 	sys.Set(eng)
 
-	// Create netstack — gVisor userspace TCP/IP stack that processes all
-	// WireGuard tunnel packets without needing a real TUN device.
+	// Create netstack — gVisor userspace TCP/IP stack. In userspace-only
+	// mode it handles all packets; with a real TUN it provides the meshd
+	// process's own dialer for mesh connections.
 	ns, err := netstack.Create(
 		logf,
 		sys.Tun.Get(),      // the tstun.Wrapper created by the engine
@@ -241,17 +300,27 @@ func New(cfg Config) (*Engine, error) {
 	)
 	if err != nil {
 		eng.Close()
+		if tunDev != nil {
+			tunDev.Close()
+		}
 		nm.Close()
 		return nil, fmt.Errorf("creating netstack: %w", err)
 	}
 	sys.Tun.Get().Start()
 	sys.Set(ns)
 
-	// With fake TUN (no real device), netstack handles everything:
-	// - ProcessLocalIPs: packets destined for our mesh IP
-	// - ProcessSubnets: packets destined for other mesh nodes
-	ns.ProcessLocalIPs = true
-	ns.ProcessSubnets = true
+	if userspaceOnly {
+		// Fake TUN mode: netstack handles everything since there is no
+		// real network interface for the OS to deliver packets through.
+		ns.ProcessLocalIPs = true
+		ns.ProcessSubnets = true
+	} else {
+		// Real TUN mode: the OS delivers packets through the TUN device.
+		// Netstack only needs to handle connections initiated by meshd
+		// itself (e.g., the DWN control client dialing through the mesh).
+		ns.ProcessLocalIPs = false
+		ns.ProcessSubnets = false
+	}
 
 	// Wire the dialer through netstack so outbound connections from the
 	// meshd process go through the WireGuard tunnel.
@@ -328,6 +397,8 @@ func New(cfg Config) (*Engine, error) {
 		dialer:          dial,
 		ns:              ns,
 		autoKeyDelivery: cfg.AutoKeyDelivery,
+		tunDev:          tunDev,
+		tunName:         tunName,
 		logger:          l,
 	}, nil
 }
@@ -382,11 +453,19 @@ func (e *Engine) Stop() error {
 	}
 
 	// Shutdown order matters: backend first (stops control polling),
-	// then network monitor.
+	// then network monitor, then TUN device.
 	e.backend.Shutdown()
 
 	if e.netMon != nil {
 		e.netMon.Close()
+	}
+
+	// Close the real TUN device if we created one. This removes the
+	// network interface from the OS.
+	if e.tunDev != nil {
+		if err := e.tunDev.Close(); err != nil {
+			e.logger.Warn("closing TUN device", slog.Any("error", err))
+		}
 	}
 
 	e.running = false
@@ -411,6 +490,12 @@ func (e *Engine) Backend() *ipnlocal.LocalBackend {
 // Use this for userspace TCP/UDP listening and dialing through the mesh.
 func (e *Engine) Netstack() *netstack.Impl {
 	return e.ns
+}
+
+// TUNDeviceName returns the OS-assigned TUN device name (e.g., "meshd0"),
+// or empty if running in userspace-only mode.
+func (e *Engine) TUNDeviceName() string {
+	return e.tunName
 }
 
 // slogToLogf adapts a *slog.Logger to meshnet's printf-style logger.Logf.

--- a/internal/engine/router_linux.go
+++ b/internal/engine/router_linux.go
@@ -1,0 +1,194 @@
+// Linux-specific router implementation for meshd.
+//
+// This provides a minimal router.Router that configures IP addresses and
+// routes on the TUN device using the `ip` command. It handles the subset
+// of router.Config that meshd needs: LocalAddrs (addresses on the TUN)
+// and Routes (routes to mesh peers through the TUN).
+//
+// Advanced features (netfilter, SNAT, stateful filtering) are not
+// implemented — meshd relies on the default allow-all packet filter.
+
+//go:build linux
+
+package engine
+
+import (
+	"fmt"
+	"net/netip"
+	"os/exec"
+	"strings"
+
+	"github.com/enboxorg/meshnet/types/logger"
+	"github.com/enboxorg/meshnet/wgengine/router"
+)
+
+// linuxRouter configures the OS network stack for a real TUN device on Linux.
+// It uses the `ip` command to manage addresses and routes.
+type linuxRouter struct {
+	logf    logger.Logf
+	tunName string
+
+	// Track current state to compute deltas on Set().
+	addrs  []netip.Prefix
+	routes []netip.Prefix
+}
+
+// newLinuxRouter creates a new router for the given TUN device.
+func newLinuxRouter(logf logger.Logf, tunName string) router.Router {
+	return &linuxRouter{logf: logf, tunName: tunName}
+}
+
+func (r *linuxRouter) Up() error {
+	// Bring the TUN interface up.
+	if err := r.cmd("ip", "link", "set", "dev", r.tunName, "up"); err != nil {
+		return fmt.Errorf("bringing up %s: %w", r.tunName, err)
+	}
+	r.logf("linuxRouter: %s is up", r.tunName)
+	return nil
+}
+
+func (r *linuxRouter) Set(cfg *router.Config) error {
+	if cfg == nil {
+		return r.cleanup()
+	}
+
+	r.logf("linuxRouter: Set: %d addrs, %d routes", len(cfg.LocalAddrs), len(cfg.Routes))
+
+	// Sync addresses: add new ones, remove stale ones.
+	if err := r.syncAddrs(cfg.LocalAddrs); err != nil {
+		return fmt.Errorf("syncing addresses: %w", err)
+	}
+
+	// Sync routes: add new ones, remove stale ones.
+	// Skip routes that are in LocalRoutes (should not go through the tunnel).
+	localRouteSet := make(map[netip.Prefix]bool, len(cfg.LocalRoutes))
+	for _, lr := range cfg.LocalRoutes {
+		localRouteSet[lr] = true
+	}
+	var tunnelRoutes []netip.Prefix
+	for _, rt := range cfg.Routes {
+		if !localRouteSet[rt] {
+			tunnelRoutes = append(tunnelRoutes, rt)
+		}
+	}
+
+	if err := r.syncRoutes(tunnelRoutes); err != nil {
+		return fmt.Errorf("syncing routes: %w", err)
+	}
+
+	return nil
+}
+
+func (r *linuxRouter) Close() error {
+	if err := r.cleanup(); err != nil {
+		return err
+	}
+	// Bring the interface down. Ignore errors — the device may already
+	// be gone if the engine closed it first.
+	_ = r.cmd("ip", "link", "set", "dev", r.tunName, "down")
+	r.logf("linuxRouter: closed")
+	return nil
+}
+
+// cleanup removes all managed addresses and routes from the TUN device.
+func (r *linuxRouter) cleanup() error {
+	for _, addr := range r.addrs {
+		_ = r.cmd("ip", "addr", "del", addr.String(), "dev", r.tunName)
+	}
+	for _, rt := range r.routes {
+		_ = r.cmd("ip", "route", "del", rt.String(), "dev", r.tunName)
+	}
+	r.addrs = nil
+	r.routes = nil
+	return nil
+}
+
+// syncAddrs reconciles the desired addresses with the current state.
+func (r *linuxRouter) syncAddrs(want []netip.Prefix) error {
+	wantSet := make(map[netip.Prefix]bool, len(want))
+	for _, a := range want {
+		wantSet[a] = true
+	}
+
+	// Remove addresses we no longer want.
+	var kept []netip.Prefix
+	for _, a := range r.addrs {
+		if wantSet[a] {
+			kept = append(kept, a)
+			continue
+		}
+		if err := r.cmd("ip", "addr", "del", a.String(), "dev", r.tunName); err != nil {
+			r.logf("linuxRouter: warning: failed to remove addr %s: %v", a, err)
+		}
+	}
+
+	// Add addresses we don't have yet.
+	haveSet := make(map[netip.Prefix]bool, len(r.addrs))
+	for _, a := range r.addrs {
+		haveSet[a] = true
+	}
+	for _, a := range want {
+		if haveSet[a] {
+			continue
+		}
+		if err := r.cmd("ip", "addr", "add", a.String(), "dev", r.tunName); err != nil {
+			// EEXIST is fine — the address is already present.
+			if !strings.Contains(err.Error(), "RTNETLINK answers: File exists") {
+				return fmt.Errorf("adding addr %s: %w", a, err)
+			}
+		}
+		kept = append(kept, a)
+	}
+
+	r.addrs = kept
+	return nil
+}
+
+// syncRoutes reconciles the desired routes with the current state.
+func (r *linuxRouter) syncRoutes(want []netip.Prefix) error {
+	wantSet := make(map[netip.Prefix]bool, len(want))
+	for _, rt := range want {
+		wantSet[rt] = true
+	}
+
+	// Remove routes we no longer want.
+	var kept []netip.Prefix
+	for _, rt := range r.routes {
+		if wantSet[rt] {
+			kept = append(kept, rt)
+			continue
+		}
+		if err := r.cmd("ip", "route", "del", rt.String(), "dev", r.tunName); err != nil {
+			r.logf("linuxRouter: warning: failed to remove route %s: %v", rt, err)
+		}
+	}
+
+	// Add routes we don't have yet.
+	haveSet := make(map[netip.Prefix]bool, len(r.routes))
+	for _, rt := range r.routes {
+		haveSet[rt] = true
+	}
+	for _, rt := range want {
+		if haveSet[rt] {
+			continue
+		}
+		if err := r.cmd("ip", "route", "add", rt.String(), "dev", r.tunName); err != nil {
+			if !strings.Contains(err.Error(), "RTNETLINK answers: File exists") {
+				return fmt.Errorf("adding route %s: %w", rt, err)
+			}
+		}
+		kept = append(kept, rt)
+	}
+
+	r.routes = kept
+	return nil
+}
+
+// cmd runs an ip command and returns any error.
+func (r *linuxRouter) cmd(name string, args ...string) error {
+	out, err := exec.Command(name, args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s %s: %w (%s)", name, strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/internal/engine/router_other.go
+++ b/internal/engine/router_other.go
@@ -1,0 +1,19 @@
+// Stub router for non-Linux platforms.
+//
+// Real TUN routing is only supported on Linux. On other platforms,
+// meshd operates in userspace-only mode (fake TUN + netstack).
+
+//go:build !linux
+
+package engine
+
+import (
+	"github.com/enboxorg/meshnet/types/logger"
+	"github.com/enboxorg/meshnet/wgengine/router"
+)
+
+// newLinuxRouter is a stub on non-Linux platforms. It returns nil,
+// signaling that the caller should fall back to the fake router.
+func newLinuxRouter(_ logger.Logf, _ string) router.Router {
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds support for creating a real OS TUN device so regular applications (ping, ssh, curl) can route through the mesh tunnel. This closes the biggest gap between "proof of concept" and "usable VPN."

### Usage

```sh
# Real TUN mode (requires root or CAP_NET_ADMIN):
sudo meshd up --tun              # creates meshd0 TUN device
sudo meshd up --tun meshd1       # custom device name

# Userspace-only mode (default, no root required):
meshd up                         # only netstack-internal code can use the tunnel
```

### Architecture

**Two modes:**

| Mode | TUN | Router | netstack | Who can use the tunnel |
|------|-----|--------|----------|----------------------|
| Userspace (default) | Fake | Fake | ProcessLocalIPs=true, ProcessSubnets=true | Only meshd process via netstack dialer |
| Real TUN (`--tun`) | Real OS device | Linux `ip` commands | ProcessLocalIPs=false, ProcessSubnets=false | All applications via kernel routing |

**Graceful fallback:** If `--tun` is specified but TUN creation fails (no root, missing `/dev/net/tun`), the engine logs a warning and falls back to userspace-only mode automatically.

### Changes

- **`internal/engine/router_linux.go`** (new) — Minimal Linux router implementing `router.Router`. Uses `ip addr add/del` and `ip route add/del` to manage the TUN interface. Delta-based sync on each `Set()` call.
- **`internal/engine/router_other.go`** (new) — Stub for non-Linux platforms, returns nil to trigger fake router fallback.
- **`internal/engine/engine.go`** — New `TUNName` config field. When set, creates a real TUN device via `tstun.New()`, wires the Linux router, adjusts netstack mode. Cleans up TUN device on `Stop()`.
- **`cmd/meshd/main.go`** — `--tun [name]` flag for `meshd up`. Reports TUN device name or userspace mode in status output. Updated usage help.

## Verification

```
go build ./...                     # Zero build errors
go vet ./...                       # Zero vet warnings
go test ./... -count=1 -race       # All tests pass, no data races
```

Closes #25