### PR TITLE
feat: wire DWN subscriptions to engine for real-time peer updates

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -40,6 +40,7 @@ import (
 //   - DWNClient reads mesh state from DWN records
 //   - Converter transforms it into meshnet NetworkMap
 //   - meshnet's LocalBackend runs WireGuard with the DWN-backed control client
+//   - SubscriptionWatcher triggers real-time updates via DWN WebSocket
 //
 // Engine is the core of `meshd up`.
 type Engine struct {
@@ -51,6 +52,7 @@ type Engine struct {
 	dialer          *tsdial.Dialer
 	ns              *netstack.Impl
 	autoKeyDelivery *AutoKeyDelivery
+	subWatcher      *SubscriptionWatcher
 	logger          *slog.Logger
 
 	// tunDev is the real TUN device when running in TUN mode.
@@ -353,6 +355,17 @@ func New(cfg Config) (*Engine, error) {
 		return nil, fmt.Errorf("starting netstack: %w", err)
 	}
 
+	// Create subscription watcher for real-time DWN updates.
+	// This replaces pure polling with event-driven updates when the DWN
+	// server supports WebSocket subscriptions.
+	subWatcher := NewSubscriptionWatcher(SubscriptionWatcherConfig{
+		AnchorEndpoint:  cfg.AnchorEndpoint,
+		AnchorTenant:    cfg.AnchorTenant,
+		NetworkRecordID: cfg.NetworkRecordID,
+		Signer:          cfg.Signer,
+		Logger:          l,
+	})
+
 	// Wire the DWN control client into the LocalBackend.
 	// MapResponseFunc closes over our DWNClient and Converter to produce
 	// NetworkMaps from DWN records. If auto key delivery is configured,
@@ -362,6 +375,9 @@ func New(cfg Config) (*Engine, error) {
 		MapResponseFunc: mapFn,
 		PollInterval:    pollInterval,
 		Logf:            logf,
+		// Capture the DWNControl reference so the subscription watcher
+		// can call Notify() to trigger immediate re-polls.
+		OnCreated: subWatcher.SetDWNControl,
 	}
 
 	// If the caller provided a WireGuard private key (already published to
@@ -397,6 +413,7 @@ func New(cfg Config) (*Engine, error) {
 		dialer:          dial,
 		ns:              ns,
 		autoKeyDelivery: cfg.AutoKeyDelivery,
+		subWatcher:      subWatcher,
 		tunDev:          tunDev,
 		tunName:         tunName,
 		logger:          l,
@@ -409,6 +426,7 @@ func New(cfg Config) (*Engine, error) {
 //  1. Call the DWN MapResponseFunc to load initial mesh state
 //  2. Configure WireGuard peers from the NetworkMap
 //  3. Begin polling DWN for state changes
+//  4. Subscribe to DWN record changes for real-time updates
 func (e *Engine) Start(ctx context.Context) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -432,6 +450,18 @@ func (e *Engine) Start(ctx context.Context) error {
 		return fmt.Errorf("starting backend: %w", err)
 	}
 
+	// Start the subscription watcher for real-time updates.
+	// This is best-effort: if the DWN server doesn't support WebSocket
+	// subscriptions, we fall back to polling only. The watcher will
+	// auto-reconnect on transient failures.
+	if e.subWatcher != nil {
+		if err := e.subWatcher.Start(ctx); err != nil {
+			e.logger.Warn("failed to start subscription watcher, falling back to polling",
+				slog.Any("error", err),
+			)
+		}
+	}
+
 	e.running = true
 	e.logger.InfoContext(ctx, "meshd engine started")
 	return nil
@@ -450,6 +480,11 @@ func (e *Engine) Stop() error {
 
 	if e.cancel != nil {
 		e.cancel()
+	}
+
+	// Stop subscription watcher first (stops WebSocket connections).
+	if e.subWatcher != nil {
+		e.subWatcher.Stop()
 	}
 
 	// Shutdown order matters: backend first (stops control polling),

--- a/internal/engine/subscribe.go
+++ b/internal/engine/subscribe.go
@@ -1,0 +1,192 @@
+// Package engine — subscription watcher for real-time DWN updates.
+//
+// Instead of polling every 30 seconds, the SubscriptionWatcher opens a
+// WebSocket subscription to the anchor DWN and triggers an immediate
+// re-poll whenever mesh records change (nodeInfo, endpoints, members).
+//
+// The watcher subscribes to all records under the wireguard-mesh protocol
+// within the network's contextId. When an event arrives, it calls
+// DWNControl.Notify() which wakes the poll loop for an immediate
+// loadAndPush cycle.
+package engine
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"github.com/enboxorg/meshd/internal/dwn"
+
+	"github.com/enboxorg/meshnet/control/controlclient"
+)
+
+// SubscriptionWatcher subscribes to DWN record changes and triggers
+// engine re-polls via DWNControl.Notify().
+//
+// This replaces pure 30-second polling with event-driven updates,
+// reducing peer discovery latency from up to 30s to near-instant.
+// The poll timer remains as a fallback for missed events.
+type SubscriptionWatcher struct {
+	endpoint        string
+	anchorTenant    string
+	networkRecordID string
+	signer          *dwn.Signer
+	logger          *slog.Logger
+
+	mu      sync.Mutex
+	manager *dwn.SubscriptionManager
+	cancel  context.CancelFunc
+	done    chan struct{}
+
+	// dwnControl is set via the OnCreated callback from DWNControlConfig.
+	// It's nil until the control client is created by the LocalBackend.
+	controlMu  sync.Mutex
+	dwnControl *controlclient.DWNControl
+}
+
+// SubscriptionWatcherConfig holds the configuration for creating a
+// SubscriptionWatcher.
+type SubscriptionWatcherConfig struct {
+	// AnchorEndpoint is the DWN server URL.
+	AnchorEndpoint string
+
+	// AnchorTenant is the DID of the anchor DWN owner.
+	AnchorTenant string
+
+	// NetworkRecordID is the contextId for the network.
+	NetworkRecordID string
+
+	// Signer signs subscription requests.
+	Signer *dwn.Signer
+
+	// Logger is the structured logger.
+	Logger *slog.Logger
+}
+
+// NewSubscriptionWatcher creates a new watcher but does not start it.
+// Call Start() to begin subscribing.
+func NewSubscriptionWatcher(cfg SubscriptionWatcherConfig) *SubscriptionWatcher {
+	l := cfg.Logger
+	if l == nil {
+		l = slog.Default()
+	}
+
+	return &SubscriptionWatcher{
+		endpoint:        cfg.AnchorEndpoint,
+		anchorTenant:    cfg.AnchorTenant,
+		networkRecordID: cfg.NetworkRecordID,
+		signer:          cfg.Signer,
+		logger:          l.With(slog.String("component", "subscription-watcher")),
+	}
+}
+
+// SetDWNControl is called by the DWNControlConfig.OnCreated callback
+// to provide the DWNControl reference for triggering Notify().
+func (w *SubscriptionWatcher) SetDWNControl(cc *controlclient.DWNControl) {
+	w.controlMu.Lock()
+	defer w.controlMu.Unlock()
+	w.dwnControl = cc
+}
+
+// notify triggers an immediate re-poll on the DWNControl if available.
+func (w *SubscriptionWatcher) notify() {
+	w.controlMu.Lock()
+	cc := w.dwnControl
+	w.controlMu.Unlock()
+
+	if cc != nil {
+		cc.Notify()
+	}
+}
+
+// Start begins subscribing to DWN record changes. It subscribes to all
+// records under the wireguard-mesh protocol within the network context.
+//
+// The subscription automatically reconnects on failure (handled by
+// SubscriptionManager). When any record changes, it triggers an
+// immediate engine re-poll.
+func (w *SubscriptionWatcher) Start(ctx context.Context) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.cancel != nil {
+		return nil // already started
+	}
+
+	subCtx, cancel := context.WithCancel(ctx)
+	w.cancel = cancel
+	w.done = make(chan struct{})
+
+	w.manager = dwn.NewSubscriptionManager(w.endpoint, w.logger)
+
+	// Subscribe to all records under the wireguard-mesh protocol for
+	// this network. This catches nodeInfo, endpoint, member, and relay
+	// record changes in a single subscription.
+	filter := dwn.RecordsFilter{
+		Protocol:  "https://enbox.org/protocols/wireguard-mesh",
+		ContextID: w.networkRecordID,
+	}
+
+	handler := func(event *dwn.SubscriptionMessage) {
+		if event == nil {
+			return
+		}
+
+		switch event.Type {
+		case "event":
+			w.logger.Debug("DWN record changed, triggering re-poll",
+				slog.String("cursor", event.Cursor),
+			)
+			w.notify()
+		case "eose":
+			// End-of-stored-events: initial backfill is done.
+			// No action needed — the poll loop already loaded initial state.
+			w.logger.Debug("subscription caught up to live events")
+		}
+	}
+
+	_, err := w.manager.Subscribe(
+		subCtx,
+		w.anchorTenant,
+		w.signer,
+		filter,
+		handler,
+	)
+	if err != nil {
+		cancel()
+		w.cancel = nil
+		return err
+	}
+
+	w.logger.Info("subscription watcher started",
+		slog.String("endpoint", w.endpoint),
+		slog.String("network", w.networkRecordID),
+	)
+
+	// Monitor context cancellation to close the done channel.
+	go func() {
+		<-subCtx.Done()
+		w.manager.CloseAll()
+		close(w.done)
+	}()
+
+	return nil
+}
+
+// Stop cancels all subscriptions and waits for cleanup.
+func (w *SubscriptionWatcher) Stop() {
+	w.mu.Lock()
+	cancel := w.cancel
+	done := w.done
+	w.cancel = nil
+	w.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+		if done != nil {
+			<-done
+		}
+	}
+
+	w.logger.Info("subscription watcher stopped")
+}

--- a/internal/engine/subscribe_test.go
+++ b/internal/engine/subscribe_test.go
@@ -1,0 +1,204 @@
+package engine
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/enboxorg/meshd/internal/dwn"
+
+	"github.com/enboxorg/meshnet/control/controlclient"
+	"github.com/enboxorg/meshnet/types/netmap"
+)
+
+func TestNewSubscriptionWatcher(t *testing.T) {
+	w := NewSubscriptionWatcher(SubscriptionWatcherConfig{
+		AnchorEndpoint:  "https://example.com",
+		AnchorTenant:    "did:dht:anchor",
+		NetworkRecordID: "record123",
+		Signer:          &dwn.Signer{DID: "did:dht:self"},
+	})
+
+	if w == nil {
+		t.Fatal("watcher is nil")
+	}
+	if w.endpoint != "https://example.com" {
+		t.Errorf("endpoint = %q, want %q", w.endpoint, "https://example.com")
+	}
+	if w.anchorTenant != "did:dht:anchor" {
+		t.Errorf("anchorTenant = %q, want %q", w.anchorTenant, "did:dht:anchor")
+	}
+	if w.networkRecordID != "record123" {
+		t.Errorf("networkRecordID = %q, want %q", w.networkRecordID, "record123")
+	}
+}
+
+func TestSubscriptionWatcherStopBeforeStart(t *testing.T) {
+	w := NewSubscriptionWatcher(SubscriptionWatcherConfig{
+		AnchorEndpoint:  "https://example.com",
+		AnchorTenant:    "did:dht:anchor",
+		NetworkRecordID: "record123",
+		Signer:          &dwn.Signer{DID: "did:dht:self"},
+	})
+
+	// Stop before Start should not panic.
+	w.Stop()
+}
+
+func TestSubscriptionWatcherDoubleStop(t *testing.T) {
+	w := NewSubscriptionWatcher(SubscriptionWatcherConfig{
+		AnchorEndpoint:  "https://example.com",
+		AnchorTenant:    "did:dht:anchor",
+		NetworkRecordID: "record123",
+		Signer:          &dwn.Signer{DID: "did:dht:self"},
+	})
+
+	// Double stop should not panic.
+	w.Stop()
+	w.Stop()
+}
+
+func TestSubscriptionWatcherSetDWNControl(t *testing.T) {
+	w := NewSubscriptionWatcher(SubscriptionWatcherConfig{
+		AnchorEndpoint:  "https://example.com",
+		AnchorTenant:    "did:dht:anchor",
+		NetworkRecordID: "record123",
+		Signer:          &dwn.Signer{DID: "did:dht:self"},
+	})
+
+	// Before setting, notify should not panic (no-op).
+	w.notify()
+
+	// Create a DWNControl with SkipStartForTests to avoid the poll loop.
+	cc, err := controlclient.NewDWNControl(
+		&controlclient.DWNControlConfig{
+			MapResponseFunc: func(ctx context.Context) (*netmap.NetworkMap, error) {
+				return nil, nil
+			},
+			PollInterval: time.Hour,
+		},
+		controlclient.Options{SkipStartForTests: true},
+	)
+	if err != nil {
+		t.Fatalf("NewDWNControl: %v", err)
+	}
+	defer cc.Shutdown()
+
+	// Set the DWNControl on the watcher.
+	w.SetDWNControl(cc)
+
+	// Now notify should trigger the DWNControl's notify channel.
+	// This is a smoke test — we just verify it doesn't panic.
+	w.notify()
+}
+
+func TestSubscriptionWatcherOnCreatedCallback(t *testing.T) {
+	w := NewSubscriptionWatcher(SubscriptionWatcherConfig{
+		AnchorEndpoint:  "https://example.com",
+		AnchorTenant:    "did:dht:anchor",
+		NetworkRecordID: "record123",
+		Signer:          &dwn.Signer{DID: "did:dht:self"},
+	})
+
+	// Simulate the factory calling OnCreated.
+	var called atomic.Bool
+	config := &controlclient.DWNControlConfig{
+		MapResponseFunc: func(ctx context.Context) (*netmap.NetworkMap, error) {
+			return nil, nil
+		},
+		PollInterval: time.Hour,
+		OnCreated: func(cc *controlclient.DWNControl) {
+			called.Store(true)
+			w.SetDWNControl(cc)
+		},
+	}
+
+	cc, err := controlclient.NewDWNControl(
+		config,
+		controlclient.Options{SkipStartForTests: true},
+	)
+	if err != nil {
+		t.Fatalf("NewDWNControl: %v", err)
+	}
+	defer cc.Shutdown()
+
+	if !called.Load() {
+		t.Error("OnCreated callback was not called")
+	}
+
+	// The watcher should now have the DWNControl reference.
+	w.controlMu.Lock()
+	hasControl := w.dwnControl != nil
+	w.controlMu.Unlock()
+
+	if !hasControl {
+		t.Error("watcher does not have DWNControl reference after OnCreated")
+	}
+}
+
+func TestSubscriptionWatcherStartFailsGracefully(t *testing.T) {
+	w := NewSubscriptionWatcher(SubscriptionWatcherConfig{
+		// Use a deliberately unreachable endpoint.
+		AnchorEndpoint:  "ws://127.0.0.1:1",
+		AnchorTenant:    "did:dht:anchor",
+		NetworkRecordID: "record123",
+		Signer:          &dwn.Signer{DID: "did:dht:self"},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Start should succeed — the subscription runs asynchronously and
+	// reconnects on failure. The SubscriptionManager.Subscribe returns
+	// immediately (the WebSocket dial happens in a goroutine).
+	err := w.Start(ctx)
+	if err != nil {
+		// Some setups might fail synchronously — that's also acceptable.
+		t.Logf("Start returned error (acceptable): %v", err)
+	}
+
+	w.Stop()
+}
+
+func TestSubscriptionWatcherStartIdempotent(t *testing.T) {
+	w := NewSubscriptionWatcher(SubscriptionWatcherConfig{
+		AnchorEndpoint:  "ws://127.0.0.1:1",
+		AnchorTenant:    "did:dht:anchor",
+		NetworkRecordID: "record123",
+		Signer:          &dwn.Signer{DID: "did:dht:self"},
+	})
+
+	ctx := context.Background()
+
+	// First start.
+	_ = w.Start(ctx)
+
+	// Second start should be a no-op (already started).
+	err := w.Start(ctx)
+	if err != nil {
+		t.Fatalf("second Start should be no-op, got: %v", err)
+	}
+
+	w.Stop()
+}
+
+func TestEngineCreatesSubscriptionWatcher(t *testing.T) {
+	cfg := Config{
+		AnchorEndpoint:  "https://example.com",
+		AnchorTenant:    "did:dht:anchor",
+		NetworkRecordID: "record123",
+		SelfDID:         "did:dht:self",
+		Signer:          &dwn.Signer{DID: "did:dht:self"},
+	}
+
+	eng, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer eng.Stop()
+
+	if eng.subWatcher == nil {
+		t.Error("engine should have a subscription watcher")
+	}
+}

--- a/vendor/github.com/enboxorg/meshnet/control/controlclient/dwn.go
+++ b/vendor/github.com/enboxorg/meshnet/control/controlclient/dwn.go
@@ -61,6 +61,13 @@ type DWNControlConfig struct {
 	// mode (direct endpoints only, no DERP relay).
 	DiscoKeyRegistry DiscoKeyRegistry
 
+	// OnCreated is called after the DWNControl instance is created but
+	// before the poll loop starts. This lets the caller capture a reference
+	// to the DWNControl for calling Notify() from subscription handlers.
+	//
+	// If nil, no callback is made.
+	OnCreated func(cc *DWNControl)
+
 	// Logf is the logging function. If nil, log.Printf is used.
 	Logf logger.Logf
 }
@@ -177,6 +184,11 @@ func NewDWNControl(config *DWNControlConfig, opts Options) (*DWNControl, error) 
 	if !cc.disco.IsZero() && cc.config.DiscoKeyRegistry != nil {
 		cc.config.DiscoKeyRegistry.SetDisco(cc.persist.PrivateNodeKey.Public(), cc.disco)
 		logf("dwn-control: published initial disco key %s for nodeKey %s", cc.disco.ShortString(), cc.persist.PrivateNodeKey.Public().ShortString())
+	}
+
+	// Notify the caller so it can capture a reference for calling Notify().
+	if config.OnCreated != nil {
+		config.OnCreated(cc)
 	}
 
 	if !opts.SkipStartForTests {


### PR DESCRIPTION
## Summary

- Adds a `SubscriptionWatcher` that opens a WebSocket subscription to the anchor DWN, reducing peer discovery latency from up to 30s (polling) to near-instant (event-driven)
- Adds `OnCreated` callback to `DWNControlConfig` (vendored) so the engine can capture the `DWNControl` reference for calling `Notify()`
- Subscription is best-effort with graceful fallback to polling on WebSocket failure; auto-reconnects on transient failures

## How it works

1. `SubscriptionWatcher` subscribes to all `wireguard-mesh` protocol records within the network's `contextId`
2. When any record changes (nodeInfo, endpoint, member, relay), the handler calls `DWNControl.Notify()`
3. `Notify()` wakes the poll loop for an immediate `loadAndPush` cycle — the engine reconfigures WireGuard peers within milliseconds of a DWN record change
4. The 30-second poll timer remains as a safety-net fallback

## Files changed

| File | Change |
|------|--------|
| `internal/engine/subscribe.go` | New `SubscriptionWatcher` type with `Start()`/`Stop()` lifecycle |
| `internal/engine/subscribe_test.go` | 8 tests covering creation, lifecycle, callback wiring, idempotency |
| `internal/engine/engine.go` | Wire `SubscriptionWatcher` into `Engine` struct, `New()`, `Start()`, `Stop()` |
| `vendor/.../controlclient/dwn.go` | Add `OnCreated` callback to `DWNControlConfig` |

## Verification

```
go build ./...     # ✅ Zero build errors
go vet ./...       # ✅ Zero vet warnings
go test ./... -count=1 -race  # ✅ All tests pass, no data races
```

Closes #29