### PR TITLE
feat: daemon control socket for meshd up/down/status

### DIFF
--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/enboxorg/meshd/internal/daemon"
 	"github.com/enboxorg/meshd/internal/did"
 	"github.com/enboxorg/meshd/internal/dwn"
 	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
@@ -867,6 +868,8 @@ func cmdPeerApprove(ctx context.Context, args []string, flagProfile string) erro
 }
 
 // cmdStatus shows the current mesh status and identity info.
+//
+// If a daemon is running, it also queries live status via the control socket.
 func cmdStatus(ctx context.Context, args []string, flagProfile string) error {
 	stateDir, err := resolveStateDir(flagProfile)
 	if err != nil {
@@ -912,6 +915,24 @@ func cmdStatus(ctx context.Context, args []string, flagProfile string) error {
 	}
 	if ns.NodeInfoRecordID != "" {
 		fmt.Printf("  NodeInfo Record: %s\n", ns.NodeInfoRecordID)
+	}
+
+	// Query live daemon status if running.
+	client := daemon.NewClient(daemon.DefaultSocketPath())
+	if client.IsRunning() {
+		live, err := client.GetStatus(ctx)
+		if err != nil {
+			fmt.Printf("\nDaemon: running (status query failed: %v)\n", err)
+		} else {
+			fmt.Printf("\nDaemon:\n")
+			fmt.Printf("  Running: yes (PID %d)\n", live.PID)
+			fmt.Printf("  Uptime: %s\n", live.Uptime)
+			if live.TUNDevice != "" {
+				fmt.Printf("  TUN device: %s\n", live.TUNDevice)
+			}
+		}
+	} else {
+		fmt.Printf("\nDaemon: not running\n")
 	}
 
 	return nil
@@ -1218,6 +1239,23 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 		return fmt.Errorf("starting engine: %w", err)
 	}
 
+	// ── Step 4: Start the daemon control socket ────────────────────
+	socketPath := daemon.DefaultSocketPath()
+	daemonSrv := daemon.NewServer(socketPath, func() daemon.Status {
+		return daemon.Status{
+			TUNDevice: eng.TUNDeviceName(),
+			MeshIP:    ns.MeshIP,
+			Network:   ns.NetworkName,
+		}
+	}, logger)
+
+	if err := daemonSrv.Start(); err != nil {
+		// Non-fatal: the mesh still works without the control socket.
+		logger.Warn("daemon control socket failed to start", slog.Any("error", err))
+	} else {
+		defer daemonSrv.Stop()
+	}
+
 	fmt.Printf("  Status: running\n")
 	if devName := eng.TUNDeviceName(); devName != "" {
 		fmt.Printf("  TUN device: %s\n", devName)
@@ -1227,12 +1265,16 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 	if ns.MeshIP != "" {
 		fmt.Printf("  Mesh IP: %s\n", ns.MeshIP)
 	}
-	fmt.Printf("\nPress Ctrl+C to stop.\n")
+	fmt.Printf("  Socket: %s\n", socketPath)
+	fmt.Printf("\nPress Ctrl+C or run 'meshd down' to stop.\n")
 
-	// Block until interrupted.
+	// Block until interrupted by signal or daemon shutdown request.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	<-sigCh
+	select {
+	case <-sigCh:
+	case <-daemonSrv.ShutdownCh():
+	}
 
 	fmt.Printf("\nShutting down...\n")
 	if err := eng.Stop(); err != nil {
@@ -1439,16 +1481,36 @@ func interactiveJoin(ctx context.Context, f upFlags, stateDir string, identity *
 	return setupJoinNetwork(ctx, f, stateDir, identity)
 }
 
-// cmdDown stops the mesh agent daemon.
+// cmdDown stops the mesh agent daemon by sending a shutdown request via the
+// Unix control socket.
 //
-// Currently this sends SIGTERM to a running `meshd up` process.
-// In the future, this will communicate with a proper daemon via Unix socket.
+// Usage: meshd down
 func cmdDown(ctx context.Context, args []string) error {
-	// For now, `down` is a placeholder. The `up` command runs in the foreground
-	// and can be stopped with Ctrl+C. A proper daemon mode with `down` support
-	// will be added when we implement the IPN socket-based architecture.
-	fmt.Println("meshd down: not yet implemented for daemon mode.")
-	fmt.Println("Stop the running 'meshd up' process with Ctrl+C or SIGTERM.")
+	socketPath := daemon.DefaultSocketPath()
+	client := daemon.NewClient(socketPath)
+
+	if !client.IsRunning() {
+		fmt.Println("meshd is not running.")
+		return nil
+	}
+
+	fmt.Printf("Stopping meshd (socket: %s)...\n", socketPath)
+	if err := client.Shutdown(ctx); err != nil {
+		return fmt.Errorf("shutdown failed: %w", err)
+	}
+
+	// Wait for the daemon to actually stop (socket goes away).
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if !client.IsRunning() {
+			fmt.Println("Stopped.")
+			return nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	fmt.Println("Shutdown request sent but daemon is still running.")
+	fmt.Println("You may need to send SIGTERM manually.")
 	return nil
 }
 

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -1,0 +1,90 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+)
+
+// Client communicates with a running meshd daemon via Unix socket.
+type Client struct {
+	socketPath string
+	httpClient *http.Client
+}
+
+// NewClient creates a new daemon client that connects to the given socket.
+func NewClient(socketPath string) *Client {
+	return &Client{
+		socketPath: socketPath,
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					var d net.Dialer
+					return d.DialContext(ctx, "unix", socketPath)
+				},
+			},
+			Timeout: 5 * time.Second,
+		},
+	}
+}
+
+// Shutdown sends a shutdown request to the running daemon.
+func (c *Client) Shutdown(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, "POST", "http://meshd/api/v0/shutdown", nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("connecting to daemon: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("daemon returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// GetStatus queries the running daemon for its current status.
+func (c *Client) GetStatus(ctx context.Context) (*Status, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://meshd/api/v0/status", nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to daemon: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("daemon returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var status Status
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		return nil, fmt.Errorf("parsing status: %w", err)
+	}
+
+	return &status, nil
+}
+
+// IsRunning checks whether a daemon is listening on the socket.
+func (c *Client) IsRunning() bool {
+	conn, err := net.DialTimeout("unix", c.socketPath, time.Second)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1,0 +1,200 @@
+// Package daemon provides a lightweight control socket for meshd.
+//
+// When meshd up starts, it opens a Unix socket and serves a minimal HTTP
+// API. Other commands (meshd down, meshd status) connect to this socket
+// to control or query the running daemon.
+//
+// Endpoints:
+//
+//	POST /api/v0/shutdown  — gracefully stop the daemon
+//	GET  /api/v0/status    — return running state as JSON
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"time"
+)
+
+// DefaultSocketPath returns the default Unix socket path for the daemon.
+//
+// Root: /var/run/meshd/meshd.sock
+// User: ~/.enbox/meshd.sock
+func DefaultSocketPath() string {
+	if os.Getuid() == 0 {
+		return "/var/run/meshd/meshd.sock"
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "/tmp/meshd.sock"
+	}
+	return filepath.Join(home, ".enbox", "meshd.sock")
+}
+
+// Status is the JSON response from GET /api/v0/status.
+type Status struct {
+	Running   bool   `json:"running"`
+	TUNDevice string `json:"tunDevice,omitempty"`
+	MeshIP    string `json:"meshIP,omitempty"`
+	Network   string `json:"network,omitempty"`
+	Uptime    string `json:"uptime,omitempty"`
+	PID       int    `json:"pid"`
+}
+
+// StatusFunc is called to obtain the current daemon status.
+type StatusFunc func() Status
+
+// Server is a lightweight HTTP control server over a Unix socket.
+type Server struct {
+	socketPath string
+	logger     *slog.Logger
+	statusFn   StatusFunc
+	startTime  time.Time
+
+	mu       sync.Mutex
+	listener net.Listener
+	srv      *http.Server
+
+	// shutdownCh is signaled when a shutdown request is received.
+	shutdownCh chan struct{}
+}
+
+// NewServer creates a new daemon control server.
+//
+// The statusFn callback is called to obtain current status for the
+// /api/v0/status endpoint. The returned ShutdownCh() channel is
+// signaled when a POST /api/v0/shutdown request is received.
+func NewServer(socketPath string, statusFn StatusFunc, logger *slog.Logger) *Server {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Server{
+		socketPath: socketPath,
+		logger:     logger,
+		statusFn:   statusFn,
+		startTime:  time.Now(),
+		shutdownCh: make(chan struct{}),
+	}
+}
+
+// ShutdownCh returns a channel that is closed when a shutdown request
+// is received via the control socket.
+func (s *Server) ShutdownCh() <-chan struct{} {
+	return s.shutdownCh
+}
+
+// SocketPath returns the path of the Unix socket.
+func (s *Server) SocketPath() string {
+	return s.socketPath
+}
+
+// Start begins listening on the Unix socket and serving HTTP requests.
+func (s *Server) Start() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Ensure socket directory exists.
+	sockDir := filepath.Dir(s.socketPath)
+	if err := os.MkdirAll(sockDir, 0755); err != nil {
+		return fmt.Errorf("creating socket directory: %w", err)
+	}
+
+	// Remove stale socket if no one is listening.
+	if conn, err := net.Dial("unix", s.socketPath); err == nil {
+		conn.Close()
+		return fmt.Errorf("another meshd instance is already running (socket: %s)", s.socketPath)
+	}
+	_ = os.Remove(s.socketPath)
+
+	listener, err := net.Listen("unix", s.socketPath)
+	if err != nil {
+		return fmt.Errorf("listening on %s: %w", s.socketPath, err)
+	}
+
+	// Set socket permissions: world-accessible on platforms with peer
+	// creds (Linux, macOS), restricted otherwise.
+	perm := os.FileMode(0600)
+	switch runtime.GOOS {
+	case "linux", "darwin", "freebsd":
+		perm = 0666
+	}
+	if err := os.Chmod(s.socketPath, perm); err != nil {
+		s.logger.Warn("setting socket permissions", slog.Any("error", err))
+	}
+
+	s.listener = listener
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v0/shutdown", s.handleShutdown)
+	mux.HandleFunc("GET /api/v0/status", s.handleStatus)
+
+	s.srv = &http.Server{Handler: mux}
+
+	go func() {
+		if err := s.srv.Serve(listener); err != nil && err != http.ErrServerClosed {
+			s.logger.Warn("daemon server error", slog.Any("error", err))
+		}
+	}()
+
+	s.logger.Info("daemon control socket listening", slog.String("path", s.socketPath))
+	return nil
+}
+
+// Stop gracefully shuts down the HTTP server and removes the socket.
+func (s *Server) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.srv != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = s.srv.Shutdown(ctx)
+	}
+
+	if s.listener != nil {
+		_ = s.listener.Close()
+	}
+
+	_ = os.Remove(s.socketPath)
+	s.logger.Info("daemon control socket closed")
+}
+
+func (s *Server) handleShutdown(w http.ResponseWriter, r *http.Request) {
+	s.logger.Info("shutdown requested via control socket")
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "shutting down"})
+
+	// Signal shutdown asynchronously so the HTTP response is sent first.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		select {
+		case s.shutdownCh <- struct{}{}:
+		default:
+		}
+	}()
+}
+
+func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	status := Status{
+		Running: true,
+		PID:     os.Getpid(),
+	}
+	if s.statusFn != nil {
+		status = s.statusFn()
+		status.Running = true
+		status.PID = os.Getpid()
+	}
+	status.Uptime = time.Since(s.startTime).Round(time.Second).String()
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(status)
+}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1,0 +1,275 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func testSocketPath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "meshd.sock")
+}
+
+func TestServerStartStop(t *testing.T) {
+	sock := testSocketPath(t)
+	srv := NewServer(sock, nil, nil)
+
+	if err := srv.Start(); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+
+	// Socket file should exist.
+	if _, err := os.Stat(sock); err != nil {
+		t.Fatalf("socket file not found: %v", err)
+	}
+
+	srv.Stop()
+
+	// Socket file should be removed.
+	if _, err := os.Stat(sock); !os.IsNotExist(err) {
+		t.Fatalf("socket file not removed after Stop()")
+	}
+}
+
+func TestServerRejectsDoubleStart(t *testing.T) {
+	sock := testSocketPath(t)
+	srv1 := NewServer(sock, nil, nil)
+	if err := srv1.Start(); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	defer srv1.Stop()
+
+	// A second server on the same socket should fail.
+	srv2 := NewServer(sock, nil, nil)
+	if err := srv2.Start(); err == nil {
+		srv2.Stop()
+		t.Fatal("expected error starting second server on same socket")
+	}
+}
+
+func TestStaleSocketCleanup(t *testing.T) {
+	sock := testSocketPath(t)
+
+	// Create a stale socket file (no listener).
+	if err := os.MkdirAll(filepath.Dir(sock), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sock, []byte("stale"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := NewServer(sock, nil, nil)
+	if err := srv.Start(); err != nil {
+		t.Fatalf("Start() should clean up stale socket: %v", err)
+	}
+	defer srv.Stop()
+}
+
+func TestStatusEndpoint(t *testing.T) {
+	sock := testSocketPath(t)
+	srv := NewServer(sock, func() Status {
+		return Status{
+			TUNDevice: "meshd0",
+			MeshIP:    "10.200.0.1",
+			Network:   "test-net",
+		}
+	}, nil)
+
+	if err := srv.Start(); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	defer srv.Stop()
+
+	client := NewClient(sock)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	status, err := client.GetStatus(ctx)
+	if err != nil {
+		t.Fatalf("GetStatus() error: %v", err)
+	}
+
+	if !status.Running {
+		t.Error("expected Running=true")
+	}
+	if status.PID != os.Getpid() {
+		t.Errorf("PID = %d, want %d", status.PID, os.Getpid())
+	}
+	if status.TUNDevice != "meshd0" {
+		t.Errorf("TUNDevice = %q, want %q", status.TUNDevice, "meshd0")
+	}
+	if status.MeshIP != "10.200.0.1" {
+		t.Errorf("MeshIP = %q, want %q", status.MeshIP, "10.200.0.1")
+	}
+	if status.Network != "test-net" {
+		t.Errorf("Network = %q, want %q", status.Network, "test-net")
+	}
+	if status.Uptime == "" {
+		t.Error("expected non-empty Uptime")
+	}
+}
+
+func TestStatusEndpointNoFunc(t *testing.T) {
+	sock := testSocketPath(t)
+	srv := NewServer(sock, nil, nil)
+
+	if err := srv.Start(); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	defer srv.Stop()
+
+	client := NewClient(sock)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	status, err := client.GetStatus(ctx)
+	if err != nil {
+		t.Fatalf("GetStatus() error: %v", err)
+	}
+
+	if !status.Running {
+		t.Error("expected Running=true")
+	}
+	if status.PID != os.Getpid() {
+		t.Errorf("PID = %d, want %d", status.PID, os.Getpid())
+	}
+}
+
+func TestShutdownEndpoint(t *testing.T) {
+	sock := testSocketPath(t)
+	srv := NewServer(sock, nil, nil)
+
+	if err := srv.Start(); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	defer srv.Stop()
+
+	client := NewClient(sock)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := client.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown() error: %v", err)
+	}
+
+	// The shutdown channel should be signaled.
+	select {
+	case <-srv.ShutdownCh():
+		// ok
+	case <-time.After(2 * time.Second):
+		t.Fatal("ShutdownCh not signaled within timeout")
+	}
+}
+
+func TestShutdownEndpointResponse(t *testing.T) {
+	sock := testSocketPath(t)
+	srv := NewServer(sock, nil, nil)
+
+	if err := srv.Start(); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	defer srv.Stop()
+
+	// Use raw HTTP to check the response body.
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", sock)
+			},
+		},
+		Timeout: 5 * time.Second,
+	}
+
+	resp, err := httpClient.Post("http://meshd/api/v0/shutdown", "", nil)
+	if err != nil {
+		t.Fatalf("POST /api/v0/shutdown error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["status"] != "shutting down" {
+		t.Errorf("body status = %q, want %q", body["status"], "shutting down")
+	}
+}
+
+func TestClientIsRunning(t *testing.T) {
+	sock := testSocketPath(t)
+	client := NewClient(sock)
+
+	// No server running — should return false.
+	if client.IsRunning() {
+		t.Fatal("expected IsRunning=false when no server")
+	}
+
+	srv := NewServer(sock, nil, nil)
+	if err := srv.Start(); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+
+	// Server running — should return true.
+	if !client.IsRunning() {
+		t.Fatal("expected IsRunning=true when server running")
+	}
+
+	srv.Stop()
+
+	// Server stopped — should return false.
+	if client.IsRunning() {
+		t.Fatal("expected IsRunning=false after Stop()")
+	}
+}
+
+func TestClientShutdownNoServer(t *testing.T) {
+	sock := testSocketPath(t)
+	client := NewClient(sock)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := client.Shutdown(ctx)
+	if err == nil {
+		t.Fatal("expected error when no server running")
+	}
+}
+
+func TestClientGetStatusNoServer(t *testing.T) {
+	sock := testSocketPath(t)
+	client := NewClient(sock)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err := client.GetStatus(ctx)
+	if err == nil {
+		t.Fatal("expected error when no server running")
+	}
+}
+
+func TestSocketPath(t *testing.T) {
+	sock := testSocketPath(t)
+	srv := NewServer(sock, nil, nil)
+	if got := srv.SocketPath(); got != sock {
+		t.Errorf("SocketPath() = %q, want %q", got, sock)
+	}
+}
+
+func TestDefaultSocketPath(t *testing.T) {
+	p := DefaultSocketPath()
+	if p == "" {
+		t.Fatal("DefaultSocketPath() returned empty string")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a Unix socket-based daemon control server to meshd, enabling `meshd down` to gracefully stop the daemon and `meshd status` to query live runtime information.

Closes #30

## Changes

### New: `internal/daemon/` package
- **`daemon.go`** — `Server` type: HTTP server over Unix socket at `/var/run/meshd/meshd.sock` (root) or `~/.enbox/meshd.sock` (user). Endpoints:
  - `POST /api/v0/shutdown` — signals graceful shutdown
  - `GET /api/v0/status` — returns JSON with PID, uptime, TUN device, mesh IP, network name
  - Stale socket detection and cleanup on startup
  - Rejects double-start (detects existing listener)
- **`client.go`** — `Client` type with `Shutdown()`, `GetStatus()`, `IsRunning()` methods
- **`daemon_test.go`** — 12 tests covering server lifecycle, client operations, stale socket cleanup, double-start rejection, shutdown signaling, and error paths

### Modified: `cmd/meshd/main.go`
- **`cmdUp()`** — starts the daemon control server after the engine starts; blocks on both signal channel and `ShutdownCh()` so either Ctrl+C or `meshd down` triggers graceful shutdown
- **`cmdDown()`** — connects to daemon socket, sends shutdown request, waits up to 10s for the process to exit
- **`cmdStatus()`** — queries live daemon status (PID, uptime, TUN device) if a daemon is running

## Verification

```
go build ./...        # Zero build errors
go vet ./...          # Zero vet warnings
go test ./... -count=1 -race  # All tests pass, no data races
```