### PR TITLE
fix: detect offline peers using endpoint record timestamps

### DIFF
--- a/internal/control/control_test.go
+++ b/internal/control/control_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/netip"
 	"testing"
+	"time"
 
 	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
 )
@@ -84,6 +85,9 @@ func TestBuildStaticMapResponse(t *testing.T) {
 }
 
 func TestNodeInfoToNode(t *testing.T) {
+	now := time.Now().UTC()
+	recentUpdate := now.Add(-2 * time.Minute).Format(time.RFC3339)
+
 	info := &NodeInfoData{
 		WireGuardPublicKey: "testkey==",
 		MeshIP:             "10.200.0.5",
@@ -98,11 +102,12 @@ func TestNodeInfoToNode(t *testing.T) {
 				},
 				LocalEndpoints: []string{"192.168.1.5:41641"},
 				PreferredDERP:  2,
+				UpdatedAt:      recentUpdate,
 			},
 		},
 	}
 
-	node := nodeInfoToNode(42, "did:dht:test", info)
+	node := nodeInfoToNodeWithThreshold(42, "did:dht:test", info, DefaultPeerStaleThreshold, now)
 
 	tests := map[string]struct {
 		got  any
@@ -114,6 +119,7 @@ func TestNodeInfoToNode(t *testing.T) {
 		"MeshIP":        {got: node.MeshIP, want: netip.MustParseAddr("10.200.0.5")},
 		"Name":          {got: node.Name, want: "myhost"},
 		"PreferredDERP": {got: node.PreferredDERP, want: 2},
+		"Online":        {got: node.Online, want: true},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -122,6 +128,12 @@ func TestNodeInfoToNode(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("LastSeen", func(t *testing.T) {
+		if node.LastSeen.IsZero() {
+			t.Fatal("expected non-zero LastSeen")
+		}
+	})
 
 	t.Run("AllowedIPs", func(t *testing.T) {
 		// mesh IP /32 + additional subnet
@@ -144,6 +156,136 @@ func TestNodeInfoToNode(t *testing.T) {
 			t.Errorf("[1] = %q", node.Endpoints[1])
 		}
 	})
+}
+
+func TestNodeOnlineStatus(t *testing.T) {
+	now := time.Date(2026, 2, 25, 12, 0, 0, 0, time.UTC)
+	threshold := 5 * time.Minute
+
+	tests := []struct {
+		name       string
+		endpoints  []EndpointData
+		wantOnline bool
+		wantSeen   bool // whether LastSeen should be non-zero
+	}{
+		{
+			name:       "no endpoints — offline",
+			endpoints:  nil,
+			wantOnline: false,
+			wantSeen:   false,
+		},
+		{
+			name: "no updatedAt — offline",
+			endpoints: []EndpointData{
+				{LocalEndpoints: []string{"192.168.1.5:41641"}},
+			},
+			wantOnline: false,
+			wantSeen:   false,
+		},
+		{
+			name: "recent update — online",
+			endpoints: []EndpointData{
+				{
+					LocalEndpoints: []string{"192.168.1.5:41641"},
+					UpdatedAt:      now.Add(-2 * time.Minute).Format(time.RFC3339),
+				},
+			},
+			wantOnline: true,
+			wantSeen:   true,
+		},
+		{
+			name: "exactly at threshold — online",
+			endpoints: []EndpointData{
+				{
+					LocalEndpoints: []string{"192.168.1.5:41641"},
+					UpdatedAt:      now.Add(-threshold).Format(time.RFC3339),
+				},
+			},
+			wantOnline: true,
+			wantSeen:   true,
+		},
+		{
+			name: "just past threshold — offline",
+			endpoints: []EndpointData{
+				{
+					LocalEndpoints: []string{"192.168.1.5:41641"},
+					UpdatedAt:      now.Add(-threshold - time.Second).Format(time.RFC3339),
+				},
+			},
+			wantOnline: false,
+			wantSeen:   true,
+		},
+		{
+			name: "stale update — offline",
+			endpoints: []EndpointData{
+				{
+					LocalEndpoints: []string{"192.168.1.5:41641"},
+					UpdatedAt:      now.Add(-30 * time.Minute).Format(time.RFC3339),
+				},
+			},
+			wantOnline: false,
+			wantSeen:   true,
+		},
+		{
+			name: "multiple endpoints uses most recent",
+			endpoints: []EndpointData{
+				{
+					LocalEndpoints: []string{"192.168.1.5:41641"},
+					UpdatedAt:      now.Add(-30 * time.Minute).Format(time.RFC3339),
+				},
+				{
+					LocalEndpoints: []string{"10.0.0.1:41641"},
+					UpdatedAt:      now.Add(-1 * time.Minute).Format(time.RFC3339),
+				},
+			},
+			wantOnline: true,
+			wantSeen:   true,
+		},
+		{
+			name: "malformed updatedAt — offline",
+			endpoints: []EndpointData{
+				{
+					LocalEndpoints: []string{"192.168.1.5:41641"},
+					UpdatedAt:      "not-a-timestamp",
+				},
+			},
+			wantOnline: false,
+			wantSeen:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			info := &NodeInfoData{
+				WireGuardPublicKey: "testkey==",
+				MeshIP:             "10.200.0.5",
+				Hostname:           "peer",
+				Endpoints:          tc.endpoints,
+			}
+
+			node := nodeInfoToNodeWithThreshold(1, "did:dht:test", info, threshold, now)
+
+			if node.Online != tc.wantOnline {
+				t.Errorf("Online = %v, want %v", node.Online, tc.wantOnline)
+			}
+			if tc.wantSeen && node.LastSeen.IsZero() {
+				t.Error("expected non-zero LastSeen")
+			}
+			if !tc.wantSeen && !node.LastSeen.IsZero() {
+				t.Errorf("expected zero LastSeen, got %v", node.LastSeen)
+			}
+		})
+	}
+}
+
+func TestDefaultPeerStaleThreshold(t *testing.T) {
+	// Verify the constant is reasonable (between 1 minute and 1 hour).
+	if DefaultPeerStaleThreshold < time.Minute {
+		t.Errorf("threshold %v is too short", DefaultPeerStaleThreshold)
+	}
+	if DefaultPeerStaleThreshold > time.Hour {
+		t.Errorf("threshold %v is too long", DefaultPeerStaleThreshold)
+	}
 }
 
 func TestDefaultDERPRegions(t *testing.T) {

--- a/internal/control/dwnclient.go
+++ b/internal/control/dwnclient.go
@@ -10,10 +10,17 @@ import (
 	"net/netip"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/enboxorg/meshd/internal/dwn"
 	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
 )
+
+// DefaultPeerStaleThreshold is the duration after which a peer is considered
+// offline if no endpoint record update has been received. This is roughly
+// 10x the default poll interval (30s), giving ample time for normal
+// endpoint refreshes to arrive even with network jitter.
+const DefaultPeerStaleThreshold = 5 * time.Minute
 
 // Protocol URIs used by meshd.
 const (
@@ -425,6 +432,14 @@ func (c *DWNClient) buildMapResponse() *MapResponse {
 }
 
 func nodeInfoToNode(id int64, did string, info *NodeInfoData) *Node {
+	return nodeInfoToNodeWithThreshold(id, did, info, DefaultPeerStaleThreshold, time.Now())
+}
+
+// nodeInfoToNodeWithThreshold converts a NodeInfoData to a Node, using the
+// given staleness threshold and reference time. The reference time is passed
+// as a parameter (instead of calling time.Now()) to make the function
+// deterministically testable.
+func nodeInfoToNodeWithThreshold(id int64, did string, info *NodeInfoData, staleThreshold time.Duration, now time.Time) *Node {
 	node := &Node{
 		ID:           id,
 		Name:         info.Hostname,
@@ -433,7 +448,6 @@ func nodeInfoToNode(id int64, did string, info *NodeInfoData) *Node {
 		DiscoKey:     info.DiscoKey,
 		OS:           info.OS,
 		Capabilities: info.Capabilities,
-		Online:       true,
 	}
 
 	if ip, err := netip.ParseAddr(info.MeshIP); err == nil {
@@ -446,6 +460,9 @@ func nodeInfoToNode(id int64, did string, info *NodeInfoData) *Node {
 			node.AllowedIPs = append(node.AllowedIPs, prefix)
 		}
 	}
+
+	// Track the most recent endpoint update time to determine online status.
+	var lastSeen time.Time
 
 	for _, ep := range info.Endpoints {
 		for _, pub := range ep.PublicEndpoints {
@@ -460,6 +477,24 @@ func nodeInfoToNode(id int64, did string, info *NodeInfoData) *Node {
 		if ep.DiscoKey != "" {
 			node.DiscoKey = ep.DiscoKey
 		}
+		// Track the most recent endpoint update.
+		if ep.UpdatedAt != "" {
+			if t, err := time.Parse(time.RFC3339, ep.UpdatedAt); err == nil {
+				if t.After(lastSeen) {
+					lastSeen = t
+				}
+			}
+		}
+	}
+
+	node.LastSeen = lastSeen
+
+	// Determine online status from the most recent endpoint update.
+	// A peer is online if it has endpoint data updated within the
+	// staleness threshold. Peers with no endpoint data are considered
+	// offline (they registered but never started the engine).
+	if !lastSeen.IsZero() && now.Sub(lastSeen) <= staleThreshold {
+		node.Online = true
 	}
 
 	// Default to DERP region 1 if no endpoint provided a preference.

--- a/internal/control/types.go
+++ b/internal/control/types.go
@@ -11,6 +11,7 @@ package control
 
 import (
 	"net/netip"
+	"time"
 )
 
 // Node represents a peer in the mesh network.
@@ -45,7 +46,13 @@ type Node struct {
 	PreferredDERP int
 
 	// Online indicates whether the node is currently reachable.
+	// Determined by whether the most recent endpoint record update
+	// is within the staleness threshold (DefaultPeerStaleThreshold).
 	Online bool
+
+	// LastSeen is the time of the most recent endpoint record update.
+	// Zero value means no endpoint data is available.
+	LastSeen time.Time
 
 	// OS is the operating system.
 	OS string

--- a/internal/engine/convert.go
+++ b/internal/engine/convert.go
@@ -163,9 +163,12 @@ func (c *Converter) convertNode(n *control.Node) (*tailcfg.Node, error) {
 		MachineAuthorized: true,
 	}
 
-	if n.Online {
-		online := true
-		node.Online = &online
+	online := n.Online
+	node.Online = &online
+
+	if !n.LastSeen.IsZero() {
+		lastSeen := n.LastSeen
+		node.LastSeen = &lastSeen
 	}
 
 	// Parse WireGuard public key. The key is stored as base64 in DWN records.


### PR DESCRIPTION
## Summary

Replaces the hardcoded `Online: true` for all peers with actual staleness detection based on endpoint record `UpdatedAt` timestamps. Peers whose most recent endpoint update is older than 5 minutes are now correctly marked offline.

Closes #32

## Changes

### `internal/control/types.go`
- Add `LastSeen time.Time` field to `Node` — populated from the most recent endpoint record `UpdatedAt` timestamp

### `internal/control/dwnclient.go`
- Add `DefaultPeerStaleThreshold` constant (5 minutes — ~10x the default 30s poll interval)
- Extract `nodeInfoToNodeWithThreshold()` for deterministic testing (accepts reference time)
- `nodeInfoToNode()` now delegates to the threshold-based version
- Online status logic: peer is online if it has endpoint data updated within the threshold; peers with no endpoint data or stale timestamps are offline

### `internal/engine/convert.go`
- `convertNode()` now always sets `tailcfg.Node.Online` (true or false, not just true)
- Propagates `LastSeen` to `tailcfg.Node.LastSeen` when available

### `internal/control/control_test.go`
- Updated `TestNodeInfoToNode` to use the threshold-based function and verify Online/LastSeen
- Added `TestNodeOnlineStatus` — 8 table-driven test cases:
  - No endpoints (offline)
  - Missing UpdatedAt (offline)
  - Recent update (online)
  - Exactly at threshold boundary (online)
  - Just past threshold (offline)
  - Stale update (offline)
  - Multiple endpoints picks most recent (online)
  - Malformed timestamp (offline)
- Added `TestDefaultPeerStaleThreshold` sanity check

## Design decisions

- **No new DWN record type**: The existing endpoint record `updatedAt` field already functions as an implicit heartbeat — it's refreshed every time the engine's STUN discovery runs (on each poll cycle)
- **5 minute threshold**: Conservative default, roughly 10x the poll interval, tolerates network jitter and temporary DWN unavailability
- **Testable**: The threshold function accepts a reference time parameter so tests are fully deterministic

## Verification

```
go build ./...                        # Zero build errors
go vet ./...                          # Zero vet warnings
go test ./... -count=1 -race          # All tests pass, no data races
```