### PR TITLE
feat: add didjwk.Create() for node identity generation

### DIFF
--- a/pkg/dids/didjwk/didjwk.go
+++ b/pkg/dids/didjwk/didjwk.go
@@ -1,62 +1,178 @@
-// Copied from github.com/enboxorg/web5-go — will be replaced by a shared enbox Go library.
+// Package didjwk implements creation and resolution of did:jwk identifiers.
+//
+// A did:jwk wraps a JWK (JSON Web Key) as a self-describing DID URI.
+// For Ed25519 keys, this package also derives X25519 key-agreement keys
+// via the birational map, enabling both signing (Ed25519) and encryption /
+// WireGuard tunneling (X25519) from a single identity.
 package didjwk
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha512"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
+
+	"filippo.io/edwards25519"
+	"golang.org/x/crypto/curve25519"
 
 	"github.com/enboxorg/meshd/pkg/dids/did"
 	"github.com/enboxorg/meshd/pkg/dids/didcore"
 	"github.com/enboxorg/meshd/pkg/jwk"
 )
 
-// Resolver is a type to implement resolution
+// Identity holds a did:jwk identity backed by an Ed25519 keypair,
+// with the derived X25519 keys for key agreement / WireGuard.
+type Identity struct {
+	// URI is the fully-formed did:jwk:... string.
+	URI string
+
+	// Ed25519 signing keys.
+	PrivateKey ed25519.PrivateKey
+	PublicKey  ed25519.PublicKey
+
+	// X25519 key-agreement keys derived via the birational map.
+	X25519PrivateKey []byte // 32 bytes, clamped
+	X25519PublicKey  []byte // 32 bytes
+}
+
+// Create generates a new Ed25519 keypair, constructs a did:jwk URI, and
+// derives the corresponding X25519 keys. The returned Identity contains
+// everything needed for DWN auth (Ed25519) and WireGuard (X25519).
+func Create() (*Identity, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generating ed25519 key: %w", err)
+	}
+	return FromPrivateKey(priv, pub)
+}
+
+// FromPrivateKey reconstructs a did:jwk Identity from an existing Ed25519
+// private key. The public key is derived if pub is nil.
+func FromPrivateKey(priv ed25519.PrivateKey, pub ed25519.PublicKey) (*Identity, error) {
+	if len(priv) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("invalid ed25519 private key length: %d", len(priv))
+	}
+	if pub == nil {
+		pub = priv.Public().(ed25519.PublicKey)
+	}
+
+	// Build the public JWK and encode as did:jwk URI.
+	pubJWK := jwk.JWK{
+		KTY: "OKP",
+		CRV: "Ed25519",
+		X:   base64.RawURLEncoding.EncodeToString(pub),
+	}
+	jwkBytes, err := json.Marshal(pubJWK)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling jwk: %w", err)
+	}
+	uri := "did:jwk:" + base64.RawURLEncoding.EncodeToString(jwkBytes)
+
+	// Derive X25519 keys.
+	x25519Pub, x25519Priv, err := ed25519ToX25519(pub, priv)
+	if err != nil {
+		return nil, fmt.Errorf("deriving x25519 keys: %w", err)
+	}
+
+	return &Identity{
+		URI:              uri,
+		PrivateKey:       priv,
+		PublicKey:        pub,
+		X25519PrivateKey: x25519Priv,
+		X25519PublicKey:  x25519Pub,
+	}, nil
+}
+
+// DeriveX25519PublicKey extracts the Ed25519 public key from a did:jwk URI
+// and derives the corresponding X25519 public key via the birational map.
+// This is how peers derive WireGuard public keys from a did:jwk identity
+// without needing any private key material.
+func DeriveX25519PublicKey(uri string) ([]byte, error) {
+	d, err := did.Parse(uri)
+	if err != nil {
+		return nil, fmt.Errorf("parsing did uri: %w", err)
+	}
+	if d.Method != "jwk" {
+		return nil, fmt.Errorf("expected did:jwk, got did:%s", d.Method)
+	}
+
+	decoded, err := base64.RawURLEncoding.DecodeString(d.ID)
+	if err != nil {
+		return nil, fmt.Errorf("decoding jwk: %w", err)
+	}
+
+	var k jwk.JWK
+	if err := json.Unmarshal(decoded, &k); err != nil {
+		return nil, fmt.Errorf("unmarshaling jwk: %w", err)
+	}
+
+	if k.KTY != "OKP" || k.CRV != "Ed25519" {
+		return nil, fmt.Errorf("unsupported key type: kty=%s crv=%s (expected OKP/Ed25519)", k.KTY, k.CRV)
+	}
+
+	pubBytes, err := base64.RawURLEncoding.DecodeString(k.X)
+	if err != nil {
+		return nil, fmt.Errorf("decoding public key: %w", err)
+	}
+	if len(pubBytes) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("invalid ed25519 public key length: %d", len(pubBytes))
+	}
+
+	return ed25519PubToX25519(pubBytes)
+}
+
+// Resolver implements did:jwk resolution.
 type Resolver struct{}
 
-// ResolveWithContext the provided DID URI (must be a did:jwk) as per the wee bit of detail provided in the
-// spec: https://github.com/quartzjer/did-jwk/blob/main/spec.md
+// ResolveWithContext resolves a did:jwk URI with a context.
 func (r Resolver) ResolveWithContext(ctx context.Context, uri string) (didcore.ResolutionResult, error) {
 	return r.Resolve(uri)
 }
 
-// Resolve the provided DID URI (must be a did:jwk) as per the wee bit of detail provided in the
-// spec: https://github.com/quartzjer/did-jwk/blob/main/spec.md
+// Resolve resolves a did:jwk URI into a DID Document. For Ed25519 keys,
+// the resolved document includes both the Ed25519 signing verification
+// method (#0) and a derived X25519 key agreement verification method (#1).
 func (r Resolver) Resolve(uri string) (didcore.ResolutionResult, error) {
-	did, err := did.Parse(uri)
+	d, err := did.Parse(uri)
 	if err != nil {
 		return didcore.ResolutionResultWithError("invalidDid"), didcore.ResolutionError{Code: "invalidDid"}
 	}
 
-	if did.Method != "jwk" {
+	if d.Method != "jwk" {
 		return didcore.ResolutionResultWithError("invalidDid"), didcore.ResolutionError{Code: "invalidDid"}
 	}
 
-	decodedID, err := base64.RawURLEncoding.DecodeString(did.ID)
+	decodedID, err := base64.RawURLEncoding.DecodeString(d.ID)
 	if err != nil {
 		return didcore.ResolutionResultWithError("invalidDid"), didcore.ResolutionError{Code: "invalidDid"}
 	}
 
-	var jwk jwk.JWK
-	err = json.Unmarshal(decodedID, &jwk)
-	if err != nil {
+	var k jwk.JWK
+	if err := json.Unmarshal(decodedID, &k); err != nil {
 		return didcore.ResolutionResultWithError("invalidDid"), didcore.ResolutionError{Code: "invalidDid"}
 	}
 
-	doc := createDocument(did, jwk)
+	doc := createDocument(d, k)
 	return didcore.ResolutionResultWithDocument(doc), nil
 }
 
-func createDocument(did did.DID, publicKey jwk.JWK) didcore.Document {
+// createDocument builds the DID Document for the given did:jwk.
+// For Ed25519 keys, it adds a derived X25519 key agreement method.
+func createDocument(d did.DID, publicKey jwk.JWK) didcore.Document {
 	doc := didcore.Document{
 		Context: []string{"https://www.w3.org/ns/did/v1"},
-		ID:      did.URI,
+		ID:      d.URI,
 	}
 
+	// #0 — the primary verification method (the JWK as-is).
 	vm := didcore.VerificationMethod{
-		ID:           did.URI + "#0",
+		ID:           d.URI + "#0",
 		Type:         "JsonWebKey",
-		Controller:   did.URI,
+		Controller:   d.URI,
 		PublicKeyJwk: &publicKey,
 	}
 
@@ -65,5 +181,68 @@ func createDocument(did did.DID, publicKey jwk.JWK) didcore.Document {
 		didcore.Purposes("assertionMethod", "authentication", "capabilityInvocation", "capabilityDelegation"),
 	)
 
+	// For Ed25519 keys, derive X25519 and add as #1 for key agreement.
+	if publicKey.KTY == "OKP" && publicKey.CRV == "Ed25519" && publicKey.X != "" {
+		pubBytes, err := base64.RawURLEncoding.DecodeString(publicKey.X)
+		if err == nil && len(pubBytes) == ed25519.PublicKeySize {
+			x25519Pub, err := ed25519PubToX25519(pubBytes)
+			if err == nil {
+				kaJWK := jwk.JWK{
+					KTY: "OKP",
+					CRV: "X25519",
+					X:   base64.RawURLEncoding.EncodeToString(x25519Pub),
+				}
+				kaVM := didcore.VerificationMethod{
+					ID:           d.URI + "#1",
+					Type:         "JsonWebKey",
+					Controller:   d.URI,
+					PublicKeyJwk: &kaJWK,
+				}
+				doc.AddVerificationMethod(kaVM, didcore.Purposes("keyAgreement"))
+			}
+		}
+	}
+
 	return doc
+}
+
+// ed25519ToX25519 derives X25519 keys from Ed25519 keys.
+//
+// Public key: birational map from Ed25519 (twisted Edwards) to X25519
+// (Montgomery) via filippo.io/edwards25519 Point.BytesMontgomery().
+//
+// Private key: SHA-512(seed), take first 32 bytes, clamp per RFC 7748.
+func ed25519ToX25519(pub ed25519.PublicKey, priv ed25519.PrivateKey) (x25519Pub, x25519Priv []byte, err error) {
+	x25519Pub, err = ed25519PubToX25519(pub)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	h := sha512.Sum512(priv.Seed())
+	x25519Priv = make([]byte, 32)
+	copy(x25519Priv, h[:32])
+	x25519Priv[0] &= 248
+	x25519Priv[31] &= 127
+	x25519Priv[31] |= 64
+
+	// Verify: derive public from private and compare.
+	derivedPub, err := curve25519.X25519(x25519Priv, curve25519.Basepoint)
+	if err != nil {
+		return nil, nil, fmt.Errorf("x25519 scalar mult: %w", err)
+	}
+	if subtle.ConstantTimeCompare(x25519Pub, derivedPub) != 1 {
+		return nil, nil, fmt.Errorf("x25519 key derivation mismatch")
+	}
+
+	return x25519Pub, x25519Priv, nil
+}
+
+// ed25519PubToX25519 converts an Ed25519 public key to an X25519 public
+// key using the birational map (Edwards → Montgomery).
+func ed25519PubToX25519(pub ed25519.PublicKey) ([]byte, error) {
+	edPoint, err := new(edwards25519.Point).SetBytes(pub)
+	if err != nil {
+		return nil, fmt.Errorf("parsing ed25519 public key: %w", err)
+	}
+	return edPoint.BytesMontgomery(), nil
 }

--- a/pkg/dids/didjwk/didjwk_test.go
+++ b/pkg/dids/didjwk/didjwk_test.go
@@ -1,9 +1,13 @@
 package didjwk
 
 import (
+	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/json"
+	"strings"
 	"testing"
+
+	"golang.org/x/crypto/curve25519"
 
 	"github.com/enboxorg/meshd/pkg/dids/didcore"
 	"github.com/enboxorg/meshd/pkg/jwk"
@@ -24,6 +28,10 @@ func makeEd25519JWK(t *testing.T) string {
 	return "did:jwk:" + base64.RawURLEncoding.EncodeToString(b)
 }
 
+// -----------------------------------------------------------------------
+// Resolve tests (existing + enhanced)
+// -----------------------------------------------------------------------
+
 func TestResolve(t *testing.T) {
 	tests := map[string]struct {
 		uri     string
@@ -37,8 +45,9 @@ func TestResolve(t *testing.T) {
 				if doc.ID == "" {
 					t.Fatal("document ID is empty")
 				}
-				if len(doc.VerificationMethod) != 1 {
-					t.Fatalf("expected 1 verification method, got %d", len(doc.VerificationMethod))
+				// Should have 2 VMs: #0 (Ed25519) and #1 (X25519).
+				if len(doc.VerificationMethod) != 2 {
+					t.Fatalf("expected 2 verification methods, got %d", len(doc.VerificationMethod))
 				}
 				vm := doc.VerificationMethod[0]
 				if vm.Type != "JsonWebKey" {
@@ -53,7 +62,6 @@ func TestResolve(t *testing.T) {
 				if vm.Controller != doc.ID {
 					t.Errorf("controller = %q, want %q", vm.Controller, doc.ID)
 				}
-				// VM ID should be URI + #0
 				if vm.ID != doc.ID+"#0" {
 					t.Errorf("VM ID = %q, want %q", vm.ID, doc.ID+"#0")
 				}
@@ -121,7 +129,6 @@ func TestResolve(t *testing.T) {
 				if resErr.Code != tc.wantErr {
 					t.Errorf("error code = %q, want %q", resErr.Code, tc.wantErr)
 				}
-				// Also check that the result has the error metadata
 				if result.ResolutionMetadata.Error != tc.wantErr {
 					t.Errorf("metadata error = %q, want %q", result.ResolutionMetadata.Error, tc.wantErr)
 				}
@@ -156,4 +163,406 @@ func TestResolve_Deterministic(t *testing.T) {
 	if r1.Document.VerificationMethod[0].ID != r2.Document.VerificationMethod[0].ID {
 		t.Error("resolve is not deterministic: different VM IDs")
 	}
+}
+
+// -----------------------------------------------------------------------
+// Resolve — X25519 key agreement enhancement
+// -----------------------------------------------------------------------
+
+func TestResolve_Ed25519_HasKeyAgreement(t *testing.T) {
+	r := Resolver{}
+	uri := makeEd25519JWK(t)
+
+	result, err := r.Resolve(uri)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	doc := result.Document
+
+	// Must have 2 VMs.
+	if len(doc.VerificationMethod) != 2 {
+		t.Fatalf("expected 2 verification methods, got %d", len(doc.VerificationMethod))
+	}
+
+	// #1 should be X25519 key agreement.
+	kaVM := doc.VerificationMethod[1]
+	if kaVM.ID != doc.ID+"#1" {
+		t.Errorf("key agreement VM ID = %q, want %q", kaVM.ID, doc.ID+"#1")
+	}
+	if kaVM.Type != "JsonWebKey" {
+		t.Errorf("key agreement VM type = %q, want %q", kaVM.Type, "JsonWebKey")
+	}
+	if kaVM.PublicKeyJwk == nil {
+		t.Fatal("key agreement PublicKeyJwk is nil")
+	}
+	if kaVM.PublicKeyJwk.KTY != "OKP" {
+		t.Errorf("key agreement KTY = %q, want %q", kaVM.PublicKeyJwk.KTY, "OKP")
+	}
+	if kaVM.PublicKeyJwk.CRV != "X25519" {
+		t.Errorf("key agreement CRV = %q, want %q", kaVM.PublicKeyJwk.CRV, "X25519")
+	}
+
+	// keyAgreement purpose list should reference #1.
+	if len(doc.KeyAgreement) == 0 {
+		t.Fatal("keyAgreement purpose list is empty")
+	}
+	if doc.KeyAgreement[0] != doc.ID+"#1" {
+		t.Errorf("keyAgreement[0] = %q, want %q", doc.KeyAgreement[0], doc.ID+"#1")
+	}
+
+	// The X25519 public key should decode to 32 bytes.
+	x25519Bytes, err := base64.RawURLEncoding.DecodeString(kaVM.PublicKeyJwk.X)
+	if err != nil {
+		t.Fatalf("decoding X25519 key: %v", err)
+	}
+	if len(x25519Bytes) != 32 {
+		t.Errorf("X25519 key length = %d, want 32", len(x25519Bytes))
+	}
+}
+
+func TestResolve_SelectKeyAgreement(t *testing.T) {
+	r := Resolver{}
+	uri := makeEd25519JWK(t)
+
+	result, err := r.Resolve(uri)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	// Should be able to select key agreement VM.
+	vm, err := result.Document.SelectVerificationMethod(didcore.PurposeKeyAgreement)
+	if err != nil {
+		t.Fatalf("selecting key agreement VM: %v", err)
+	}
+	if vm.PublicKeyJwk == nil || vm.PublicKeyJwk.CRV != "X25519" {
+		t.Error("selected VM is not X25519")
+	}
+}
+
+// -----------------------------------------------------------------------
+// Create tests
+// -----------------------------------------------------------------------
+
+func TestCreate(t *testing.T) {
+	id, err := Create()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// URI should start with did:jwk:
+	if !strings.HasPrefix(id.URI, "did:jwk:") {
+		t.Errorf("URI = %q, want prefix did:jwk:", id.URI)
+	}
+
+	// Key lengths.
+	if len(id.PrivateKey) != ed25519.PrivateKeySize {
+		t.Errorf("private key length = %d, want %d", len(id.PrivateKey), ed25519.PrivateKeySize)
+	}
+	if len(id.PublicKey) != ed25519.PublicKeySize {
+		t.Errorf("public key length = %d, want %d", len(id.PublicKey), ed25519.PublicKeySize)
+	}
+	if len(id.X25519PrivateKey) != 32 {
+		t.Errorf("x25519 private key length = %d, want 32", len(id.X25519PrivateKey))
+	}
+	if len(id.X25519PublicKey) != 32 {
+		t.Errorf("x25519 public key length = %d, want 32", len(id.X25519PublicKey))
+	}
+
+	// Ed25519 signing round-trip.
+	msg := []byte("test message")
+	sig := ed25519.Sign(id.PrivateKey, msg)
+	if !ed25519.Verify(id.PublicKey, msg, sig) {
+		t.Error("ed25519 sign/verify failed")
+	}
+
+	// X25519 key pair consistency: derive pub from priv, compare.
+	derivedPub, err := curve25519.X25519(id.X25519PrivateKey, curve25519.Basepoint)
+	if err != nil {
+		t.Fatalf("x25519 scalar mult: %v", err)
+	}
+	if !equal(derivedPub, id.X25519PublicKey) {
+		t.Error("x25519 public key does not match derivation from private key")
+	}
+}
+
+func TestCreate_Unique(t *testing.T) {
+	id1, err := Create()
+	if err != nil {
+		t.Fatalf("Create 1: %v", err)
+	}
+	id2, err := Create()
+	if err != nil {
+		t.Fatalf("Create 2: %v", err)
+	}
+
+	if id1.URI == id2.URI {
+		t.Error("two Create() calls produced the same URI")
+	}
+	if equal(id1.PrivateKey, id2.PrivateKey) {
+		t.Error("two Create() calls produced the same private key")
+	}
+}
+
+// -----------------------------------------------------------------------
+// FromPrivateKey tests
+// -----------------------------------------------------------------------
+
+func TestFromPrivateKey(t *testing.T) {
+	// Create, then reconstruct from private key — should be identical.
+	original, err := Create()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	reconstructed, err := FromPrivateKey(original.PrivateKey, nil)
+	if err != nil {
+		t.Fatalf("FromPrivateKey: %v", err)
+	}
+
+	if original.URI != reconstructed.URI {
+		t.Errorf("URI mismatch:\n  original:      %s\n  reconstructed: %s", original.URI, reconstructed.URI)
+	}
+	if !equal(original.PublicKey, reconstructed.PublicKey) {
+		t.Error("public key mismatch")
+	}
+	if !equal(original.X25519PublicKey, reconstructed.X25519PublicKey) {
+		t.Error("x25519 public key mismatch")
+	}
+	if !equal(original.X25519PrivateKey, reconstructed.X25519PrivateKey) {
+		t.Error("x25519 private key mismatch")
+	}
+}
+
+func TestFromPrivateKey_WithExplicitPublicKey(t *testing.T) {
+	original, err := Create()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	reconstructed, err := FromPrivateKey(original.PrivateKey, original.PublicKey)
+	if err != nil {
+		t.Fatalf("FromPrivateKey: %v", err)
+	}
+
+	if original.URI != reconstructed.URI {
+		t.Error("URI mismatch when providing explicit public key")
+	}
+}
+
+func TestFromPrivateKey_InvalidLength(t *testing.T) {
+	_, err := FromPrivateKey([]byte("too short"), nil)
+	if err == nil {
+		t.Fatal("expected error for invalid key length")
+	}
+}
+
+// -----------------------------------------------------------------------
+// DeriveX25519PublicKey tests
+// -----------------------------------------------------------------------
+
+func TestDeriveX25519PublicKey(t *testing.T) {
+	id, err := Create()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Derive from the URI only (no private key material).
+	x25519Pub, err := DeriveX25519PublicKey(id.URI)
+	if err != nil {
+		t.Fatalf("DeriveX25519PublicKey: %v", err)
+	}
+
+	if !equal(x25519Pub, id.X25519PublicKey) {
+		t.Error("derived X25519 public key does not match identity's X25519 public key")
+	}
+}
+
+func TestDeriveX25519PublicKey_MatchesWireGuard(t *testing.T) {
+	// The X25519 public key derived from a did:jwk should be usable as a
+	// WireGuard public key: verify by deriving pub from priv and comparing.
+	id, err := Create()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	wgPub, err := curve25519.X25519(id.X25519PrivateKey, curve25519.Basepoint)
+	if err != nil {
+		t.Fatalf("curve25519.X25519: %v", err)
+	}
+
+	peerDerived, err := DeriveX25519PublicKey(id.URI)
+	if err != nil {
+		t.Fatalf("DeriveX25519PublicKey: %v", err)
+	}
+
+	if !equal(wgPub, peerDerived) {
+		t.Error("peer-derived X25519 pubkey does not match WireGuard pubkey from private key")
+	}
+}
+
+func TestDeriveX25519PublicKey_Errors(t *testing.T) {
+	tests := map[string]string{
+		"not a DID":     "not-a-did",
+		"wrong method":  "did:web:example.com",
+		"invalid base64": "did:jwk:!!!invalid!!!",
+		"not JSON":      "did:jwk:" + base64.RawURLEncoding.EncodeToString([]byte("nope")),
+		"wrong curve": func() string {
+			k := jwk.JWK{KTY: "EC", CRV: "P-256", X: "dGVzdA"}
+			b, _ := json.Marshal(k)
+			return "did:jwk:" + base64.RawURLEncoding.EncodeToString(b)
+		}(),
+	}
+
+	for name, uri := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := DeriveX25519PublicKey(uri)
+			if err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}
+
+// -----------------------------------------------------------------------
+// Round-trip: Create → Resolve → DeriveX25519 → verify
+// -----------------------------------------------------------------------
+
+func TestRoundTrip_Create_Resolve_Derive(t *testing.T) {
+	id, err := Create()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Resolve the created URI.
+	r := Resolver{}
+	result, err := r.Resolve(id.URI)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	doc := result.Document
+
+	// Document ID should match the URI.
+	if doc.ID != id.URI {
+		t.Errorf("document ID = %q, want %q", doc.ID, id.URI)
+	}
+
+	// The Ed25519 public key from the document should match.
+	vm0 := doc.VerificationMethod[0]
+	if vm0.PublicKeyJwk.CRV != "Ed25519" {
+		t.Fatalf("VM #0 CRV = %q, want Ed25519", vm0.PublicKeyJwk.CRV)
+	}
+	ed25519PubFromDoc, err := base64.RawURLEncoding.DecodeString(vm0.PublicKeyJwk.X)
+	if err != nil {
+		t.Fatalf("decoding ed25519 key from doc: %v", err)
+	}
+	if !equal(ed25519PubFromDoc, id.PublicKey) {
+		t.Error("ed25519 public key from doc does not match identity")
+	}
+
+	// The X25519 public key from the document should match.
+	vm1 := doc.VerificationMethod[1]
+	if vm1.PublicKeyJwk.CRV != "X25519" {
+		t.Fatalf("VM #1 CRV = %q, want X25519", vm1.PublicKeyJwk.CRV)
+	}
+	x25519PubFromDoc, err := base64.RawURLEncoding.DecodeString(vm1.PublicKeyJwk.X)
+	if err != nil {
+		t.Fatalf("decoding x25519 key from doc: %v", err)
+	}
+	if !equal(x25519PubFromDoc, id.X25519PublicKey) {
+		t.Error("x25519 public key from doc does not match identity")
+	}
+
+	// DeriveX25519PublicKey should also match.
+	derived, err := DeriveX25519PublicKey(id.URI)
+	if err != nil {
+		t.Fatalf("DeriveX25519PublicKey: %v", err)
+	}
+	if !equal(derived, id.X25519PublicKey) {
+		t.Error("DeriveX25519PublicKey result does not match identity")
+	}
+
+	// And it should match WireGuard derivation from private key.
+	wgPub, err := curve25519.X25519(id.X25519PrivateKey, curve25519.Basepoint)
+	if err != nil {
+		t.Fatalf("curve25519.X25519: %v", err)
+	}
+	if !equal(wgPub, derived) {
+		t.Error("WireGuard pubkey from private does not match peer-derived pubkey")
+	}
+}
+
+// -----------------------------------------------------------------------
+// X25519 key exchange test — proves the derived keys actually work
+// -----------------------------------------------------------------------
+
+func TestX25519KeyExchange(t *testing.T) {
+	// Create two identities and verify they can perform a Diffie-Hellman
+	// key exchange using their X25519 keys.
+	alice, err := Create()
+	if err != nil {
+		t.Fatalf("Create alice: %v", err)
+	}
+	bob, err := Create()
+	if err != nil {
+		t.Fatalf("Create bob: %v", err)
+	}
+
+	// Alice computes shared secret using her private key and Bob's public key.
+	sharedAlice, err := curve25519.X25519(alice.X25519PrivateKey, bob.X25519PublicKey)
+	if err != nil {
+		t.Fatalf("alice DH: %v", err)
+	}
+
+	// Bob computes shared secret using his private key and Alice's public key.
+	sharedBob, err := curve25519.X25519(bob.X25519PrivateKey, alice.X25519PublicKey)
+	if err != nil {
+		t.Fatalf("bob DH: %v", err)
+	}
+
+	if !equal(sharedAlice, sharedBob) {
+		t.Error("DH shared secrets do not match")
+	}
+
+	// Also test with peer-derived public keys (from URI only).
+	alicePubFromURI, err := DeriveX25519PublicKey(alice.URI)
+	if err != nil {
+		t.Fatalf("derive alice pub: %v", err)
+	}
+	bobPubFromURI, err := DeriveX25519PublicKey(bob.URI)
+	if err != nil {
+		t.Fatalf("derive bob pub: %v", err)
+	}
+
+	// Bob computes shared secret using alice's URI-derived public key.
+	sharedBob2, err := curve25519.X25519(bob.X25519PrivateKey, alicePubFromURI)
+	if err != nil {
+		t.Fatalf("bob DH with URI key: %v", err)
+	}
+	if !equal(sharedBob2, sharedAlice) {
+		t.Error("DH with URI-derived key does not match")
+	}
+
+	// Alice computes shared secret using bob's URI-derived public key.
+	sharedAlice2, err := curve25519.X25519(alice.X25519PrivateKey, bobPubFromURI)
+	if err != nil {
+		t.Fatalf("alice DH with URI key: %v", err)
+	}
+	if !equal(sharedAlice2, sharedBob) {
+		t.Error("DH with URI-derived key does not match (alice side)")
+	}
+}
+
+// equal is a helper to compare byte slices.
+func equal(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## Summary

Implements `did:jwk` identity creation and X25519 key derivation for meshd's new node identity model (#43). A single Ed25519 seed provides both DWN authentication (signing) and WireGuard tunneling (X25519 key agreement via the birational map).

## Changes

- **`Create()`** — generates Ed25519 keypair, constructs `did:jwk` URI, derives X25519 keys
- **`FromPrivateKey()`** — reconstructs identity from existing Ed25519 private key (for persistence)
- **`DeriveX25519PublicKey()`** — extracts WireGuard pubkey from any `did:jwk` URI (for peer key derivation)
- **Enhanced `Resolve()`** — for Ed25519 `did:jwk` URIs, the resolved document now includes an X25519 key agreement verification method at `#1`
- **`Identity` struct** — holds URI, Ed25519 key pair, and X25519 key pair

## Test coverage

- Create/FromPrivateKey round-trip
- DeriveX25519PublicKey matches identity's X25519 key
- Full round-trip: Create → Resolve → DeriveX25519 → verify WireGuard key
- X25519 Diffie-Hellman key exchange between two identities
- URI-derived public keys work for key exchange
- Ed25519 sign/verify round-trip
- Error cases for DeriveX25519PublicKey (wrong method, wrong curve, etc.)
- Existing Resolve tests updated for 2 VMs

## Verification

```
go build ./...       # ✓ zero errors
go vet ./...         # ✓ zero warnings
go test ./... -count=1 -race  # ✓ all pass, no races
```

Closes #44