### PR TITLE
refactor: derive WireGuard key from did:jwk identity

### DIFF
--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -334,10 +333,10 @@ func cmdNetworkCreate(ctx context.Context, args []string, flagProfile string) er
 		fmt.Printf("  Created admin member record (encrypted).\n")
 	}
 
-	// 5. Generate WireGuard keys and allocate mesh IP.
-	wgKeys, err := mesh.GenerateWireGuardKeyPair()
+	// 5. Derive WireGuard keys from identity and allocate mesh IP.
+	wgKeys, err := mesh.WireGuardKeyFromIdentity(identity.EncryptionPrivateKey)
 	if err != nil {
-		return fmt.Errorf("generating WireGuard keys: %w", err)
+		return fmt.Errorf("deriving WireGuard keys: %w", err)
 	}
 
 	meshIP, err := mesh.AllocateMeshIP(meshCIDR, identity.URI)
@@ -364,14 +363,12 @@ func cmdNetworkCreate(ctx context.Context, args []string, flagProfile string) er
 
 	// 7. Persist network state.
 	ns := &state.NetworkState{
-		NetworkRecordID:     record.ID,
-		AnchorDID:           identity.URI,
-		AnchorEndpoint:      endpoint,
-		NetworkName:         name,
-		MeshCIDR:            meshCIDR,
-		MeshIP:              meshIP.String(),
-		WireGuardPublicKey:  wgKeys.PublicKeyBase64(),
-		WireGuardPrivateKey: wgKeys.PrivateKeyBase64(),
+		NetworkRecordID: record.ID,
+		AnchorDID:       identity.URI,
+		AnchorEndpoint:  endpoint,
+		NetworkName:     name,
+		MeshCIDR:        meshCIDR,
+		MeshIP:          meshIP.String(),
 	}
 	if reg != nil {
 		ns.NodeInfoRecordID = reg.NodeInfoRecordID
@@ -465,10 +462,10 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 		networkData.MeshCIDR = "10.200.0.0/16"
 	}
 
-	// Generate WireGuard keys and allocate mesh IP.
-	wgKeys, err := mesh.GenerateWireGuardKeyPair()
+	// Derive WireGuard keys from identity and allocate mesh IP.
+	wgKeys, err := mesh.WireGuardKeyFromIdentity(identity.EncryptionPrivateKey)
 	if err != nil {
-		return fmt.Errorf("generating WireGuard keys: %w", err)
+		return fmt.Errorf("deriving WireGuard keys: %w", err)
 	}
 
 	meshIP, err := mesh.AllocateMeshIP(networkData.MeshCIDR, identity.URI)
@@ -530,8 +527,6 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 		NetworkName:         networkData.Name,
 		MeshCIDR:            networkData.MeshCIDR,
 		MeshIP:              meshIP.String(),
-		WireGuardPublicKey:  wgKeys.PublicKeyBase64(),
-		WireGuardPrivateKey: wgKeys.PrivateKeyBase64(),
 		NodeInfoRecordID:    nodeInfoRecordID,
 		NodeInfoDateCreated: nodeInfoDateCreated,
 	}
@@ -849,8 +844,12 @@ func cmdStatus(ctx context.Context, args []string, flagProfile string) error {
 	if ns.MeshIP != "" {
 		fmt.Printf("  Mesh IP: %s\n", ns.MeshIP)
 	}
-	if ns.WireGuardPublicKey != "" {
-		fmt.Printf("  WireGuard Key: %s\n", ns.WireGuardPublicKey)
+	// WireGuard public key is derived from the identity, not stored.
+	if identity != nil {
+		wgPubKey, wgErr := mesh.WireGuardPubKeyFromDID(identity.URI)
+		if wgErr == nil {
+			fmt.Printf("  WireGuard Key: %s\n", wgPubKey)
+		}
 	}
 	if ns.NodeInfoRecordID != "" {
 		fmt.Printf("  NodeInfo Record: %s\n", ns.NodeInfoRecordID)
@@ -1053,6 +1052,13 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 		}
 	}
 
+	// Derive WireGuard key pair from identity (no separate WG key generation).
+	wgKeys, err := mesh.WireGuardKeyFromIdentity(identity.EncryptionPrivateKey)
+	if err != nil {
+		return fmt.Errorf("deriving WireGuard keys from identity: %w", err)
+	}
+	wgPubKey := wgKeys.PublicKeyBase64()
+
 	fmt.Printf("Starting meshd...\n")
 	fmt.Printf("  Network: %s\n", ns.NetworkName)
 	fmt.Printf("  DID: %s\n", identity.URI)
@@ -1072,7 +1078,7 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 			SelfDID:                 identity.URI,
 			Signer:                  signer,
 			EncryptionKeyManager:    encMgr,
-			WireGuardPubKey:         ns.WireGuardPublicKey,
+			WireGuardPubKey:         wgPubKey,
 			MeshIP:                  ns.MeshIP,
 			ProtocolRole:            "network/member",
 			UseContextEncryption:    true,
@@ -1138,19 +1144,6 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 		}
 	}
 
-	// Decode the WireGuard private key so the engine uses the same identity
-	// that was published to DWN records.
-	var wgPrivKey [32]byte
-	if ns.WireGuardPrivateKey != "" {
-		wgBytes, decErr := base64.StdEncoding.DecodeString(ns.WireGuardPrivateKey)
-		if decErr != nil {
-			return fmt.Errorf("decoding WireGuard private key: %w", decErr)
-		}
-		if len(wgBytes) == 32 {
-			copy(wgPrivKey[:], wgBytes)
-		}
-	}
-
 	eng, err := engine.New(engine.Config{
 		AnchorEndpoint:       ns.AnchorEndpoint,
 		AnchorTenant:         ns.AnchorDID,
@@ -1162,7 +1155,7 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 		NodeInfoRecordID:     ns.NodeInfoRecordID,
 		AutoKeyDelivery:      autoKeyDelivery,
 		UseContextEncryption: useContextEncryption,
-		WireGuardPrivateKey:  wgPrivKey,
+		WireGuardPrivateKey:  wgKeys.PrivateKey,
 		TUNName:             f.tunName,
 		Domain:               ns.NetworkName,
 		ListenPort:           f.listenPort,

--- a/internal/engine/connectivity_test.go
+++ b/internal/engine/connectivity_test.go
@@ -161,9 +161,9 @@ func TestTwoNodeConnectivity(t *testing.T) {
 		t.Fatalf("admin member: %d %s", memberStatus.Code, memberStatus.Detail)
 	}
 
-	wgKeysA, err := mesh.GenerateWireGuardKeyPair()
+	wgKeysA, err := mesh.WireGuardKeyFromIdentity(nodeA.identity.EncryptionPrivateKey)
 	if err != nil {
-		t.Fatalf("generating WG keys for A: %v", err)
+		t.Fatalf("deriving WG keys for A: %v", err)
 	}
 	meshIPA, err := mesh.AllocateMeshIP(meshCIDR, nodeA.identity.URI)
 	if err != nil {
@@ -222,9 +222,9 @@ func TestTwoNodeConnectivity(t *testing.T) {
 	}
 	t.Log("  Node B member record created by Node A")
 
-	wgKeysB, err := mesh.GenerateWireGuardKeyPair()
+	wgKeysB, err := mesh.WireGuardKeyFromIdentity(nodeB.identity.EncryptionPrivateKey)
 	if err != nil {
-		t.Fatalf("generating WG keys for B: %v", err)
+		t.Fatalf("deriving WG keys for B: %v", err)
 	}
 	meshIPB, err := mesh.AllocateMeshIP(meshCIDR, nodeB.identity.URI)
 	if err != nil {
@@ -760,7 +760,7 @@ func TestTwoNodeNetworkMapDiscovery(t *testing.T) {
 	}
 
 	// Register both nodes (initial registration uses Protocol Path encryption).
-	wgA, _ := mesh.GenerateWireGuardKeyPair()
+	wgA, _ := mesh.WireGuardKeyFromIdentity(nodeA.identity.EncryptionPrivateKey)
 	ipA, _ := mesh.AllocateMeshIP(meshCIDR, nodeA.identity.URI)
 	regADisc, _ := mesh.RegisterNode(ctx, mesh.RegisterNodeParams{
 		AnchorEndpoint: endpoint, AnchorDID: nodeA.identity.URI,
@@ -770,7 +770,7 @@ func TestTwoNodeNetworkMapDiscovery(t *testing.T) {
 		Hostname: "disc-a",
 	})
 
-	wgB, _ := mesh.GenerateWireGuardKeyPair()
+	wgB, _ := mesh.WireGuardKeyFromIdentity(nodeB.identity.EncryptionPrivateKey)
 	ipB, _ := mesh.AllocateMeshIP(meshCIDR, nodeB.identity.URI)
 	regBDisc, _ := mesh.RegisterNode(ctx, mesh.RegisterNodeParams{
 		AnchorEndpoint: endpoint, AnchorDID: nodeA.identity.URI,

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -117,10 +117,9 @@ type Config struct {
 	// have the context key stored (via StoreContextKey) for NetworkRecordID.
 	UseContextEncryption bool
 
-	// WireGuardPrivateKey is the raw 32-byte Curve25519 private key that was
-	// published to DWN records. If set, the engine will use this key instead
-	// of generating a new one, ensuring the engine's WireGuard identity
-	// matches what peers see in DWN records.
+	// WireGuardPrivateKey is the raw 32-byte X25519 private key derived from
+	// the node's did:jwk identity. The engine uses this key for WireGuard,
+	// so peers can derive the matching public key from the node's DID.
 	WireGuardPrivateKey [32]byte
 
 	// DiscoKeyRegistry enables disco key exchange between engines. In normal

--- a/internal/mesh/e2e_test.go
+++ b/internal/mesh/e2e_test.go
@@ -189,11 +189,11 @@ func TestE2ENetworkCreateJoinQueryDecrypt(t *testing.T) {
 		t.Logf("  Admin member created: %d %s", memberStatus.Code, memberStatus.Detail)
 	}
 
-	// ---- Step 5: Node A generates WireGuard keys and registers nodeInfo (encrypted) ----
-	t.Log("Step 5: Node A generates WG keys and registers nodeInfo")
-	wgKeysA, err := mesh.GenerateWireGuardKeyPair()
+	// ---- Step 5: Node A derives WireGuard keys and registers nodeInfo (encrypted) ----
+	t.Log("Step 5: Node A derives WG keys from identity and registers nodeInfo")
+	wgKeysA, err := mesh.WireGuardKeyFromIdentity(nodeA.DID.EncryptionPrivateKey)
 	if err != nil {
-		t.Fatalf("generating WG keys for node A: %v", err)
+		t.Fatalf("deriving WG keys for node A: %v", err)
 	}
 	meshIPA, err := mesh.AllocateMeshIP(meshCIDR, nodeA.DID.URI)
 	if err != nil {
@@ -285,9 +285,9 @@ func TestE2ENetworkCreateJoinQueryDecrypt(t *testing.T) {
 	// Node B registers its nodeInfo (encrypted) using its own member role.
 	// Note: Node B can write its own nodeInfo because the protocol allows
 	// "role": "network/member" to ["create", "update", "read"] on nodeInfo.
-	wgKeysB, err := mesh.GenerateWireGuardKeyPair()
+	wgKeysB, err := mesh.WireGuardKeyFromIdentity(nodeB.DID.EncryptionPrivateKey)
 	if err != nil {
-		t.Fatalf("generating WG keys for node B: %v", err)
+		t.Fatalf("deriving WG keys for node B: %v", err)
 	}
 	meshIPB, err := mesh.AllocateMeshIP(meshCIDR, nodeB.DID.URI)
 	if err != nil {

--- a/internal/mesh/keys.go
+++ b/internal/mesh/keys.go
@@ -3,12 +3,12 @@
 package mesh
 
 import (
-	"crypto/rand"
 	"encoding/base64"
 	"fmt"
-	"io"
 
 	"golang.org/x/crypto/curve25519"
+
+	"github.com/enboxorg/meshd/pkg/dids/didjwk"
 )
 
 // WireGuardKeySize is the size of a WireGuard key in bytes (Curve25519 = 32).
@@ -20,49 +20,36 @@ type WireGuardKeyPair struct {
 	PublicKey  [WireGuardKeySize]byte
 }
 
-// GenerateWireGuardKeyPair generates a new random WireGuard Curve25519 key pair.
+// WireGuardKeyFromIdentity creates a WireGuard key pair from the node's
+// X25519 private key (already derived from Ed25519 by the identity layer).
 //
-// The private key is clamped per Curve25519 convention:
-//   - Bits 0-2 cleared (divisible by 8)
-//   - Bit 255 cleared
-//   - Bit 254 set
-func GenerateWireGuardKeyPair() (*WireGuardKeyPair, error) {
-	var priv [WireGuardKeySize]byte
-	if _, err := io.ReadFull(rand.Reader, priv[:]); err != nil {
-		return nil, fmt.Errorf("generating WireGuard private key: %w", err)
+// This is the primary way to get WireGuard keys — no random generation.
+// The X25519 private key comes from did.DID.EncryptionPrivateKey.
+func WireGuardKeyFromIdentity(x25519PrivateKey []byte) (*WireGuardKeyPair, error) {
+	if len(x25519PrivateKey) != WireGuardKeySize {
+		return nil, fmt.Errorf("X25519 private key must be %d bytes, got %d", WireGuardKeySize, len(x25519PrivateKey))
 	}
 
-	// Clamp per Curve25519 / WireGuard spec.
-	priv[0] &= 248
-	priv[31] &= 127
-	priv[31] |= 64
-
-	pub, err := curve25519.X25519(priv[:], curve25519.Basepoint)
+	pub, err := curve25519.X25519(x25519PrivateKey, curve25519.Basepoint)
 	if err != nil {
 		return nil, fmt.Errorf("deriving WireGuard public key: %w", err)
 	}
 
 	kp := &WireGuardKeyPair{}
-	copy(kp.PrivateKey[:], priv[:])
+	copy(kp.PrivateKey[:], x25519PrivateKey)
 	copy(kp.PublicKey[:], pub)
 	return kp, nil
 }
 
-// WireGuardKeyPairFromPrivate reconstructs a key pair from a private key.
-func WireGuardKeyPairFromPrivate(priv []byte) (*WireGuardKeyPair, error) {
-	if len(priv) != WireGuardKeySize {
-		return nil, fmt.Errorf("WireGuard private key must be %d bytes, got %d", WireGuardKeySize, len(priv))
-	}
-
-	pub, err := curve25519.X25519(priv, curve25519.Basepoint)
+// WireGuardPubKeyFromDID derives a WireGuard public key from a did:jwk URI.
+// This is how peers compute each other's WireGuard public keys without
+// needing a record field — the key is derivable from the DID itself.
+func WireGuardPubKeyFromDID(didJWKURI string) (string, error) {
+	x25519Pub, err := didjwk.DeriveX25519PublicKey(didJWKURI)
 	if err != nil {
-		return nil, fmt.Errorf("deriving WireGuard public key: %w", err)
+		return "", fmt.Errorf("deriving X25519 public key from DID: %w", err)
 	}
-
-	kp := &WireGuardKeyPair{}
-	copy(kp.PrivateKey[:], priv)
-	copy(kp.PublicKey[:], pub)
-	return kp, nil
+	return base64.StdEncoding.EncodeToString(x25519Pub), nil
 }
 
 // PublicKeyBase64 returns the public key as standard base64 (WireGuard convention).

--- a/internal/mesh/mesh_test.go
+++ b/internal/mesh/mesh_test.go
@@ -5,16 +5,23 @@ import (
 	"net/netip"
 	"strings"
 	"testing"
+
+	"github.com/enboxorg/meshd/pkg/dids/didjwk"
 )
 
 // =============================================================================
 // WireGuard key tests
 // =============================================================================
 
-func TestGenerateWireGuardKeyPair(t *testing.T) {
-	kp, err := GenerateWireGuardKeyPair()
+func TestWireGuardKeyFromIdentity(t *testing.T) {
+	id, err := didjwk.Create()
 	if err != nil {
-		t.Fatalf("GenerateWireGuardKeyPair: %v", err)
+		t.Fatalf("Create: %v", err)
+	}
+
+	kp, err := WireGuardKeyFromIdentity(id.X25519PrivateKey)
+	if err != nil {
+		t.Fatalf("WireGuardKeyFromIdentity: %v", err)
 	}
 
 	// Verify key sizes.
@@ -25,7 +32,7 @@ func TestGenerateWireGuardKeyPair(t *testing.T) {
 		t.Fatalf("public key size = %d, want %d", len(kp.PublicKey), WireGuardKeySize)
 	}
 
-	// Verify clamping.
+	// X25519 keys from identity are already clamped.
 	if kp.PrivateKey[0]&7 != 0 {
 		t.Fatal("private key bits 0-2 not cleared")
 	}
@@ -36,39 +43,51 @@ func TestGenerateWireGuardKeyPair(t *testing.T) {
 		t.Fatal("private key bit 254 not set")
 	}
 
-	// Public key should not be all zeros.
-	allZero := true
-	for _, b := range kp.PublicKey {
-		if b != 0 {
-			allZero = false
-			break
-		}
-	}
-	if allZero {
-		t.Fatal("public key is all zeros")
+	// Public key should match the identity's X25519 public key.
+	if string(kp.PublicKey[:]) != string(id.X25519PublicKey) {
+		t.Fatal("public key does not match identity's X25519 public key")
 	}
 }
 
-func TestWireGuardKeyPairFromPrivate(t *testing.T) {
-	original, err := GenerateWireGuardKeyPair()
+func TestWireGuardKeyFromIdentity_InvalidLength(t *testing.T) {
+	_, err := WireGuardKeyFromIdentity([]byte("too short"))
+	if err == nil {
+		t.Fatal("expected error for invalid key length")
+	}
+}
+
+func TestWireGuardPubKeyFromDID(t *testing.T) {
+	id, err := didjwk.Create()
 	if err != nil {
-		t.Fatalf("generating: %v", err)
+		t.Fatalf("Create: %v", err)
 	}
 
-	restored, err := WireGuardKeyPairFromPrivate(original.PrivateKey[:])
+	kp, err := WireGuardKeyFromIdentity(id.X25519PrivateKey)
 	if err != nil {
-		t.Fatalf("WireGuardKeyPairFromPrivate: %v", err)
+		t.Fatalf("WireGuardKeyFromIdentity: %v", err)
 	}
 
-	if original.PublicKey != restored.PublicKey {
-		t.Fatal("public keys don't match")
+	// Peer derives public key from the DID URI only.
+	peerDerived, err := WireGuardPubKeyFromDID(id.URI)
+	if err != nil {
+		t.Fatalf("WireGuardPubKeyFromDID: %v", err)
+	}
+
+	// Should match the key pair's public key.
+	if peerDerived != kp.PublicKeyBase64() {
+		t.Fatalf("peer-derived pubkey %q != identity pubkey %q", peerDerived, kp.PublicKeyBase64())
 	}
 }
 
 func TestWireGuardKeyPairBase64(t *testing.T) {
-	kp, err := GenerateWireGuardKeyPair()
+	id, err := didjwk.Create()
 	if err != nil {
-		t.Fatalf("generating: %v", err)
+		t.Fatalf("Create: %v", err)
+	}
+
+	kp, err := WireGuardKeyFromIdentity(id.X25519PrivateKey)
+	if err != nil {
+		t.Fatalf("WireGuardKeyFromIdentity: %v", err)
 	}
 
 	pubB64 := kp.PublicKeyBase64()
@@ -90,12 +109,29 @@ func TestWireGuardKeyPairBase64(t *testing.T) {
 	}
 }
 
-func TestGenerateWireGuardKeyPair_Unique(t *testing.T) {
-	kp1, _ := GenerateWireGuardKeyPair()
-	kp2, _ := GenerateWireGuardKeyPair()
+func TestWireGuardKeyFromIdentity_Deterministic(t *testing.T) {
+	id, err := didjwk.Create()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	kp1, _ := WireGuardKeyFromIdentity(id.X25519PrivateKey)
+	kp2, _ := WireGuardKeyFromIdentity(id.X25519PrivateKey)
+
+	if kp1.PublicKey != kp2.PublicKey {
+		t.Fatal("same identity should produce same WG key pair")
+	}
+}
+
+func TestWireGuardKeyFromIdentity_DifferentIdentities(t *testing.T) {
+	id1, _ := didjwk.Create()
+	id2, _ := didjwk.Create()
+
+	kp1, _ := WireGuardKeyFromIdentity(id1.X25519PrivateKey)
+	kp2, _ := WireGuardKeyFromIdentity(id2.X25519PrivateKey)
 
 	if kp1.PublicKey == kp2.PublicKey {
-		t.Fatal("two generated key pairs should differ")
+		t.Fatal("different identities should produce different WG keys")
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -63,13 +63,6 @@ type NetworkState struct {
 	// MeshIP is this node's allocated IP within the mesh.
 	MeshIP string `json:"meshIp,omitempty"`
 
-	// WireGuardPublicKey is this node's WG public key (base64).
-	WireGuardPublicKey string `json:"wireguardPublicKey,omitempty"`
-
-	// WireGuardPrivateKey is this node's WG private key (base64).
-	// Stored locally only — never sent over the network.
-	WireGuardPrivateKey string `json:"wireguardPrivateKey,omitempty"`
-
 	// NodeInfoRecordID is the record ID of this node's nodeInfo record.
 	NodeInfoRecordID string `json:"nodeInfoRecordId,omitempty"`
 


### PR DESCRIPTION
## Summary

Derives WireGuard keys deterministically from the node's `did:jwk` (Ed25519) identity instead of generating and storing them separately. Closes #46.

- **`internal/mesh/keys.go`**: Replaced `GenerateWireGuardKeyPair()` with `WireGuardKeyFromIdentity()` (derives X25519 private key from Ed25519 seed) and `WireGuardPubKeyFromDID()` (derives X25519 public key from a `did:jwk` URI). Uses the birational Ed25519→X25519 map.
- **`internal/state/state.go`**: Removed `WireGuardPublicKey` and `WireGuardPrivateKey` fields from `NetworkState` — these are now derived on the fly from the identity.
- **`cmd/meshd/main.go`**: Updated `meshd up` to derive WireGuard keys from identity instead of generating/loading them. Removed `encoding/base64` import.
- **`internal/engine/engine.go`**: Updated `Config.WireGuardPrivateKey` comment to reflect derivation from identity.
- **Tests**: Rewritten to verify deterministic derivation, round-trip consistency, and cross-validation with `didjwk.DeriveX25519PublicKey()`.
- **Integration tests**: Removed `.Publish()` calls and switched to `WireGuardKeyFromIdentity()`.

### Build, vet, tests

All pass:
```
go build ./...     # zero errors
go vet ./...       # zero warnings
go test ./... -count=1 -race  # all pass, no data races
```