### PR TITLE
refactor: update control layer for node-based protocol

### DIFF
--- a/internal/control/control_test.go
+++ b/internal/control/control_test.go
@@ -9,13 +9,26 @@ import (
 	"time"
 
 	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
+	"github.com/enboxorg/meshd/pkg/dids/didjwk"
 )
+
+// testDIDJWK creates a real did:jwk URI for testing.
+// Returns the URI and the expected base64-encoded WireGuard public key.
+func testDIDJWK(t *testing.T) (string, string) {
+	t.Helper()
+	id, err := didjwk.Create()
+	if err != nil {
+		t.Fatalf("creating did:jwk: %v", err)
+	}
+	wgKey := base64.StdEncoding.EncodeToString(id.X25519PublicKey)
+	return id.URI, wgKey
+}
 
 func TestBuildStaticMapResponse(t *testing.T) {
 	self := &Node{
 		ID:     1,
 		Name:   "laptop",
-		DID:    "did:dht:self123",
+		DID:    "did:jwk:test-self",
 		Key:    "AAAA==",
 		MeshIP: netip.MustParseAddr("10.200.0.2"),
 		AllowedIPs: []netip.Prefix{
@@ -28,7 +41,7 @@ func TestBuildStaticMapResponse(t *testing.T) {
 	peer := &Node{
 		ID:     2,
 		Name:   "server",
-		DID:    "did:dht:peer456",
+		DID:    "did:jwk:test-peer",
 		Key:    "BBBB==",
 		MeshIP: netip.MustParseAddr("10.200.0.3"),
 		AllowedIPs: []netip.Prefix{
@@ -84,17 +97,19 @@ func TestBuildStaticMapResponse(t *testing.T) {
 	})
 }
 
-func TestNodeInfoToNode(t *testing.T) {
+func TestNodeRecordToNode(t *testing.T) {
 	now := time.Now().UTC()
 	recentUpdate := now.Add(-2 * time.Minute).Format(time.RFC3339)
 
-	info := &NodeInfoData{
-		WireGuardPublicKey: "testkey==",
-		MeshIP:             "10.200.0.5",
-		Hostname:           "myhost",
-		OS:                 "linux",
-		Capabilities:       []string{"relay"},
-		AllowedIPs:         []string{"192.168.1.0/24"},
+	didURI, wantKey := testDIDJWK(t)
+
+	rec := &NodeRecord{
+		MeshIP:       "10.200.0.5",
+		Hostname:     "myhost",
+		OS:           "linux",
+		Capabilities: []string{"relay"},
+		AllowedIPs:   []string{"192.168.1.0/24"},
+		AddedAt:      "2026-01-01T00:00:00Z",
 		Endpoints: []EndpointData{
 			{
 				PublicEndpoints: []PublicEndpoint{
@@ -107,15 +122,15 @@ func TestNodeInfoToNode(t *testing.T) {
 		},
 	}
 
-	node := nodeInfoToNodeWithThreshold(42, "did:dht:test", info, DefaultPeerStaleThreshold, now)
+	node := nodeRecordToNodeWithThreshold(42, didURI, rec, DefaultPeerStaleThreshold, now)
 
 	tests := map[string]struct {
 		got  any
 		want any
 	}{
 		"ID":            {got: node.ID, want: int64(42)},
-		"DID":           {got: node.DID, want: "did:dht:test"},
-		"Key":           {got: node.Key, want: "testkey=="},
+		"DID":           {got: node.DID, want: didURI},
+		"Key":           {got: node.Key, want: wantKey},
 		"MeshIP":        {got: node.MeshIP, want: netip.MustParseAddr("10.200.0.5")},
 		"Name":          {got: node.Name, want: "myhost"},
 		"PreferredDERP": {got: node.PreferredDERP, want: 2},
@@ -156,11 +171,22 @@ func TestNodeInfoToNode(t *testing.T) {
 			t.Errorf("[1] = %q", node.Endpoints[1])
 		}
 	})
+
+	t.Run("non-jwk DID yields empty key", func(t *testing.T) {
+		// nodeRecordToNode should not panic on a non-jwk DID.
+		rec2 := &NodeRecord{MeshIP: "10.200.0.6", Hostname: "other"}
+		node2 := nodeRecordToNodeWithThreshold(99, "did:web:example.com", rec2, DefaultPeerStaleThreshold, now)
+		if node2.Key != "" {
+			t.Errorf("expected empty Key for non-jwk DID, got %q", node2.Key)
+		}
+	})
 }
 
 func TestNodeOnlineStatus(t *testing.T) {
 	now := time.Date(2026, 2, 25, 12, 0, 0, 0, time.UTC)
 	threshold := 5 * time.Minute
+
+	didURI, _ := testDIDJWK(t)
 
 	tests := []struct {
 		name       string
@@ -256,14 +282,13 @@ func TestNodeOnlineStatus(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			info := &NodeInfoData{
-				WireGuardPublicKey: "testkey==",
-				MeshIP:             "10.200.0.5",
-				Hostname:           "peer",
-				Endpoints:          tc.endpoints,
+			rec := &NodeRecord{
+				MeshIP:    "10.200.0.5",
+				Hostname:  "peer",
+				Endpoints: tc.endpoints,
 			}
 
-			node := nodeInfoToNodeWithThreshold(1, "did:dht:test", info, threshold, now)
+			node := nodeRecordToNodeWithThreshold(1, didURI, rec, threshold, now)
 
 			if node.Online != tc.wantOnline {
 				t.Errorf("Online = %v, want %v", node.Online, tc.wantOnline)
@@ -360,7 +385,7 @@ func TestDefaultFilterRules(t *testing.T) {
 }
 
 func TestExtractEntryMetadata(t *testing.T) {
-	t.Run("wrapped format with tags and recipient", func(t *testing.T) {
+	t.Run("wrapped format with recipient", func(t *testing.T) {
 		entry := json.RawMessage(`{
 			"recordsWrite": {
 				"recordId": "bafyreiabc123",
@@ -368,13 +393,8 @@ func TestExtractEntryMetadata(t *testing.T) {
 					"interface": "Records",
 					"method": "Write",
 					"protocol": "https://enbox.org/protocols/wireguard-mesh",
-					"protocolPath": "network/nodeInfo",
-					"recipient": "did:dht:anchor123",
-					"tags": {
-						"did": "did:dht:node456",
-						"hostname": "myhost",
-						"os": "linux"
-					}
+					"protocolPath": "network/node",
+					"recipient": "did:jwk:node456"
 				},
 				"encodedData": "dGVzdA"
 			}
@@ -385,11 +405,8 @@ func TestExtractEntryMetadata(t *testing.T) {
 		if meta.RecordID != "bafyreiabc123" {
 			t.Errorf("RecordID = %q, want %q", meta.RecordID, "bafyreiabc123")
 		}
-		if meta.Recipient != "did:dht:anchor123" {
-			t.Errorf("Recipient = %q, want %q", meta.Recipient, "did:dht:anchor123")
-		}
-		if did, ok := meta.Tags["did"].(string); !ok || did != "did:dht:node456" {
-			t.Errorf("Tags[did] = %v, want %q", meta.Tags["did"], "did:dht:node456")
+		if meta.Recipient != "did:jwk:node456" {
+			t.Errorf("Recipient = %q, want %q", meta.Recipient, "did:jwk:node456")
 		}
 	})
 
@@ -397,8 +414,7 @@ func TestExtractEntryMetadata(t *testing.T) {
 		entry := json.RawMessage(`{
 			"recordId": "bafyreiflat",
 			"descriptor": {
-				"recipient": "did:dht:member789",
-				"tags": {"did": "did:dht:member789"}
+				"recipient": "did:jwk:node789"
 			}
 		}`)
 
@@ -407,8 +423,8 @@ func TestExtractEntryMetadata(t *testing.T) {
 		if meta.RecordID != "bafyreiflat" {
 			t.Errorf("RecordID = %q, want %q", meta.RecordID, "bafyreiflat")
 		}
-		if meta.Recipient != "did:dht:member789" {
-			t.Errorf("Recipient = %q, want %q", meta.Recipient, "did:dht:member789")
+		if meta.Recipient != "did:jwk:node789" {
+			t.Errorf("Recipient = %q, want %q", meta.Recipient, "did:jwk:node789")
 		}
 	})
 
@@ -517,7 +533,7 @@ func TestParseEntryData(t *testing.T) {
 			ProtocolURI:    "https://example.com/proto",
 		}
 
-		recipients, err := mgr.DeriveWriteEncryption("network/member")
+		recipients, err := mgr.DeriveWriteEncryption("network/node")
 		if err != nil {
 			t.Fatalf("deriving encryption: %v", err)
 		}
@@ -536,7 +552,7 @@ func TestParseEntryData(t *testing.T) {
 
 		// Decrypt using the key manager.
 		decryptor := func(ct []byte, e *dwncrypto.Encryption) ([]byte, error) {
-			privKey, err := mgr.DeriveDecryptionKey("network/member")
+			privKey, err := mgr.DeriveDecryptionKey("network/node")
 			if err != nil {
 				return nil, err
 			}

--- a/internal/control/data.go
+++ b/internal/control/data.go
@@ -10,27 +10,20 @@ type NetworkConfig struct {
 	ListenPort     int      `json:"listenPort,omitempty"`
 }
 
-// MemberInfo is the parsed member record data with metadata.
-type MemberInfo struct {
-	DID      string `json:"-"`
-	JoinedAt string `json:"joinedAt"`
-	Label    string `json:"label,omitempty"`
-	Status   string `json:"-"`
-	RecordID string `json:"-"`
-}
-
-// NodeInfoData is the parsed nodeInfo record data.
-type NodeInfoData struct {
-	DID                string         `json:"-"`
-	WireGuardPublicKey string         `json:"wireguardPublicKey"`
-	MeshIP             string         `json:"meshIP"`
-	Hostname           string         `json:"hostname,omitempty"`
-	OS                 string         `json:"os,omitempty"`
-	DiscoKey           string         `json:"discoKey,omitempty"`
-	Capabilities       []string       `json:"capabilities,omitempty"`
-	AllowedIPs         []string       `json:"allowedIPs,omitempty"`
-	Endpoints          []EndpointData `json:"-"`
-	RecordID           string         `json:"-"`
+// NodeRecord is the parsed node record data (merged member + nodeInfo).
+// The WireGuard public key is NOT stored here — it is derived from
+// the DID (did:jwk → X25519 birational map) at conversion time.
+type NodeRecord struct {
+	DID          string         `json:"-"`                     // did:jwk from the recipient descriptor field
+	MeshIP       string         `json:"meshIP"`
+	Hostname     string         `json:"hostname,omitempty"`
+	OS           string         `json:"os,omitempty"`
+	Capabilities []string       `json:"capabilities,omitempty"`
+	AllowedIPs   []string       `json:"allowedIPs,omitempty"`
+	AddedAt      string         `json:"addedAt"`
+	Label        string         `json:"label,omitempty"`
+	Endpoints    []EndpointData `json:"-"`
+	RecordID     string         `json:"-"`
 }
 
 // EndpointData is the parsed endpoint record data.

--- a/internal/control/dwnclient.go
+++ b/internal/control/dwnclient.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/enboxorg/meshd/internal/dwn"
 	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
+	"github.com/enboxorg/meshd/pkg/dids/didjwk"
 )
 
 // DefaultPeerStaleThreshold is the duration after which a peer is considered
@@ -90,10 +91,9 @@ type DWNClient struct {
 	resolver        Resolver
 	encManager      *dwncrypto.EncryptionKeyManager
 
-	mu      sync.RWMutex
+	mu     sync.RWMutex
 	network *NetworkConfig
-	members map[string]*MemberInfo
-	nodes   map[string]*NodeInfoData
+	nodes   map[string]*NodeRecord
 	relays  []*RelayData
 	acl     *ACLPolicyData
 
@@ -127,8 +127,7 @@ func NewDWNClient(
 		onUpdate:        options.onUpdate,
 		resolver:        options.resolver,
 		encManager:      options.encManager,
-		members:         make(map[string]*MemberInfo),
-		nodes:           make(map[string]*NodeInfoData),
+		nodes:           make(map[string]*NodeRecord),
 		peerEndpoints:   make(map[string]*PeerEndpointInfo),
 	}
 }
@@ -143,7 +142,7 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 
 	netResp, err := c.anchorDWN.RecordsRead(ctx, c.anchorTenant, dwn.RecordsFilter{
 		RecordID: c.networkRecordID,
-	}, "network/member")
+	}, "network/node")
 	if err != nil {
 		return nil, fmt.Errorf("reading network: %w", err)
 	}
@@ -166,61 +165,14 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 	c.network = &network
 	c.mu.Unlock()
 
-	// 2. Query members.
-	c.logger.DebugContext(ctx, "querying members")
+	// 2. Query node records (replaces separate member + nodeInfo queries).
+	c.logger.DebugContext(ctx, "querying nodes")
 
-	membersResp, err := c.anchorDWN.RecordsQuery(ctx, c.anchorTenant, dwn.RecordsFilter{
-		Protocol:     ProtocolMesh,
-		ProtocolPath: "network/member",
-		ContextID:    c.networkRecordID,
-	}, "createdAscending", nil, "network/member")
-	if err != nil {
-		return nil, fmt.Errorf("querying members: %w", err)
-	}
-
-	entries, err := dwn.QueryResult(membersResp)
-	if err != nil {
-		return nil, fmt.Errorf("parsing members: %w", err)
-	}
-
-	memberDecryptor := c.makeDecryptor("network/member")
-	c.mu.Lock()
-	for _, entry := range entries {
-		// Extract DID from descriptor metadata (not encrypted).
-		meta := extractEntryMetadata(entry)
-		memberDID := meta.Recipient // member records use recipient as the member DID
-
-		var member MemberInfo
-		if err := parseEntryData(entry, &member, memberDecryptor); err != nil {
-			c.logger.DebugContext(ctx, "parsing member entry",
-				slog.Any("error", err),
-				slog.String("memberDID", memberDID),
-			)
-			// Even if we can't decrypt the data, we can still track the member
-			// by DID from the unencrypted descriptor fields.
-			if memberDID != "" {
-				member.DID = memberDID
-				member.RecordID = meta.RecordID
-				c.members[memberDID] = &member
-			}
-			continue
-		}
-		member.DID = memberDID
-		member.RecordID = meta.RecordID
-		if memberDID != "" {
-			c.members[memberDID] = &member
-		}
-	}
-	c.mu.Unlock()
-
-	c.logger.DebugContext(ctx, "loaded members", slog.Int("count", len(entries)))
-
-	// 3. Query nodeInfo records.
 	nodesResp, err := c.anchorDWN.RecordsQuery(ctx, c.anchorTenant, dwn.RecordsFilter{
 		Protocol:     ProtocolMesh,
-		ProtocolPath: "network/nodeInfo",
+		ProtocolPath: "network/node",
 		ContextID:    c.networkRecordID,
-	}, "createdAscending", nil, "network/member")
+	}, "createdAscending", nil, "network/node")
 	if err != nil {
 		return nil, fmt.Errorf("querying nodes: %w", err)
 	}
@@ -230,25 +182,22 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 		return nil, fmt.Errorf("parsing nodes: %w", err)
 	}
 
-	nodeDecryptor := c.makeDecryptor("network/nodeInfo")
+	nodeDecryptor := c.makeDecryptor("network/node")
 	c.mu.Lock()
 	for _, entry := range nodeEntries {
-		// Extract DID from descriptor tags (not encrypted).
+		// DID comes from the recipient descriptor field (not tags — tags removed).
 		meta := extractEntryMetadata(entry)
-		nodeDID := ""
-		if did, ok := meta.Tags["did"].(string); ok {
-			nodeDID = did
-		}
+		nodeDID := meta.Recipient
 
-		var node NodeInfoData
+		var node NodeRecord
 		if err := parseEntryData(entry, &node, nodeDecryptor); err != nil {
 			c.logger.DebugContext(ctx, "parsing node entry",
 				slog.Any("error", err),
 				slog.String("nodeDID", nodeDID),
 			)
 			// Even if we can't decrypt the data payload, track the node DID
-			// from the unencrypted tags. This allows peer discovery and auto
-			// key delivery to work even before context key exchange completes.
+			// from the unencrypted recipient field. This allows peer discovery
+			// and auto key delivery to work even before context key exchange.
 			if nodeDID != "" {
 				node.DID = nodeDID
 				node.RecordID = meta.RecordID
@@ -266,12 +215,12 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 
 	c.logger.DebugContext(ctx, "loaded nodes", slog.Int("count", len(nodeEntries)))
 
-	// 4. Query relay records.
+	// 3. Query relay records.
 	relayResp, err := c.anchorDWN.RecordsQuery(ctx, c.anchorTenant, dwn.RecordsFilter{
 		Protocol:     ProtocolMesh,
 		ProtocolPath: "network/relay",
 		ContextID:    c.networkRecordID,
-	}, "createdAscending", nil, "network/member")
+	}, "createdAscending", nil, "network/node")
 	if err != nil {
 		return nil, fmt.Errorf("querying relays: %w", err)
 	}
@@ -293,15 +242,15 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 	}
 	c.mu.Unlock()
 
-	// 5. Query endpoint records for each node.
-	// Endpoint records are children of nodeInfo records. We query all
+	// 4. Query endpoint records for each node.
+	// Endpoint records are children of node records. We query all
 	// endpoint records in the network context and attach them to their
-	// parent nodeInfo via the parentId descriptor field.
+	// parent node via the parentId descriptor field.
 	endpointResp, err := c.anchorDWN.RecordsQuery(ctx, c.anchorTenant, dwn.RecordsFilter{
 		Protocol:     ProtocolMesh,
-		ProtocolPath: "network/nodeInfo/endpoint",
+		ProtocolPath: "network/node/endpoint",
 		ContextID:    c.networkRecordID,
-	}, "createdDescending", nil, "network/member")
+	}, "createdDescending", nil, "network/node")
 	if err != nil {
 		// Non-fatal: endpoints are optional. Log and continue.
 		c.logger.DebugContext(ctx, "querying endpoints failed", slog.Any("error", err))
@@ -310,7 +259,7 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 		if err != nil {
 			c.logger.DebugContext(ctx, "parsing endpoint results", slog.Any("error", err))
 		} else {
-			endpointDecryptor := c.makeDecryptor("network/nodeInfo/endpoint")
+			endpointDecryptor := c.makeDecryptor("network/node/endpoint")
 			c.mu.Lock()
 			for _, entry := range endpointEntries {
 				meta := extractEntryMetadata(entry)
@@ -320,7 +269,7 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 					continue
 				}
 
-				// Find the parent nodeInfo by matching the parentId from
+				// Find the parent node by matching the parentId from
 				// the endpoint's descriptor to a node's recordID.
 				parentID := meta.ParentID
 				for _, node := range c.nodes {
@@ -338,7 +287,6 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 
 	c.logger.DebugContext(ctx, "mesh state loaded",
 		slog.String("network", network.Name),
-		slog.Int("members", len(c.members)),
 		slog.Int("nodes", len(c.nodes)),
 		slog.Int("relays", len(c.relays)),
 	)
@@ -410,8 +358,8 @@ func (c *DWNClient) buildMapResponse() *MapResponse {
 
 	var nodeID int64 = 1
 	for _, did := range dids {
-		nodeInfo := c.nodes[did]
-		node := nodeInfoToNode(nodeID, did, nodeInfo)
+		rec := c.nodes[did]
+		node := nodeRecordToNode(nodeID, did, rec)
 		nodeID++
 
 		if did == c.selfDID {
@@ -430,31 +378,38 @@ func (c *DWNClient) buildMapResponse() *MapResponse {
 	return resp
 }
 
-func nodeInfoToNode(id int64, did string, info *NodeInfoData) *Node {
-	return nodeInfoToNodeWithThreshold(id, did, info, DefaultPeerStaleThreshold, time.Now())
+func nodeRecordToNode(id int64, did string, rec *NodeRecord) *Node {
+	return nodeRecordToNodeWithThreshold(id, did, rec, DefaultPeerStaleThreshold, time.Now())
 }
 
-// nodeInfoToNodeWithThreshold converts a NodeInfoData to a Node, using the
+// nodeRecordToNodeWithThreshold converts a NodeRecord to a Node, using the
 // given staleness threshold and reference time. The reference time is passed
 // as a parameter (instead of calling time.Now()) to make the function
 // deterministically testable.
-func nodeInfoToNodeWithThreshold(id int64, did string, info *NodeInfoData, staleThreshold time.Duration, now time.Time) *Node {
+//
+// The WireGuard public key is derived from the node's did:jwk identity
+// (Ed25519 → X25519 birational map). If derivation fails (e.g., non-jwk DID),
+// the Key field is left empty and logged.
+func nodeRecordToNodeWithThreshold(id int64, nodeDID string, rec *NodeRecord, staleThreshold time.Duration, now time.Time) *Node {
 	node := &Node{
 		ID:           id,
-		Name:         info.Hostname,
-		DID:          did,
-		Key:          info.WireGuardPublicKey,
-		DiscoKey:     info.DiscoKey,
-		OS:           info.OS,
-		Capabilities: info.Capabilities,
+		Name:         rec.Hostname,
+		DID:          nodeDID,
+		OS:           rec.OS,
+		Capabilities: rec.Capabilities,
 	}
 
-	if ip, err := netip.ParseAddr(info.MeshIP); err == nil {
+	// Derive WireGuard public key from did:jwk.
+	if x25519Pub, err := didjwk.DeriveX25519PublicKey(nodeDID); err == nil {
+		node.Key = base64.StdEncoding.EncodeToString(x25519Pub)
+	}
+
+	if ip, err := netip.ParseAddr(rec.MeshIP); err == nil {
 		node.MeshIP = ip
 		node.AllowedIPs = []netip.Prefix{netip.PrefixFrom(ip, ip.BitLen())}
 	}
 
-	for _, cidr := range info.AllowedIPs {
+	for _, cidr := range rec.AllowedIPs {
 		if prefix, err := netip.ParsePrefix(cidr); err == nil {
 			node.AllowedIPs = append(node.AllowedIPs, prefix)
 		}
@@ -463,7 +418,7 @@ func nodeInfoToNodeWithThreshold(id int64, did string, info *NodeInfoData, stale
 	// Track the most recent endpoint update time to determine online status.
 	var lastSeen time.Time
 
-	for _, ep := range info.Endpoints {
+	for _, ep := range rec.Endpoints {
 		for _, pub := range ep.PublicEndpoints {
 			node.Endpoints = append(node.Endpoints, fmt.Sprintf("%s:%d", pub.Address, pub.Port))
 		}
@@ -471,8 +426,7 @@ func nodeInfoToNodeWithThreshold(id int64, did string, info *NodeInfoData, stale
 		if ep.PreferredDERP != 0 {
 			node.PreferredDERP = ep.PreferredDERP
 		}
-		// Endpoint records may carry a more recent disco key than
-		// the nodeInfo record. Use the latest non-empty disco key.
+		// Endpoint records may carry a disco key. Use the latest non-empty one.
 		if ep.DiscoKey != "" {
 			node.DiscoKey = ep.DiscoKey
 		}

--- a/internal/control/types.go
+++ b/internal/control/types.go
@@ -27,10 +27,12 @@ type Node struct {
 	DID string
 
 	// Key is the WireGuard public key (Curve25519, base64).
+	// Derived from the node's did:jwk identity (Ed25519 → X25519 birational map),
+	// not read from a record field.
 	Key string
 
 	// DiscoKey is the disco public key (base64) for DERP relay and
-	// direct connection upgrade. Exchanged via DWN nodeInfo/endpoint records.
+	// direct connection upgrade. Exchanged via DWN node/endpoint records.
 	DiscoKey string
 
 	// Endpoints are the node's reachable ip:port pairs.


### PR DESCRIPTION
## Summary

Updates the DWN control client (`internal/control/`) to work with the new protocol structure from #47: merged `node` records replacing `member` + `nodeInfo`, no tags, WireGuard pubkey derived from `did:jwk`. Closes #48.

### Data type changes

| Before | After |
|--------|-------|
| `MemberInfo` struct | **Removed** |
| `NodeInfoData` struct | **Removed** |
| — | `NodeRecord` (merges both, no `WireGuardPublicKey` field) |
| `c.members map[string]*MemberInfo` | **Removed** |
| `c.nodes map[string]*NodeInfoData` | `c.nodes map[string]*NodeRecord` |

### LoadState query changes

| Before | After |
|--------|-------|
| Query `network/member` records | **Removed** (merged into node) |
| Query `network/nodeInfo` records | Query `network/node` records |
| DID from `meta.Tags["did"]` | DID from `meta.Recipient` |
| Query `network/nodeInfo/endpoint` | Query `network/node/endpoint` |
| Protocol role `network/member` | Protocol role `network/node` |

### WireGuard key derivation

- `nodeInfoToNode()` renamed to `nodeRecordToNode()`
- No longer reads `info.WireGuardPublicKey` from record data
- Derives WG public key via `didjwk.DeriveX25519PublicKey(did)` at conversion time
- Gracefully handles non-jwk DIDs (empty Key, no panic)

### Tests

- `TestNodeRecordToNode` — uses real `did:jwk` identities, verifies WG key is correctly derived
- `TestNodeOnlineStatus` — updated for `NodeRecord` type
- Encryption round-trip test uses `network/node` path
- Metadata extraction tests updated for new record format (no tags, recipient-based DID)
- New sub-test: non-jwk DID yields empty Key without panic

### Build, vet, tests

All pass:
```
go build ./...     # zero errors
go vet ./...       # zero warnings
go test ./... -count=1 -race  # all pass, no data races
```