### PR TITLE
refactor: update mesh registration for node-based protocol

### DIFF
--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -333,18 +333,13 @@ func cmdNetworkCreate(ctx context.Context, args []string, flagProfile string) er
 		fmt.Printf("  Created admin member record (encrypted).\n")
 	}
 
-	// 5. Derive WireGuard keys from identity and allocate mesh IP.
-	wgKeys, err := mesh.WireGuardKeyFromIdentity(identity.EncryptionPrivateKey)
-	if err != nil {
-		return fmt.Errorf("deriving WireGuard keys: %w", err)
-	}
-
+	// 5. Allocate mesh IP.
 	meshIP, err := mesh.AllocateMeshIP(meshCIDR, identity.URI)
 	if err != nil {
 		return fmt.Errorf("allocating mesh IP: %w", err)
 	}
 
-	// 6. Register nodeInfo on DWN (encrypted).
+	// 6. Register node on DWN (encrypted).
 	reg, err := mesh.RegisterNode(ctx, mesh.RegisterNodeParams{
 		AnchorEndpoint:       endpoint,
 		AnchorDID:            identity.URI,
@@ -352,11 +347,10 @@ func cmdNetworkCreate(ctx context.Context, args []string, flagProfile string) er
 		SelfDID:              identity.URI,
 		Signer:               signer,
 		EncryptionKeyManager: encMgr,
-		WireGuardPubKey:      wgKeys.PublicKeyBase64(),
 		MeshIP:               meshIP.String(),
 	})
 	if err != nil {
-		fmt.Printf("  Warning: nodeInfo registration failed: %v\n", err)
+		fmt.Printf("  Warning: node registration failed: %v\n", err)
 	} else {
 		fmt.Printf("  Registered node (encrypted): IP=%s\n", meshIP)
 	}
@@ -371,8 +365,8 @@ func cmdNetworkCreate(ctx context.Context, args []string, flagProfile string) er
 		MeshIP:          meshIP.String(),
 	}
 	if reg != nil {
-		ns.NodeInfoRecordID = reg.NodeInfoRecordID
-		ns.NodeInfoDateCreated = reg.DateCreated
+		ns.NodeRecordID = reg.NodeRecordID
+		ns.NodeDateCreated = reg.DateCreated
 	}
 	if err := state.SaveNetworkState(stateDir, ns); err != nil {
 		return fmt.Errorf("saving network state: %w", err)
@@ -462,12 +456,7 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 		networkData.MeshCIDR = "10.200.0.0/16"
 	}
 
-	// Derive WireGuard keys from identity and allocate mesh IP.
-	wgKeys, err := mesh.WireGuardKeyFromIdentity(identity.EncryptionPrivateKey)
-	if err != nil {
-		return fmt.Errorf("deriving WireGuard keys: %w", err)
-	}
-
+	// Allocate mesh IP.
 	meshIP, err := mesh.AllocateMeshIP(networkData.MeshCIDR, identity.URI)
 	if err != nil {
 		return fmt.Errorf("allocating mesh IP: %w", err)
@@ -481,25 +470,11 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 	// multi-party encryption). This is sufficient for single-owner networks.
 	encMgr := newEncryptionKeyManager(identity)
 
-	// Create member record (encrypted).
-	err = mesh.CreateMember(ctx, mesh.CreateMemberParams{
-		AnchorEndpoint:       endpoint,
-		AnchorDID:            anchorDID,
-		NetworkRecordID:      networkID,
-		MemberDID:            identity.URI,
-		Label:                "member",
-		Signer:               signer,
-		EncryptionKeyManager: encMgr,
-	})
-	if err != nil {
-		fmt.Printf("  Warning: member record creation failed: %v\n", err)
-	} else {
-		fmt.Printf("  Created member record (encrypted).\n")
-	}
-
-	// Register nodeInfo (encrypted), invoking the network/member role for authorization.
-	var nodeInfoRecordID string
-	var nodeInfoDateCreated string
+	// Register node (encrypted). The node record replaces the old separate
+	// member + nodeInfo records. The recipient field (SelfDID) assigns the
+	// network/node role for authorization.
+	var nodeRecordID string
+	var nodeDateCreated string
 	reg, err := mesh.RegisterNode(ctx, mesh.RegisterNodeParams{
 		AnchorEndpoint:       endpoint,
 		AnchorDID:            anchorDID,
@@ -507,28 +482,27 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 		SelfDID:              identity.URI,
 		Signer:               signer,
 		EncryptionKeyManager: encMgr,
-		WireGuardPubKey:      wgKeys.PublicKeyBase64(),
 		MeshIP:               meshIP.String(),
-		ProtocolRole:         "network/member",
+		ProtocolRole:         "network/node",
 	})
 	if err != nil {
-		fmt.Printf("  Warning: nodeInfo registration failed: %v\n", err)
+		fmt.Printf("  Warning: node registration failed: %v\n", err)
 	} else {
-		nodeInfoRecordID = reg.NodeInfoRecordID
-		nodeInfoDateCreated = reg.DateCreated
+		nodeRecordID = reg.NodeRecordID
+		nodeDateCreated = reg.DateCreated
 		fmt.Printf("  Registered node (encrypted): IP=%s\n", meshIP)
 	}
 
 	// Save network state locally.
 	ns := &state.NetworkState{
-		NetworkRecordID:     networkID,
-		AnchorDID:           anchorDID,
-		AnchorEndpoint:      endpoint,
-		NetworkName:         networkData.Name,
-		MeshCIDR:            networkData.MeshCIDR,
-		MeshIP:              meshIP.String(),
-		NodeInfoRecordID:    nodeInfoRecordID,
-		NodeInfoDateCreated: nodeInfoDateCreated,
+		NetworkRecordID: networkID,
+		AnchorDID:       anchorDID,
+		AnchorEndpoint:  endpoint,
+		NetworkName:     networkData.Name,
+		MeshCIDR:        networkData.MeshCIDR,
+		MeshIP:          meshIP.String(),
+		NodeRecordID:    nodeRecordID,
+		NodeDateCreated: nodeDateCreated,
 	}
 	if err := state.SaveNetworkState(stateDir, ns); err != nil {
 		return fmt.Errorf("saving network state: %w", err)
@@ -695,21 +669,27 @@ func cmdPeerAdd(ctx context.Context, args []string, flagProfile string) error {
 	}
 	encMgr := newEncryptionKeyManager(identity)
 
-	// 1. Create a member record for the peer.
+	// 1. Create a node record for the peer (assigns the network/node role).
+	// The peer's mesh IP is derived deterministically from their DID.
 	fmt.Printf("Adding peer %s...\n", peerDID)
-	err = mesh.CreateMember(ctx, mesh.CreateMemberParams{
+	peerMeshIP, err := mesh.AllocateMeshIP(ns.MeshCIDR, peerDID)
+	if err != nil {
+		return fmt.Errorf("allocating mesh IP for peer: %w", err)
+	}
+	_, err = mesh.RegisterNode(ctx, mesh.RegisterNodeParams{
 		AnchorEndpoint:       ns.AnchorEndpoint,
 		AnchorDID:            ns.AnchorDID,
 		NetworkRecordID:      ns.NetworkRecordID,
-		MemberDID:            peerDID,
-		Label:                label,
+		SelfDID:              peerDID,
 		Signer:               signer,
 		EncryptionKeyManager: encMgr,
+		MeshIP:               peerMeshIP.String(),
+		Label:                label,
 	})
 	if err != nil {
-		return fmt.Errorf("creating member record: %w", err)
+		return fmt.Errorf("creating node record: %w", err)
 	}
-	fmt.Printf("  Member record created.\n")
+	fmt.Printf("  Node record created (IP=%s).\n", peerMeshIP)
 
 	// 2. Deliver the context encryption key so the peer can decrypt records.
 	kdm := &mesh.KeyDeliveryManager{
@@ -851,8 +831,8 @@ func cmdStatus(ctx context.Context, args []string, flagProfile string) error {
 			fmt.Printf("  WireGuard Key: %s\n", wgPubKey)
 		}
 	}
-	if ns.NodeInfoRecordID != "" {
-		fmt.Printf("  NodeInfo Record: %s\n", ns.NodeInfoRecordID)
+	if ns.NodeRecordID != "" {
+		fmt.Printf("  Node Record: %s\n", ns.NodeRecordID)
 	}
 
 	// Query live daemon status if running.
@@ -1057,7 +1037,6 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 	if err != nil {
 		return fmt.Errorf("deriving WireGuard keys from identity: %w", err)
 	}
-	wgPubKey := wgKeys.PublicKeyBase64()
 
 	fmt.Printf("Starting meshd...\n")
 	fmt.Printf("  Network: %s\n", ns.NetworkName)
@@ -1065,50 +1044,49 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 	fmt.Printf("  Mesh IP: %s\n", ns.MeshIP)
 	fmt.Printf("  Anchor: %s\n", ns.AnchorEndpoint)
 
-	// If we have a context key, re-register nodeInfo with Protocol Context
+	// If we have a context key, re-register node with Protocol Context
 	// encryption. The initial registration during "network join" used Protocol
 	// Path encryption (our own key) which the anchor can't decrypt. Re-writing
-	// with Protocol Context encryption allows the anchor to read our nodeInfo.
+	// with Protocol Context encryption allows the anchor to read our node record.
 	// This is a RecordsWrite update (same recordId, preserved dateCreated).
-	if useContextEncryption && ns.NodeInfoRecordID != "" {
+	if useContextEncryption && ns.NodeRecordID != "" {
 		reg, err := mesh.RegisterNode(ctx, mesh.RegisterNodeParams{
-			AnchorEndpoint:          ns.AnchorEndpoint,
-			AnchorDID:               ns.AnchorDID,
-			NetworkRecordID:         ns.NetworkRecordID,
-			SelfDID:                 identity.URI,
-			Signer:                  signer,
-			EncryptionKeyManager:    encMgr,
-			WireGuardPubKey:         wgPubKey,
-			MeshIP:                  ns.MeshIP,
-			ProtocolRole:            "network/member",
-			UseContextEncryption:    true,
-			ExistingNodeInfoRecordID: ns.NodeInfoRecordID,
-			ExistingDateCreated:     ns.NodeInfoDateCreated,
+			AnchorEndpoint:       ns.AnchorEndpoint,
+			AnchorDID:            ns.AnchorDID,
+			NetworkRecordID:      ns.NetworkRecordID,
+			SelfDID:              identity.URI,
+			Signer:               signer,
+			EncryptionKeyManager: encMgr,
+			MeshIP:               ns.MeshIP,
+			ProtocolRole:         "network/node",
+			UseContextEncryption: true,
+			ExistingNodeRecordID: ns.NodeRecordID,
+			ExistingDateCreated:  ns.NodeDateCreated,
 		})
 		if err != nil {
-			logger.Warn("nodeInfo re-registration with context encryption failed",
+			logger.Warn("node re-registration with context encryption failed",
 				slog.Any("error", err),
 			)
 		} else {
 			// Update state — recordId stays the same for updates, but store dateCreated.
-			if reg.NodeInfoRecordID != "" {
-				ns.NodeInfoRecordID = reg.NodeInfoRecordID
+			if reg.NodeRecordID != "" {
+				ns.NodeRecordID = reg.NodeRecordID
 			}
 			if reg.DateCreated != "" {
-				ns.NodeInfoDateCreated = reg.DateCreated
+				ns.NodeDateCreated = reg.DateCreated
 			}
-			fmt.Printf("  NodeInfo re-encrypted with context key.\n")
+			fmt.Printf("  Node re-encrypted with context key.\n")
 		}
 	}
 
 	// Write/update endpoint record (encrypted) before starting the engine.
-	if ns.NodeInfoRecordID != "" {
+	if ns.NodeRecordID != "" {
 		localEndpoints := mesh.DiscoverLocalEndpoints(f.listenPort)
 		wpParams := mesh.WriteEndpointParams{
 			AnchorEndpoint:       ns.AnchorEndpoint,
 			AnchorDID:            ns.AnchorDID,
 			NetworkRecordID:      ns.NetworkRecordID,
-			NodeInfoRecordID:     ns.NodeInfoRecordID,
+			NodeRecordID:         ns.NodeRecordID,
 			Signer:               signer,
 			EncryptionKeyManager: encMgr,
 			LocalEndpoints:       localEndpoints,
@@ -1117,7 +1095,7 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 		}
 		// Non-anchor nodes must invoke their role for authorization.
 		if ns.AnchorDID != identity.URI {
-			wpParams.ProtocolRole = "network/member"
+			wpParams.ProtocolRole = "network/node"
 		}
 		err = mesh.WriteEndpoint(ctx, wpParams)
 		if err != nil {
@@ -1152,7 +1130,7 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 		Signer:               signer,
 		Resolver:             universalResolver{},
 		EncryptionKeyManager: encMgr,
-		NodeInfoRecordID:     ns.NodeInfoRecordID,
+		NodeInfoRecordID:     ns.NodeRecordID,
 		AutoKeyDelivery:      autoKeyDelivery,
 		UseContextEncryption: useContextEncryption,
 		WireGuardPrivateKey:  wgKeys.PrivateKey,

--- a/internal/engine/connectivity_test.go
+++ b/internal/engine/connectivity_test.go
@@ -29,10 +29,10 @@ import (
 //  1. Creates two DID identities (node A = anchor, node B = joiner)
 //  2. Node A installs wireguard-mesh + key-delivery protocols with encryption
 //  3. Node A creates the network record
-//  4. Node A creates admin member + nodeInfo (encrypted with Protocol Path)
-//  5. Node B joins: member created by A, nodeInfo + endpoint by B (Protocol Path)
+//  4. Node A registers its node record (encrypted, no WireGuardPubKey — derived from did:jwk)
+//  5. Node A registers Node B's node record (recipient = B's DID, assigns network/node role)
 //  6. Node A delivers context key to both nodes
-//  6b. Node B fetches context key, re-registers nodeInfo + endpoint with Protocol Context encryption
+//  6b. Node B fetches context key, re-registers node + endpoint with Protocol Context encryption
 //  7. Both nodes create real engines (UserspaceEngine + netstack)
 //  8. Both engines start, poll DWN, and discover each other
 //  9. TCP connectivity test: B dials A's mesh IP, echo round-trip verified
@@ -130,41 +130,10 @@ func TestTwoNodeConnectivity(t *testing.T) {
 	t.Logf("  Network record: %s", networkRecordID)
 
 	// ================================================================
-	// Step 4: Node A creates admin member + nodeInfo (encrypted)
+	// Step 4: Node A registers its own node record (encrypted)
 	// ================================================================
-	t.Log("Step 4: Node A creates admin member and nodeInfo records")
+	t.Log("Step 4: Node A registers its own node record")
 
-	memberRecipients, err := nodeA.encMgr.DeriveWriteEncryption("network/member")
-	if err != nil {
-		t.Fatalf("deriving member encryption: %v", err)
-	}
-
-	memberData, _ := json.Marshal(map[string]any{
-		"joinedAt": time.Now().UTC().Format(time.RFC3339),
-		"label":    "admin",
-	})
-	_, memberStatus, err := nodeA.api.Write(ctx, nodeA.identity.URI, dwn.WriteParams{
-		Protocol:             protocols.MeshProtocolURI,
-		ProtocolPath:         "network/member",
-		Schema:               "https://enbox.org/schemas/wireguard-mesh/member",
-		DataFormat:           "application/json",
-		Recipient:            nodeA.identity.URI,
-		ParentContextID:     networkRecordID,
-		Data:                 memberData,
-		Tags:                 map[string]any{"status": "active"},
-		EncryptionRecipients: memberRecipients,
-	})
-	if err != nil {
-		t.Fatalf("creating admin member: %v", err)
-	}
-	if memberStatus.Code >= 300 {
-		t.Fatalf("admin member: %d %s", memberStatus.Code, memberStatus.Detail)
-	}
-
-	wgKeysA, err := mesh.WireGuardKeyFromIdentity(nodeA.identity.EncryptionPrivateKey)
-	if err != nil {
-		t.Fatalf("deriving WG keys for A: %v", err)
-	}
 	meshIPA, err := mesh.AllocateMeshIP(meshCIDR, nodeA.identity.URI)
 	if err != nil {
 		t.Fatalf("allocating mesh IP for A: %v", err)
@@ -177,21 +146,20 @@ func TestTwoNodeConnectivity(t *testing.T) {
 		SelfDID:              nodeA.identity.URI,
 		Signer:               nodeA.signer,
 		EncryptionKeyManager: nodeA.encMgr,
-		WireGuardPubKey:      wgKeysA.PublicKeyBase64(),
 		MeshIP:               meshIPA.String(),
 		Hostname:             "node-a",
 	})
 	if err != nil {
 		t.Fatalf("registering node A: %v", err)
 	}
-	t.Logf("  Node A: IP=%s, nodeInfo=%s", meshIPA, regA.NodeInfoRecordID)
+	t.Logf("  Node A: IP=%s, nodeRecord=%s", meshIPA, regA.NodeRecordID)
 
 	// Write endpoint record for node A.
 	err = mesh.WriteEndpoint(ctx, mesh.WriteEndpointParams{
 		AnchorEndpoint:       endpoint,
 		AnchorDID:            nodeA.identity.URI,
 		NetworkRecordID:      networkRecordID,
-		NodeInfoRecordID:     regA.NodeInfoRecordID,
+		NodeRecordID:         regA.NodeRecordID,
 		Signer:               nodeA.signer,
 		EncryptionKeyManager: nodeA.encMgr,
 		LocalEndpoints:       mesh.DiscoverLocalEndpoints(0),
@@ -206,26 +174,9 @@ func TestTwoNodeConnectivity(t *testing.T) {
 	// ================================================================
 	t.Log("Step 5: Node B joins the network")
 
-	// Node A (network author) creates Node B's member record on the anchor DWN.
-	// Per the protocol's $actions: only the network author can create members.
-	err = mesh.CreateMember(ctx, mesh.CreateMemberParams{
-		AnchorEndpoint:       endpoint,
-		AnchorDID:            nodeA.identity.URI,
-		NetworkRecordID:      networkRecordID,
-		MemberDID:            nodeB.identity.URI,
-		Label:                "member",
-		Signer:               nodeA.signer,
-		EncryptionKeyManager: nodeA.encMgr,
-	})
-	if err != nil {
-		t.Fatalf("Node B member creation (by Node A) failed: %v", err)
-	}
-	t.Log("  Node B member record created by Node A")
-
-	wgKeysB, err := mesh.WireGuardKeyFromIdentity(nodeB.identity.EncryptionPrivateKey)
-	if err != nil {
-		t.Fatalf("deriving WG keys for B: %v", err)
-	}
+	// Node A (network author) creates Node B's node record on the anchor DWN.
+	// The node record's Recipient is set to Node B's DID, assigning Node B
+	// the network/node role for authorization.
 	meshIPB, err := mesh.AllocateMeshIP(meshCIDR, nodeB.identity.URI)
 	if err != nil {
 		t.Fatalf("allocating mesh IP for B: %v", err)
@@ -236,29 +187,28 @@ func TestTwoNodeConnectivity(t *testing.T) {
 		AnchorDID:            nodeA.identity.URI,
 		NetworkRecordID:      networkRecordID,
 		SelfDID:              nodeB.identity.URI,
-		Signer:               nodeB.signer,
-		EncryptionKeyManager: nodeB.encMgr,
-		WireGuardPubKey:      wgKeysB.PublicKeyBase64(),
+		Signer:               nodeA.signer, // Node A creates B's record
+		EncryptionKeyManager: nodeA.encMgr,
 		MeshIP:               meshIPB.String(),
 		Hostname:             "node-b",
-		ProtocolRole:         "network/member",
 	})
 	if err != nil {
-		t.Fatalf("Node B nodeInfo registration failed: %v", err)
+		t.Fatalf("Node B node registration failed: %v", err)
 	}
-	t.Logf("  Node B: IP=%s, nodeInfo=%s", meshIPB, regB.NodeInfoRecordID)
+	t.Logf("  Node B: IP=%s, nodeRecord=%s", meshIPB, regB.NodeRecordID)
 
-	// Write endpoint record for node B.
-	if regB != nil && regB.NodeInfoRecordID != "" {
+	// Write endpoint record for node B (authored by B using network/node role).
+	if regB != nil && regB.NodeRecordID != "" {
 		err = mesh.WriteEndpoint(ctx, mesh.WriteEndpointParams{
 			AnchorEndpoint:       endpoint,
 			AnchorDID:            nodeA.identity.URI,
 			NetworkRecordID:      networkRecordID,
-			NodeInfoRecordID:     regB.NodeInfoRecordID,
+			NodeRecordID:         regB.NodeRecordID,
 			Signer:               nodeB.signer,
 			EncryptionKeyManager: nodeB.encMgr,
 			LocalEndpoints:       mesh.DiscoverLocalEndpoints(0),
 			NATType:              "unknown",
+			ProtocolRole:         "network/node",
 		})
 		if err != nil {
 			t.Logf("  Warning: Node B endpoint write failed: %v", err)
@@ -302,26 +252,25 @@ func TestTwoNodeConnectivity(t *testing.T) {
 	}
 	t.Log("  Context key delivered to Node B")
 
-	// Node A (anchor) also re-registers with context encryption so non-anchor
-	// nodes can decrypt its nodeInfo using the shared context key.
+	// Node A (anchor) re-registers with context encryption so non-anchor
+	// nodes can decrypt its node record using the shared context key.
 	regA2, err := mesh.RegisterNode(ctx, mesh.RegisterNodeParams{
-		AnchorEndpoint:          endpoint,
-		AnchorDID:               nodeA.identity.URI,
-		NetworkRecordID:         networkRecordID,
-		SelfDID:                 nodeA.identity.URI,
-		Signer:                  nodeA.signer,
-		EncryptionKeyManager:    nodeA.encMgr,
-		WireGuardPubKey:         wgKeysA.PublicKeyBase64(),
-		MeshIP:                  meshIPA.String(),
-		Hostname:                "node-a",
-		UseContextEncryption:    true,
-		ExistingNodeInfoRecordID: regA.NodeInfoRecordID,
-		ExistingDateCreated:     regA.DateCreated,
+		AnchorEndpoint:       endpoint,
+		AnchorDID:            nodeA.identity.URI,
+		NetworkRecordID:      networkRecordID,
+		SelfDID:              nodeA.identity.URI,
+		Signer:               nodeA.signer,
+		EncryptionKeyManager: nodeA.encMgr,
+		MeshIP:               meshIPA.String(),
+		Hostname:             "node-a",
+		UseContextEncryption: true,
+		ExistingNodeRecordID: regA.NodeRecordID,
+		ExistingDateCreated:  regA.DateCreated,
 	})
 	if err != nil {
 		t.Fatalf("re-registering Node A with context encryption: %v", err)
 	}
-	t.Logf("  Node A re-registered with context encryption: %s", regA2.NodeInfoRecordID)
+	t.Logf("  Node A re-registered with context encryption: %s", regA2.NodeRecordID)
 
 	// ================================================================
 	// Step 6b: Node B fetches and stores context key, re-registers with context encryption
@@ -348,37 +297,34 @@ func TestTwoNodeConnectivity(t *testing.T) {
 	nodeB.encMgr.StoreContextKey(networkRecordID, contextKeyBytes)
 	t.Log("  Node B stored context key")
 
-	// Re-register Node B's nodeInfo with Protocol Context encryption.
+	// Re-register Node B's node record with Protocol Context encryption.
 	// This is an UPDATE (same recordId, preserved dateCreated) which replaces
 	// the old Protocol Path encrypted record in-place, avoiding duplicates.
 	regB2, err := mesh.RegisterNode(ctx, mesh.RegisterNodeParams{
-		AnchorEndpoint:          endpoint,
-		AnchorDID:               nodeA.identity.URI,
-		NetworkRecordID:         networkRecordID,
-		SelfDID:                 nodeB.identity.URI,
-		Signer:                  nodeB.signer,
-		EncryptionKeyManager:    nodeB.encMgr,
-		WireGuardPubKey:         wgKeysB.PublicKeyBase64(),
-		MeshIP:                  meshIPB.String(),
-		Hostname:                "node-b",
-		ProtocolRole:            "network/member",
-		UseContextEncryption:    true,
-		ExistingNodeInfoRecordID: regB.NodeInfoRecordID,
-		ExistingDateCreated:     regB.DateCreated,
+		AnchorEndpoint:       endpoint,
+		AnchorDID:            nodeA.identity.URI,
+		NetworkRecordID:      networkRecordID,
+		SelfDID:              nodeB.identity.URI,
+		Signer:               nodeB.signer,
+		EncryptionKeyManager: nodeB.encMgr,
+		MeshIP:               meshIPB.String(),
+		Hostname:             "node-b",
+		ProtocolRole:         "network/node",
+		UseContextEncryption: true,
+		ExistingNodeRecordID: regB.NodeRecordID,
+		ExistingDateCreated:  regB.DateCreated,
 	})
 	if err != nil {
 		t.Fatalf("re-registering Node B with context encryption: %v", err)
 	}
-	t.Logf("  Node B re-registered with context encryption: %s", regB2.NodeInfoRecordID)
+	t.Logf("  Node B re-registered with context encryption: %s", regB2.NodeRecordID)
 
-	// Re-write Node B's endpoint with context encryption, parented under the new nodeInfo.
-	// No ProtocolRole needed — the "who": "author", "of": "network/nodeInfo" action
-	// authorizes the nodeInfo author to create endpoint records.
+	// Re-write Node B's endpoint with context encryption, parented under the node record.
 	err = mesh.WriteEndpoint(ctx, mesh.WriteEndpointParams{
 		AnchorEndpoint:       endpoint,
 		AnchorDID:            nodeA.identity.URI,
 		NetworkRecordID:      networkRecordID,
-		NodeInfoRecordID:     regB2.NodeInfoRecordID,
+		NodeRecordID:         regB2.NodeRecordID,
 		Signer:               nodeB.signer,
 		EncryptionKeyManager: nodeB.encMgr,
 		LocalEndpoints:       mesh.DiscoverLocalEndpoints(0),
@@ -396,15 +342,27 @@ func TestTwoNodeConnectivity(t *testing.T) {
 	// ================================================================
 	t.Log("Step 7: Creating engines for both nodes")
 
+	// Derive WireGuard keys from identity for engine Config.
+	// The engine needs the raw X25519 private key for WireGuard, even though
+	// the public key is no longer stored in DWN records (peers derive it
+	// from the did:jwk).
+	wgKeysA, err := mesh.WireGuardKeyFromIdentity(nodeA.identity.EncryptionPrivateKey)
+	if err != nil {
+		t.Fatalf("deriving WG keys for A: %v", err)
+	}
+	wgKeysB, err := mesh.WireGuardKeyFromIdentity(nodeB.identity.EncryptionPrivateKey)
+	if err != nil {
+		t.Fatalf("deriving WG keys for B: %v", err)
+	}
+
 	// Diagnostic: verify that the NodePublic derived from the private key
-	// matches the public key stored in DWN records. This is critical for
-	// disco key lookup — if these don't match, disco keys won't be found.
+	// matches the public key that peers will derive from the did:jwk.
 	nodePrivA := key.NodePrivateFromRaw32(go4mem.B(wgKeysA.PrivateKey[:]))
 	nodePrivB := key.NodePrivateFromRaw32(go4mem.B(wgKeysB.PrivateKey[:]))
 	nodePubA := nodePrivA.Public()
 	nodePubB := nodePrivB.Public()
 
-	// Parse the public keys from the DWN-stored base64 (same path as converter)
+	// Parse the public keys from the base64 (same path as converter)
 	dwnPubA, _ := parseTestWireGuardKey(wgKeysA.PublicKeyBase64())
 	dwnPubB, _ := parseTestWireGuardKey(wgKeysB.PublicKeyBase64())
 
@@ -736,22 +694,6 @@ func TestTwoNodeNetworkMapDiscovery(t *testing.T) {
 		}
 	}
 
-	// Create member records (Node A is network author, so it creates both).
-	memberRecipients, _ := nodeA.encMgr.DeriveWriteEncryption("network/member")
-	mData, _ := json.Marshal(map[string]any{"joinedAt": time.Now().UTC().Format(time.RFC3339)})
-	nodeA.api.Write(ctx, nodeA.identity.URI, dwn.WriteParams{
-		Protocol: protocols.MeshProtocolURI, ProtocolPath: "network/member",
-		Schema: "https://enbox.org/schemas/wireguard-mesh/member", DataFormat: "application/json",
-		Recipient: nodeA.identity.URI, ParentContextID: networkRecordID,
-		Data: mData, Tags: map[string]any{"status": "active"}, EncryptionRecipients: memberRecipients,
-	})
-	nodeA.api.Write(ctx, nodeA.identity.URI, dwn.WriteParams{
-		Protocol: protocols.MeshProtocolURI, ProtocolPath: "network/member",
-		Schema: "https://enbox.org/schemas/wireguard-mesh/member", DataFormat: "application/json",
-		Recipient: nodeB.identity.URI, ParentContextID: networkRecordID,
-		Data: mData, Tags: map[string]any{"status": "active"}, EncryptionRecipients: memberRecipients,
-	})
-
 	// Install key-delivery protocol on anchor.
 	err = mesh.EnsureKeyDeliveryProtocol(ctx, endpoint, nodeA.identity.URI, nodeA.signer,
 		nodeA.identity.EncryptionPrivateKey, nodeA.identity.EncryptionKeyID())
@@ -759,25 +701,22 @@ func TestTwoNodeNetworkMapDiscovery(t *testing.T) {
 		t.Fatalf("EnsureKeyDeliveryProtocol: %v", err)
 	}
 
-	// Register both nodes (initial registration uses Protocol Path encryption).
-	wgA, _ := mesh.WireGuardKeyFromIdentity(nodeA.identity.EncryptionPrivateKey)
+	// Register both nodes. Node A is the anchor (network author).
 	ipA, _ := mesh.AllocateMeshIP(meshCIDR, nodeA.identity.URI)
 	regADisc, _ := mesh.RegisterNode(ctx, mesh.RegisterNodeParams{
 		AnchorEndpoint: endpoint, AnchorDID: nodeA.identity.URI,
 		NetworkRecordID: networkRecordID, SelfDID: nodeA.identity.URI,
 		Signer: nodeA.signer, EncryptionKeyManager: nodeA.encMgr,
-		WireGuardPubKey: wgA.PublicKeyBase64(), MeshIP: ipA.String(),
-		Hostname: "disc-a",
+		MeshIP: ipA.String(), Hostname: "disc-a",
 	})
 
-	wgB, _ := mesh.WireGuardKeyFromIdentity(nodeB.identity.EncryptionPrivateKey)
+	// Node A creates Node B's node record (assigns network/node role via Recipient).
 	ipB, _ := mesh.AllocateMeshIP(meshCIDR, nodeB.identity.URI)
 	regBDisc, _ := mesh.RegisterNode(ctx, mesh.RegisterNodeParams{
 		AnchorEndpoint: endpoint, AnchorDID: nodeA.identity.URI,
 		NetworkRecordID: networkRecordID, SelfDID: nodeB.identity.URI,
-		Signer: nodeB.signer, EncryptionKeyManager: nodeB.encMgr,
-		WireGuardPubKey: wgB.PublicKeyBase64(), MeshIP: ipB.String(),
-		Hostname: "disc-b", ProtocolRole: "network/member",
+		Signer: nodeA.signer, EncryptionKeyManager: nodeA.encMgr,
+		MeshIP: ipB.String(), Hostname: "disc-b",
 	})
 
 	// Deliver context key to Node B, then re-register both nodes with context encryption.
@@ -801,10 +740,9 @@ func TestTwoNodeNetworkMapDiscovery(t *testing.T) {
 		AnchorEndpoint: endpoint, AnchorDID: nodeA.identity.URI,
 		NetworkRecordID: networkRecordID, SelfDID: nodeA.identity.URI,
 		Signer: nodeA.signer, EncryptionKeyManager: nodeA.encMgr,
-		WireGuardPubKey: wgA.PublicKeyBase64(), MeshIP: ipA.String(),
-		Hostname: "disc-a", UseContextEncryption: true,
-		ExistingNodeInfoRecordID: regADisc.NodeInfoRecordID,
-		ExistingDateCreated:      regADisc.DateCreated,
+		MeshIP: ipA.String(), Hostname: "disc-a", UseContextEncryption: true,
+		ExistingNodeRecordID: regADisc.NodeRecordID,
+		ExistingDateCreated:  regADisc.DateCreated,
 	})
 
 	// Node B fetches and stores context key.
@@ -829,13 +767,16 @@ func TestTwoNodeNetworkMapDiscovery(t *testing.T) {
 			AnchorEndpoint: endpoint, AnchorDID: nodeA.identity.URI,
 			NetworkRecordID: networkRecordID, SelfDID: nodeB.identity.URI,
 			Signer: nodeB.signer, EncryptionKeyManager: nodeB.encMgr,
-			WireGuardPubKey: wgB.PublicKeyBase64(), MeshIP: ipB.String(),
-			Hostname: "disc-b", ProtocolRole: "network/member",
+			MeshIP: ipB.String(), Hostname: "disc-b",
+			ProtocolRole:         "network/node",
 			UseContextEncryption: true,
-			ExistingNodeInfoRecordID: regBDisc.NodeInfoRecordID,
-			ExistingDateCreated:      regBDisc.DateCreated,
+			ExistingNodeRecordID: regBDisc.NodeRecordID,
+			ExistingDateCreated:  regBDisc.DateCreated,
 		})
 	}
+
+	// Derive WireGuard key for engine Config.
+	wgA, _ := mesh.WireGuardKeyFromIdentity(nodeA.identity.EncryptionPrivateKey)
 
 	// Create engine A.
 	discoReg := engine.NewInMemoryDiscoRegistry()
@@ -868,7 +809,7 @@ func TestTwoNodeNetworkMapDiscovery(t *testing.T) {
 			t.Logf("  Engine A NetMap: domain=%s, selfNode=%v, peers=%d",
 				nm.Domain, nm.SelfNode.Valid(), len(nm.Peers))
 
-			// Check if we see at least 1 nodeInfo (ourselves).
+			// Check if we see at least 1 node (ourselves).
 			if nm.SelfNode.Valid() {
 				t.Log("  Engine A successfully loaded network map from DWN")
 				return

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -608,14 +608,14 @@ func makeEndpointUpdateFunc(cfg Config, l *slog.Logger) func(context.Context, []
 			AnchorEndpoint:       cfg.AnchorEndpoint,
 			AnchorDID:            cfg.AnchorTenant,
 			NetworkRecordID:      cfg.NetworkRecordID,
-			NodeInfoRecordID:     cfg.NodeInfoRecordID,
+			NodeRecordID:         cfg.NodeInfoRecordID,
 			Signer:               cfg.Signer,
 			EncryptionKeyManager: cfg.EncryptionKeyManager,
 			PublicEndpoints:      publicEPs,
 			LocalEndpoints:       localEPs,
 			DiscoKey:             discoKeyB64,
 			NATType:              "unknown",
-			ProtocolRole:         "network/member",
+			ProtocolRole:         "network/node",
 			UseContextEncryption: cfg.UseContextEncryption,
 		})
 		if err != nil {

--- a/internal/mesh/e2e_test.go
+++ b/internal/mesh/e2e_test.go
@@ -158,43 +158,8 @@ func TestE2ENetworkCreateJoinQueryDecrypt(t *testing.T) {
 		t.Logf("  Network record ID (from query): %s", networkRecordID)
 	}
 
-	// ---- Step 4: Node A creates itself as admin member (encrypted) ----
-	t.Log("Step 4: Node A creates admin member record (encrypted)")
-	memberData, _ := json.Marshal(map[string]any{
-		"joinedAt": time.Now().UTC().Format(time.RFC3339),
-		"label":    "admin",
-	})
-	memberRecipients, err := nodeA.EncMgr.DeriveWriteEncryption("network/member")
-	if err != nil {
-		t.Fatalf("deriving member encryption: %v", err)
-	}
-
-	_, memberStatus, err := nodeA.API.Write(ctx, nodeA.DID.URI, dwn.WriteParams{
-		Protocol:             "https://enbox.org/protocols/wireguard-mesh",
-		ProtocolPath:         "network/member",
-		Schema:               "https://enbox.org/schemas/wireguard-mesh/member",
-		DataFormat:           "application/json",
-		Recipient:            nodeA.DID.URI,
-		ParentContextID:     networkRecordID,
-		Data:                 memberData,
-		Tags:                 map[string]any{"status": "active"},
-		EncryptionRecipients: memberRecipients,
-	})
-	if err != nil {
-		t.Fatalf("creating admin member: %v", err)
-	}
-	if memberStatus.Code >= 300 {
-		t.Logf("  Warning: admin member creation: %d %s", memberStatus.Code, memberStatus.Detail)
-	} else {
-		t.Logf("  Admin member created: %d %s", memberStatus.Code, memberStatus.Detail)
-	}
-
-	// ---- Step 5: Node A derives WireGuard keys and registers nodeInfo (encrypted) ----
-	t.Log("Step 5: Node A derives WG keys from identity and registers nodeInfo")
-	wgKeysA, err := mesh.WireGuardKeyFromIdentity(nodeA.DID.EncryptionPrivateKey)
-	if err != nil {
-		t.Fatalf("deriving WG keys for node A: %v", err)
-	}
+	// ---- Step 4: Node A registers itself as a node (encrypted) ----
+	t.Log("Step 4: Node A registers itself as a node (encrypted)")
 	meshIPA, err := mesh.AllocateMeshIP(meshCIDR, nodeA.DID.URI)
 	if err != nil {
 		t.Fatalf("allocating mesh IP for node A: %v", err)
@@ -207,18 +172,41 @@ func TestE2ENetworkCreateJoinQueryDecrypt(t *testing.T) {
 		SelfDID:              nodeA.DID.URI,
 		Signer:               nodeA.Signer,
 		EncryptionKeyManager: nodeA.EncMgr,
-		WireGuardPubKey:      wgKeysA.PublicKeyBase64(),
 		MeshIP:               meshIPA.String(),
 		Hostname:             "node-a",
 	})
 	if err != nil {
 		t.Fatalf("registering node A: %v", err)
 	}
-	t.Logf("  Node A registered: IP=%s, nodeInfo=%s", meshIPA, regA.NodeInfoRecordID)
+	t.Logf("  Node A registered: IP=%s, node=%s", meshIPA, regA.NodeRecordID)
 
-	// ---- Step 6: Node B joins the network ----
-	// Node B needs to install the protocol on its own DWN as well.
-	t.Log("Step 6: Node B installs protocol and joins the network")
+	// ---- Step 5: Node A creates Node B's node record (assigns network/node role) ----
+	t.Log("Step 5: Node A creates Node B's node record")
+	meshIPB, err := mesh.AllocateMeshIP(meshCIDR, nodeB.DID.URI)
+	if err != nil {
+		t.Fatalf("allocating mesh IP for node B: %v", err)
+	}
+
+	// Node A (network author) creates Node B's node record on the anchor DWN.
+	// The node record's recipient is Node B, assigning the "network/node" role.
+	_, err = mesh.RegisterNode(ctx, mesh.RegisterNodeParams{
+		AnchorEndpoint:       endpoint,
+		AnchorDID:            nodeA.DID.URI,
+		NetworkRecordID:      networkRecordID,
+		SelfDID:              nodeB.DID.URI,
+		Signer:               nodeA.Signer,
+		EncryptionKeyManager: nodeA.EncMgr,
+		MeshIP:               meshIPB.String(),
+		Hostname:             "node-b",
+		Label:                "node-b",
+	})
+	if err != nil {
+		t.Fatalf("Node B node creation (by Node A) failed: %v", err)
+	}
+	t.Log("  Node B node record created by Node A (encrypted)")
+
+	// ---- Step 6: Node B installs protocol on its own DWN ----
+	t.Log("Step 6: Node B installs protocol")
 	protocolDefB, err := dwncrypto.InjectEncryptionDirectives(
 		protocols.MeshProtocolJSON,
 		nodeB.DID.EncryptionPrivateKey,
@@ -235,82 +223,6 @@ func TestE2ENetworkCreateJoinQueryDecrypt(t *testing.T) {
 		t.Fatalf("ConfigureProtocol for node B: %d %s", statusB.Code, statusB.Detail)
 	}
 
-	// Node A (network author) creates Node B's member record on the anchor DWN.
-	// Per the protocol's $actions: only the network author or admins can create members.
-	// The member record's recipient is Node B — this assigns Node B the "network/member" role.
-	err = mesh.CreateMember(ctx, mesh.CreateMemberParams{
-		AnchorEndpoint:       endpoint,
-		AnchorDID:            nodeA.DID.URI,
-		NetworkRecordID:      networkRecordID,
-		MemberDID:            nodeB.DID.URI,
-		Label:                "member",
-		Signer:               nodeA.Signer,
-		EncryptionKeyManager: nodeA.EncMgr,
-	})
-	if err != nil {
-		t.Fatalf("Node B member creation (by Node A) failed: %v", err)
-	}
-	t.Log("  Node B member record created by Node A (encrypted)")
-
-	// Debug: query member records to verify they exist with correct recipients.
-	memberRecords, mqs, err := nodeA.API.Query(ctx, nodeA.DID.URI, dwn.QueryParams{
-		Filter: dwn.RecordsFilter{
-			Protocol:     "https://enbox.org/protocols/wireguard-mesh",
-			ProtocolPath: "network/member",
-			ParentID:     networkRecordID,
-		},
-	}, "")
-	if err == nil && mqs.Code == 200 {
-		for i, m := range memberRecords {
-			t.Logf("  Member[%d]: id=%s, recipient=%s, contextId=%s, author=%s", i, m.ID, m.Recipient, m.ContextID, m.Author)
-		}
-	}
-
-	// Debug: Node B queries for its own member role record on Node A's DWN.
-	// This uses the same filter the server would use internally.
-	nodeBMembers, nbqs, _ := nodeB.API.Query(ctx, nodeA.DID.URI, dwn.QueryParams{
-		Filter: dwn.RecordsFilter{
-			Protocol:     "https://enbox.org/protocols/wireguard-mesh",
-			ProtocolPath: "network/member",
-			Recipient:    nodeB.DID.URI,
-		},
-	}, "")
-	if nbqs != nil {
-		t.Logf("  Node B member query (on A's DWN): status=%d, count=%d", nbqs.Code, len(nodeBMembers))
-		for i, m := range nodeBMembers {
-			t.Logf("    [%d]: id=%s, recipient=%s, contextId=%s", i, m.ID, m.Recipient, m.ContextID)
-		}
-	}
-
-	// Node B registers its nodeInfo (encrypted) using its own member role.
-	// Note: Node B can write its own nodeInfo because the protocol allows
-	// "role": "network/member" to ["create", "update", "read"] on nodeInfo.
-	wgKeysB, err := mesh.WireGuardKeyFromIdentity(nodeB.DID.EncryptionPrivateKey)
-	if err != nil {
-		t.Fatalf("deriving WG keys for node B: %v", err)
-	}
-	meshIPB, err := mesh.AllocateMeshIP(meshCIDR, nodeB.DID.URI)
-	if err != nil {
-		t.Fatalf("allocating mesh IP for node B: %v", err)
-	}
-
-	regB, err := mesh.RegisterNode(ctx, mesh.RegisterNodeParams{
-		AnchorEndpoint:       endpoint,
-		AnchorDID:            nodeA.DID.URI,
-		NetworkRecordID:      networkRecordID,
-		SelfDID:              nodeB.DID.URI,
-		Signer:               nodeB.Signer,
-		EncryptionKeyManager: nodeB.EncMgr,
-		WireGuardPubKey:      wgKeysB.PublicKeyBase64(),
-		MeshIP:               meshIPB.String(),
-		Hostname:             "node-b",
-		ProtocolRole:         "network/member",
-	})
-	if err != nil {
-		t.Fatalf("Node B nodeInfo registration failed: %v", err)
-	}
-	t.Logf("  Node B registered: IP=%s, nodeInfo=%s", meshIPB, regB.NodeInfoRecordID)
-
 	// ---- Step 7: Verify mesh IPs are different ----
 	t.Log("Step 7: Verifying mesh IP uniqueness")
 	if meshIPA.String() == meshIPB.String() {
@@ -318,55 +230,35 @@ func TestE2ENetworkCreateJoinQueryDecrypt(t *testing.T) {
 	}
 	t.Logf("  Node A: %s, Node B: %s — unique", meshIPA, meshIPB)
 
-	// ---- Step 8: Query member records from the anchor DWN ----
-	t.Log("Step 8: Querying member records from anchor DWN")
-	members, queryStatus, err := nodeA.API.Query(ctx, nodeA.DID.URI, dwn.QueryParams{
+	// ---- Step 8: Query node records from the anchor DWN ----
+	t.Log("Step 8: Querying node records from anchor DWN")
+	nodes, queryStatus, err := nodeA.API.Query(ctx, nodeA.DID.URI, dwn.QueryParams{
 		Filter: dwn.RecordsFilter{
 			Protocol:     "https://enbox.org/protocols/wireguard-mesh",
-			ProtocolPath: "network/member",
+			ProtocolPath: "network/node",
 			ParentID:     networkRecordID,
 		},
 		DateSort: "createdAscending",
 	}, "")
 	if err != nil {
-		t.Fatalf("querying members: %v", err)
+		t.Fatalf("querying nodes: %v", err)
 	}
 	if queryStatus.Code != 200 {
-		t.Fatalf("member query: %d %s", queryStatus.Code, queryStatus.Detail)
+		t.Fatalf("node query: %d %s", queryStatus.Code, queryStatus.Detail)
 	}
-	t.Logf("  Found %d member records", len(members))
-	if len(members) < 2 {
-		t.Fatalf("expected at least 2 member records (node A admin + node B member), got %d", len(members))
-	}
-
-	// ---- Step 9: Query nodeInfo records from the anchor DWN ----
-	t.Log("Step 9: Querying nodeInfo records from anchor DWN")
-	nodeInfos, niStatus, err := nodeA.API.Query(ctx, nodeA.DID.URI, dwn.QueryParams{
-		Filter: dwn.RecordsFilter{
-			Protocol:     "https://enbox.org/protocols/wireguard-mesh",
-			ProtocolPath: "network/nodeInfo",
-			ParentID:     networkRecordID,
-		},
-	}, "")
-	if err != nil {
-		t.Fatalf("querying nodeInfos: %v", err)
-	}
-	if niStatus.Code != 200 {
-		t.Fatalf("nodeInfo query: %d %s", niStatus.Code, niStatus.Detail)
-	}
-	t.Logf("  Found %d nodeInfo records", len(nodeInfos))
-	if len(nodeInfos) < 2 {
-		t.Fatalf("expected at least 2 nodeInfo records (node A + node B), got %d", len(nodeInfos))
+	t.Logf("  Found %d node records", len(nodes))
+	if len(nodes) < 2 {
+		t.Fatalf("expected at least 2 node records (node A + node B), got %d", len(nodes))
 	}
 
-	// ---- Step 10: Node A writes an encrypted endpoint record ----
-	t.Log("Step 10: Node A writes encrypted endpoint record")
-	if regA != nil && regA.NodeInfoRecordID != "" {
+	// ---- Step 9: Node A writes an encrypted endpoint record ----
+	t.Log("Step 9: Node A writes encrypted endpoint record")
+	if regA != nil && regA.NodeRecordID != "" {
 		err = mesh.WriteEndpoint(ctx, mesh.WriteEndpointParams{
 			AnchorEndpoint:       endpoint,
 			AnchorDID:            nodeA.DID.URI,
 			NetworkRecordID:      networkRecordID,
-			NodeInfoRecordID:     regA.NodeInfoRecordID,
+			NodeRecordID:         regA.NodeRecordID,
 			Signer:               nodeA.Signer,
 			EncryptionKeyManager: nodeA.EncMgr,
 			PublicEndpoints: []mesh.PublicEndpoint{
@@ -382,13 +274,12 @@ func TestE2ENetworkCreateJoinQueryDecrypt(t *testing.T) {
 		}
 	}
 
-	// ---- Step 11: Verify local encryption round-trip ----
-	// Build a message locally and verify we can encrypt/decrypt it.
-	t.Log("Step 11: Verifying local encryption round-trip")
+	// ---- Step 10: Verify local encryption round-trip ----
+	t.Log("Step 10: Verifying local encryption round-trip")
 	testPlaintext := []byte(`{"test":"e2e encryption verification","timestamp":"2026-02-24T00:00:00Z"}`)
-	recipients, err := nodeA.EncMgr.DeriveWriteEncryption("network/nodeInfo")
+	recipients, err := nodeA.EncMgr.DeriveWriteEncryption("network/node")
 	if err != nil {
-		t.Fatalf("deriving nodeInfo encryption: %v", err)
+		t.Fatalf("deriving node encryption: %v", err)
 	}
 
 	ciphertext, enc, err := dwncrypto.EncryptData(testPlaintext, recipients)
@@ -396,14 +287,12 @@ func TestE2ENetworkCreateJoinQueryDecrypt(t *testing.T) {
 		t.Fatalf("EncryptData: %v", err)
 	}
 
-	// Ciphertext should be different from plaintext.
 	if string(ciphertext) == string(testPlaintext) {
 		t.Fatal("SECURITY: ciphertext matches plaintext!")
 	}
 	t.Logf("  Encrypted %d bytes → %d bytes ciphertext", len(testPlaintext), len(ciphertext))
 
-	// Node A can decrypt using the same key path.
-	decryptKey, err := nodeA.EncMgr.DeriveDecryptionKey("network/nodeInfo")
+	decryptKey, err := nodeA.EncMgr.DeriveDecryptionKey("network/node")
 	if err != nil {
 		t.Fatalf("DeriveDecryptionKey: %v", err)
 	}
@@ -418,44 +307,42 @@ func TestE2ENetworkCreateJoinQueryDecrypt(t *testing.T) {
 	}
 	t.Logf("  Decryption verified: %q", string(decrypted))
 
-	// ---- Step 12: Verify hierarchical key property ----
+	// ---- Step 11: Verify hierarchical key property ----
 	// A key derived at "network" should be able to decrypt records at
-	// "network/member" (parent can decrypt children).
-	t.Log("Step 12: Verifying hierarchical key property")
-	memberPlaintext := []byte(`{"joinedAt":"2026-02-24","label":"test-member"}`)
-	memberRecipients2, err := nodeA.EncMgr.DeriveWriteEncryption("network/member")
+	// "network/node" (parent can decrypt children).
+	t.Log("Step 11: Verifying hierarchical key property")
+	nodePlaintext := []byte(`{"meshIP":"10.200.0.5","addedAt":"2026-02-24","hostname":"test-node"}`)
+	nodeRecipients, err := nodeA.EncMgr.DeriveWriteEncryption("network/node")
 	if err != nil {
-		t.Fatalf("deriving member encryption: %v", err)
+		t.Fatalf("deriving node encryption: %v", err)
 	}
 
-	memberCT, memberEnc, err := dwncrypto.EncryptData(memberPlaintext, memberRecipients2)
+	nodeCT, nodeEnc, err := dwncrypto.EncryptData(nodePlaintext, nodeRecipients)
 	if err != nil {
-		t.Fatalf("encrypting member data: %v", err)
+		t.Fatalf("encrypting node data: %v", err)
 	}
 
-	// Decrypt using the "network/member" path (direct match).
-	memberDecryptKey, err := nodeA.EncMgr.DeriveDecryptionKey("network/member")
+	nodeDecryptKey, err := nodeA.EncMgr.DeriveDecryptionKey("network/node")
 	if err != nil {
-		t.Fatalf("DeriveDecryptionKey for member: %v", err)
+		t.Fatalf("DeriveDecryptionKey for node: %v", err)
 	}
 
-	memberDecrypted, err := dwncrypto.DecryptData(memberCT, memberEnc, memberDecryptKey, nodeA.EncMgr.RootKeyID)
+	nodeDecrypted, err := dwncrypto.DecryptData(nodeCT, nodeEnc, nodeDecryptKey, nodeA.EncMgr.RootKeyID)
 	if err != nil {
-		t.Fatalf("DecryptData for member: %v", err)
+		t.Fatalf("DecryptData for node: %v", err)
 	}
 
-	if string(memberDecrypted) != string(memberPlaintext) {
-		t.Fatalf("member decrypted mismatch: got %q, want %q", memberDecrypted, memberPlaintext)
+	if string(nodeDecrypted) != string(nodePlaintext) {
+		t.Fatalf("node decrypted mismatch: got %q, want %q", nodeDecrypted, nodePlaintext)
 	}
-	t.Logf("  Member decryption verified: %q", string(memberDecrypted))
+	t.Logf("  Node decryption verified: %q", string(nodeDecrypted))
 
 	// ---- Summary ----
 	t.Log("=== E2E Test Summary ===")
 	t.Logf("  Network: e2e-test-network (%s)", networkRecordID)
 	t.Logf("  Node A: %s → %s", nodeA.DID.URI[:30]+"...", meshIPA)
 	t.Logf("  Node B: %s → %s", nodeB.DID.URI[:30]+"...", meshIPB)
-	t.Logf("  Members found: %d", len(members))
-	t.Logf("  NodeInfos found: %d", len(nodeInfos))
+	t.Logf("  Nodes found: %d", len(nodes))
 	t.Log("  Encryption: verified (HKDF → ECDH-ES+A256KW → A256GCM)")
 	t.Log("  Hierarchical keys: verified")
 }

--- a/internal/mesh/register.go
+++ b/internal/mesh/register.go
@@ -17,16 +17,14 @@ import (
 const (
 	protocolMesh = "https://enbox.org/protocols/wireguard-mesh"
 
-	schemaNodeInfo = "https://enbox.org/schemas/wireguard-mesh/node-info"
+	schemaNode     = "https://enbox.org/schemas/wireguard-mesh/node"
 	schemaEndpoint = "https://enbox.org/schemas/wireguard-mesh/endpoint"
-	schemaMember   = "https://enbox.org/schemas/wireguard-mesh/member"
 )
 
 // NodeRegistration holds the result of registering a node on DWN.
 type NodeRegistration struct {
-	NodeInfoRecordID string
-	MeshIP           string
-	WireGuardPubKey  string
+	NodeRecordID string
+	MeshIP       string
 
 	// DateCreated is the dateCreated timestamp from the initial write.
 	// Store this and pass it back for subsequent updates so the immutable
@@ -45,7 +43,7 @@ type RegisterNodeParams struct {
 	// NetworkRecordID is the root network record ID (used as contextId).
 	NetworkRecordID string
 
-	// SelfDID is this node's DID URI.
+	// SelfDID is this node's DID URI (did:jwk).
 	SelfDID string
 
 	// Signer signs DWN messages.
@@ -54,12 +52,9 @@ type RegisterNodeParams struct {
 	// EncryptionKeyManager derives encryption keys for protocol paths.
 	EncryptionKeyManager *dwncrypto.EncryptionKeyManager
 
-	// WireGuardPubKey is this node's WireGuard public key (base64).
-	WireGuardPubKey string
-
 	// DiscoKey is this node's disco public key (base64). The disco key
 	// enables DERP relay and direct connection upgrades between peers.
-	// Optional: if empty, the disco key is omitted from the nodeInfo record.
+	// Optional: if empty, the disco key is omitted from the node record.
 	DiscoKey string
 
 	// MeshIP is this node's allocated mesh IP.
@@ -68,16 +63,19 @@ type RegisterNodeParams struct {
 	// Hostname is the machine hostname. Auto-detected if empty.
 	Hostname string
 
-	// ExistingNodeInfoRecordID is set when updating an existing nodeInfo.
+	// Label is a human-readable label for this node.
+	Label string
+
+	// ExistingNodeRecordID is set when updating an existing node record.
 	// Leave empty for initial registration.
-	ExistingNodeInfoRecordID string
+	ExistingNodeRecordID string
 
 	// ExistingDateCreated is the dateCreated timestamp from the initial write.
-	// Required when ExistingNodeInfoRecordID is set (updates), because
+	// Required when ExistingNodeRecordID is set (updates), because
 	// dateCreated is immutable across record updates.
 	ExistingDateCreated string
 
-	// ProtocolRole is the role to invoke for authorization (e.g., "network/member").
+	// ProtocolRole is the role to invoke for authorization (e.g., "network/node").
 	// Required when writing to another party's DWN as a non-owner.
 	ProtocolRole string
 
@@ -90,19 +88,18 @@ type RegisterNodeParams struct {
 
 	// Squash indicates this is a squash (snapshot) write. When true,
 	// the server atomically creates this new record and deletes all
-	// older sibling nodeInfo records at the same protocol path within
+	// older sibling node records at the same protocol path within
 	// the same parent context. Use this when re-registering to replace
-	// a previous nodeInfo record. Requires $squash: true on the
-	// nodeInfo protocol rule set.
+	// a previous node record.
 	Squash bool
 }
 
-// RegisterNode writes or updates the node's nodeInfo record (encrypted) on
-// the anchor DWN.
+// RegisterNode writes or updates the node record (encrypted) on the anchor DWN.
 //
-// It creates a nodeInfo record under the network context with the node's
-// WireGuard public key, mesh IP, hostname, and OS. The record is encrypted
-// using the protocol path derivation scheme at "network/nodeInfo".
+// The node record is a merged record containing the node's mesh IP, hostname,
+// OS, and capabilities. The WireGuard public key is NOT stored — peers derive
+// it from the node's did:jwk identity. The recipient field is set to the node's
+// DID, which assigns the network/node role for authorization.
 func RegisterNode(ctx context.Context, params RegisterNodeParams) (*NodeRegistration, error) {
 	if params.EncryptionKeyManager == nil {
 		return nil, fmt.Errorf("EncryptionKeyManager is required for encrypted writes")
@@ -113,18 +110,18 @@ func RegisterNode(ctx context.Context, params RegisterNodeParams) (*NodeRegistra
 		hostname, _ = os.Hostname()
 	}
 
-	nodeInfo := map[string]any{
-		"wireguardPublicKey": params.WireGuardPubKey,
-		"meshIP":             params.MeshIP,
-		"hostname":           hostname,
-		"os":                 runtime.GOOS,
+	nodeData := map[string]any{
+		"meshIP":   params.MeshIP,
+		"hostname": hostname,
+		"os":       runtime.GOOS,
+		"addedAt":  time.Now().UTC().Format(time.RFC3339),
 	}
-	if params.DiscoKey != "" {
-		nodeInfo["discoKey"] = params.DiscoKey
+	if params.Label != "" {
+		nodeData["label"] = params.Label
 	}
-	nodeInfoData, err := json.Marshal(nodeInfo)
+	nodeDataBytes, err := json.Marshal(nodeData)
 	if err != nil {
-		return nil, fmt.Errorf("marshaling nodeInfo: %w", err)
+		return nil, fmt.Errorf("marshaling node data: %w", err)
 	}
 
 	// Derive encryption recipients.
@@ -135,12 +132,12 @@ func RegisterNode(ctx context.Context, params RegisterNodeParams) (*NodeRegistra
 	if params.UseContextEncryption {
 		recipients, err = params.EncryptionKeyManager.DeriveContextWriteEncryption(params.NetworkRecordID)
 		if err != nil {
-			return nil, fmt.Errorf("deriving nodeInfo context encryption: %w", err)
+			return nil, fmt.Errorf("deriving node context encryption: %w", err)
 		}
 	} else {
-		recipients, err = params.EncryptionKeyManager.DeriveWriteEncryption("network/nodeInfo")
+		recipients, err = params.EncryptionKeyManager.DeriveWriteEncryption("network/node")
 		if err != nil {
-			return nil, fmt.Errorf("deriving nodeInfo encryption: %w", err)
+			return nil, fmt.Errorf("deriving node encryption: %w", err)
 		}
 	}
 
@@ -149,34 +146,29 @@ func RegisterNode(ctx context.Context, params RegisterNodeParams) (*NodeRegistra
 
 	writeParams := dwn.WriteParams{
 		Protocol:             protocolMesh,
-		ProtocolPath:         "network/nodeInfo",
-		Schema:               schemaNodeInfo,
+		ProtocolPath:         "network/node",
+		Schema:               schemaNode,
 		DataFormat:           "application/json",
-		Recipient:            params.AnchorDID,
+		Recipient:            params.SelfDID,
 		ParentContextID:     params.NetworkRecordID,
-		Data:                 nodeInfoData,
-		Tags: map[string]any{
-			"did":      params.SelfDID,
-			"hostname": hostname,
-			"os":       runtime.GOOS,
-		},
+		Data:                 nodeDataBytes,
 		ProtocolRole:         params.ProtocolRole,
 		EncryptionRecipients: recipients,
 		Squash:               params.Squash,
 	}
 
 	// If updating, set the existing record ID and preserve dateCreated.
-	if params.ExistingNodeInfoRecordID != "" {
-		writeParams.RecordID = params.ExistingNodeInfoRecordID
+	if params.ExistingNodeRecordID != "" {
+		writeParams.RecordID = params.ExistingNodeRecordID
 		writeParams.DateCreated = params.ExistingDateCreated
 	}
 
 	record, status, err := api.Write(ctx, params.AnchorDID, writeParams)
 	if err != nil {
-		return nil, fmt.Errorf("writing nodeInfo: %w", err)
+		return nil, fmt.Errorf("writing node record: %w", err)
 	}
 	if status.Code >= 300 {
-		return nil, fmt.Errorf("nodeInfo write failed: %d %s", status.Code, status.Detail)
+		return nil, fmt.Errorf("node write failed: %d %s", status.Code, status.Detail)
 	}
 
 	// Extract dateCreated from the record — callers need this for future updates.
@@ -186,16 +178,15 @@ func RegisterNode(ctx context.Context, params RegisterNodeParams) (*NodeRegistra
 	}
 
 	return &NodeRegistration{
-		NodeInfoRecordID: record.ID,
-		MeshIP:           params.MeshIP,
-		WireGuardPubKey:  params.WireGuardPubKey,
-		DateCreated:      dateCreated,
+		NodeRecordID: record.ID,
+		MeshIP:       params.MeshIP,
+		DateCreated:  dateCreated,
 	}, nil
 }
 
 // WriteEndpoint writes or updates the node's endpoint record (encrypted).
 //
-// The endpoint record is a child of the nodeInfo record and contains the
+// The endpoint record is a child of the node record and contains the
 // node's network-reachable endpoints (public IPs, local IPs, NAT type).
 func WriteEndpoint(ctx context.Context, params WriteEndpointParams) error {
 	if params.EncryptionKeyManager == nil {
@@ -224,7 +215,7 @@ func WriteEndpoint(ctx context.Context, params WriteEndpointParams) error {
 			return fmt.Errorf("deriving endpoint context encryption: %w", err)
 		}
 	} else {
-		recipients, err = params.EncryptionKeyManager.DeriveWriteEncryption("network/nodeInfo/endpoint")
+		recipients, err = params.EncryptionKeyManager.DeriveWriteEncryption("network/node/endpoint")
 		if err != nil {
 			return fmt.Errorf("deriving endpoint encryption: %w", err)
 		}
@@ -233,15 +224,15 @@ func WriteEndpoint(ctx context.Context, params WriteEndpointParams) error {
 	agent := dwn.NewSimpleAgent(params.AnchorEndpoint, params.Signer)
 	api := dwn.NewDwnAPI(agent)
 
-	// The endpoint's parent is nodeInfo, whose contextId is networkRecordID/nodeInfoRecordID.
-	nodeInfoContextID := params.NetworkRecordID + "/" + params.NodeInfoRecordID
+	// The endpoint's parent is the node record, whose contextId is networkRecordID/nodeRecordID.
+	nodeContextID := params.NetworkRecordID + "/" + params.NodeRecordID
 	_, status, err := api.Write(ctx, params.AnchorDID, dwn.WriteParams{
 		Protocol:             protocolMesh,
-		ProtocolPath:         "network/nodeInfo/endpoint",
+		ProtocolPath:         "network/node/endpoint",
 		Schema:               schemaEndpoint,
 		DataFormat:           "application/json",
 		Recipient:            params.AnchorDID,
-		ParentContextID:     nodeInfoContextID,
+		ParentContextID:     nodeContextID,
 		Data:                 endpointData,
 		ProtocolRole:         params.ProtocolRole,
 		EncryptionRecipients: recipients,
@@ -262,7 +253,7 @@ type WriteEndpointParams struct {
 	AnchorEndpoint       string
 	AnchorDID            string
 	NetworkRecordID      string
-	NodeInfoRecordID     string
+	NodeRecordID         string
 	Signer               *dwn.Signer
 	EncryptionKeyManager *dwncrypto.EncryptionKeyManager
 	PublicEndpoints      []PublicEndpoint
@@ -290,72 +281,6 @@ type PublicEndpoint struct {
 	Port     int    `json:"port"`
 	Priority int    `json:"priority,omitempty"`
 	Source   string `json:"source,omitempty"`
-}
-
-// CreateMember creates an encrypted member record on the anchor DWN.
-func CreateMember(ctx context.Context, params CreateMemberParams) error {
-	if params.EncryptionKeyManager == nil {
-		return fmt.Errorf("EncryptionKeyManager is required for encrypted writes")
-	}
-
-	memberData, err := json.Marshal(map[string]any{
-		"joinedAt": time.Now().UTC().Format(time.RFC3339),
-		"label":    params.Label,
-	})
-	if err != nil {
-		return fmt.Errorf("marshaling member: %w", err)
-	}
-
-	var recipients []dwncrypto.KeyEncryptionInput
-	if params.UseContextEncryption {
-		recipients, err = params.EncryptionKeyManager.DeriveContextWriteEncryption(params.NetworkRecordID)
-		if err != nil {
-			return fmt.Errorf("deriving member context encryption: %w", err)
-		}
-	} else {
-		recipients, err = params.EncryptionKeyManager.DeriveWriteEncryption("network/member")
-		if err != nil {
-			return fmt.Errorf("deriving member encryption: %w", err)
-		}
-	}
-
-	agent := dwn.NewSimpleAgent(params.AnchorEndpoint, params.Signer)
-	api := dwn.NewDwnAPI(agent)
-
-	_, status, err := api.Write(ctx, params.AnchorDID, dwn.WriteParams{
-		Protocol:             protocolMesh,
-		ProtocolPath:         "network/member",
-		Schema:               schemaMember,
-		DataFormat:           "application/json",
-		Recipient:            params.MemberDID,
-		ParentContextID:     params.NetworkRecordID,
-		Data:                 memberData,
-		Tags:                 map[string]any{"status": "active"},
-		EncryptionRecipients: recipients,
-	})
-	if err != nil {
-		return fmt.Errorf("writing member: %w", err)
-	}
-	if status.Code >= 300 {
-		return fmt.Errorf("member write failed: %d %s", status.Code, status.Detail)
-	}
-
-	return nil
-}
-
-// CreateMemberParams configures a member record creation.
-type CreateMemberParams struct {
-	AnchorEndpoint       string
-	AnchorDID            string
-	NetworkRecordID      string
-	MemberDID            string
-	Label                string
-	Signer               *dwn.Signer
-	EncryptionKeyManager *dwncrypto.EncryptionKeyManager
-
-	// UseContextEncryption enables Protocol Context encryption instead of
-	// Protocol Path encryption. See RegisterNodeParams.UseContextEncryption.
-	UseContextEncryption bool
 }
 
 // DiscoverLocalEndpoints discovers local network endpoints for this node.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -63,12 +63,12 @@ type NetworkState struct {
 	// MeshIP is this node's allocated IP within the mesh.
 	MeshIP string `json:"meshIp,omitempty"`
 
-	// NodeInfoRecordID is the record ID of this node's nodeInfo record.
-	NodeInfoRecordID string `json:"nodeInfoRecordId,omitempty"`
+	// NodeRecordID is the record ID of this node's node record on the anchor DWN.
+	NodeRecordID string `json:"nodeRecordId,omitempty"`
 
-	// NodeInfoDateCreated is the dateCreated timestamp from the initial
-	// nodeInfo write. Required for updates because dateCreated is immutable.
-	NodeInfoDateCreated string `json:"nodeInfoDateCreated,omitempty"`
+	// NodeDateCreated is the dateCreated timestamp from the initial
+	// node record write. Required for updates because dateCreated is immutable.
+	NodeDateCreated string `json:"nodeDateCreated,omitempty"`
 }
 
 const networkFile = "network.json"


### PR DESCRIPTION
## Summary

- Remove `CreateMember()` and `CreateMemberParams` — the new protocol has no separate member records
- Remove `WireGuardPubKey` from `RegisterNodeParams` — peers derive the WG public key from `did:jwk` identity
- Rename `NodeInfoRecordID` → `NodeRecordID` throughout registration, state, engine, and CLI
- Update all protocol paths from `network/member` to `network/node`, remove tags (privacy)
- Update `connectivity_test.go` and `e2e_test.go` for the new node-based API

Net reduction of 269 lines — member+nodeInfo dual-record pattern replaced with a single `node` record.

## Files changed

| File | Changes |
|------|---------|
| `internal/mesh/register.go` | Remove `CreateMember()`, `schemaMember`/`schemaNodeInfo` → `schemaNode`, no `WireGuardPubKey` |
| `internal/state/state.go` | `NodeInfoRecordID` → `NodeRecordID`, `NodeInfoDateCreated` → `NodeDateCreated` |
| `internal/engine/engine.go` | `WriteEndpointParams` field name + protocol role update |
| `internal/engine/connectivity_test.go` | Full rewrite: remove `CreateMember`, member records, tags, `WireGuardPubKey` refs |
| `internal/mesh/e2e_test.go` | Rewrite for node-based registration |
| `cmd/meshd/main.go` | Remove `CreateMember` calls, update all field references |

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./... -count=1 -race` ✅

Closes #49