### PR TITLE
refactor: update engine for did:jwk identity and node protocol

### DIFF
--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -1130,7 +1130,7 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 		Signer:               signer,
 		Resolver:             universalResolver{},
 		EncryptionKeyManager: encMgr,
-		NodeInfoRecordID:     ns.NodeRecordID,
+		NodeRecordID:         ns.NodeRecordID,
 		AutoKeyDelivery:      autoKeyDelivery,
 		UseContextEncryption: useContextEncryption,
 		WireGuardPrivateKey:  wgKeys.PrivateKey,

--- a/internal/engine/autodeliver.go
+++ b/internal/engine/autodeliver.go
@@ -13,13 +13,13 @@ import (
 	"github.com/enboxorg/meshd/protocols"
 )
 
-// AutoKeyDelivery monitors the mesh member list and automatically delivers
-// context keys to new members. This is only active on the anchor node
+// AutoKeyDelivery monitors the mesh node list and automatically delivers
+// context keys to new nodes. This is only active on the anchor node
 // (the network owner who holds the root private key).
 //
-// When the engine polls DWN state and discovers members who don't yet have
+// When the engine polls DWN state and discovers nodes that don't yet have
 // a context key, it delivers one to each of them. This removes the need for
-// the anchor operator to manually run "peer approve" for every new member.
+// the anchor operator to manually run "peer approve" for every new node.
 type AutoKeyDelivery struct {
 	// Endpoint is the DWN server URL for the anchor.
 	Endpoint string
@@ -76,20 +76,20 @@ type AutoKeyDeliveryConfig struct {
 	Logger               *slog.Logger
 }
 
-// OnMembersUpdated should be called after each poll that discovers member DIDs.
-// It checks for members who haven't received a context key yet and delivers
+// OnNodesUpdated should be called after each poll that discovers node DIDs.
+// It checks for nodes that haven't received a context key yet and delivers
 // one to each of them.
 //
-// memberDIDs is the full set of member DIDs from the current mesh state.
+// nodeDIDs is the full set of node DIDs from the current mesh state.
 // It is safe to call concurrently.
-func (a *AutoKeyDelivery) OnMembersUpdated(ctx context.Context, memberDIDs []string) {
+func (a *AutoKeyDelivery) OnNodesUpdated(ctx context.Context, nodeDIDs []string) {
 	if a == nil {
 		return
 	}
 
 	a.mu.Lock()
 	var pending []string
-	for _, did := range memberDIDs {
+	for _, did := range nodeDIDs {
 		if !a.delivered[did] {
 			pending = append(pending, did)
 		}
@@ -132,7 +132,7 @@ func (a *AutoKeyDelivery) OnMembersUpdated(ctx context.Context, memberDIDs []str
 	}
 }
 
-// MarkDelivered marks a member DID as already having received a context key.
+// MarkDelivered marks a node DID as already having received a context key.
 // Use this to seed the delivered set from existing contextKey records.
 func (a *AutoKeyDelivery) MarkDelivered(did string) {
 	if a == nil {
@@ -143,7 +143,7 @@ func (a *AutoKeyDelivery) MarkDelivered(did string) {
 	a.mu.Unlock()
 }
 
-// DeliveredCount returns the number of members with delivered context keys.
+// DeliveredCount returns the number of nodes with delivered context keys.
 func (a *AutoKeyDelivery) DeliveredCount() int {
 	if a == nil {
 		return 0
@@ -153,9 +153,9 @@ func (a *AutoKeyDelivery) DeliveredCount() int {
 	return len(a.delivered)
 }
 
-// PendingDelivery returns the list of member DIDs from the given set that
+// PendingDelivery returns the list of node DIDs from the given set that
 // haven't received a context key yet.
-func (a *AutoKeyDelivery) PendingDelivery(memberDIDs []string) []string {
+func (a *AutoKeyDelivery) PendingDelivery(nodeDIDs []string) []string {
 	if a == nil {
 		return nil
 	}
@@ -163,7 +163,7 @@ func (a *AutoKeyDelivery) PendingDelivery(memberDIDs []string) []string {
 	defer a.mu.Unlock()
 
 	var pending []string
-	for _, did := range memberDIDs {
+	for _, did := range nodeDIDs {
 		if !a.delivered[did] {
 			pending = append(pending, did)
 		}

--- a/internal/engine/convert.go
+++ b/internal/engine/convert.go
@@ -182,7 +182,7 @@ func (c *Converter) convertNode(n *control.Node) (*tailcfg.Node, error) {
 
 	// Parse disco public key. The disco key enables DERP relay and direct
 	// connection upgrades between peers. It is exchanged via DWN
-	// nodeInfo/endpoint records as base64.
+	// node/endpoint records as base64.
 	if n.DiscoKey != "" {
 		dk, err := parseDiscoKey(n.DiscoKey)
 		if err != nil {
@@ -358,7 +358,7 @@ func (c *Converter) convertFilterRules(rules []control.FilterRule) []tailcfg.Fil
 // meshnet's DWNControl polling loop. It is passed to DWNControlConfig.MapResponseFunc.
 //
 // If autoDelivery is non-nil, it is triggered after each successful state
-// load to deliver context keys to any new members.
+// load to deliver context keys to any new nodes.
 func MapResponseFunc(client *control.DWNClient, converter *Converter, autoDelivery *AutoKeyDelivery) func(context.Context) (*netmap.NetworkMap, error) {
 	return func(ctx context.Context) (*netmap.NetworkMap, error) {
 		resp, err := client.LoadState(ctx)
@@ -366,17 +366,17 @@ func MapResponseFunc(client *control.DWNClient, converter *Converter, autoDelive
 			return nil, fmt.Errorf("loading DWN state: %w", err)
 		}
 
-		// If auto key delivery is active, extract member DIDs from
-		// the response and deliver context keys to any new members.
+		// If auto key delivery is active, extract node DIDs from
+		// the response and deliver context keys to any new nodes.
 		if autoDelivery != nil && resp != nil {
-			var memberDIDs []string
+			var nodeDIDs []string
 			if resp.Node != nil {
-				memberDIDs = append(memberDIDs, resp.Node.DID)
+				nodeDIDs = append(nodeDIDs, resp.Node.DID)
 			}
 			for _, p := range resp.Peers {
-				memberDIDs = append(memberDIDs, p.DID)
+				nodeDIDs = append(nodeDIDs, p.DID)
 			}
-			autoDelivery.OnMembersUpdated(ctx, memberDIDs)
+			autoDelivery.OnNodesUpdated(ctx, nodeDIDs)
 		}
 
 		return converter.Convert(resp)

--- a/internal/engine/dwncontrol.go
+++ b/internal/engine/dwncontrol.go
@@ -395,7 +395,7 @@ func (cc *DWNControl) SetHostinfo(hi *tailcfg.Hostinfo) {
 	cc.mu.Lock()
 	cc.hostinfo = hi
 	cc.mu.Unlock()
-	// TODO: publish hostinfo to DWN as a nodeInfo record update.
+	// TODO: publish hostinfo to DWN as a node record update.
 }
 
 func (cc *DWNControl) SetNetInfo(ni *tailcfg.NetInfo) {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -102,11 +102,11 @@ type Config struct {
 	// protocol records. If nil, encrypted records cannot be read.
 	EncryptionKeyManager *dwncrypto.EncryptionKeyManager
 
-	// NodeInfoRecordID is this node's nodeInfo record ID on the anchor DWN.
+	// NodeRecordID is this node's node record ID on the anchor DWN.
 	// Required for writing endpoint updates back to DWN.
-	NodeInfoRecordID string
+	NodeRecordID string
 
-	// AutoKeyDelivery enables automatic context key delivery to new members.
+	// AutoKeyDelivery enables automatic context key delivery to new nodes.
 	// Only active when this node is the anchor and has the root private key.
 	// If nil, auto delivery is disabled.
 	AutoKeyDelivery *AutoKeyDelivery
@@ -368,7 +368,7 @@ func New(cfg Config) (*Engine, error) {
 	// Wire the DWN control client into the LocalBackend.
 	// MapResponseFunc closes over our DWNClient and Converter to produce
 	// NetworkMaps from DWN records. If auto key delivery is configured,
-	// it also triggers key delivery to new members after each poll.
+	// it also triggers key delivery to new nodes after each poll.
 	mapFn := MapResponseFunc(dwnClient, converter, cfg.AutoKeyDelivery)
 	dwnControlConfig := &DWNControlConfig{
 		MapResponseFunc: mapFn,
@@ -396,7 +396,7 @@ func New(cfg Config) (*Engine, error) {
 
 	// Wire endpoint writeback: when magicsock discovers STUN endpoints,
 	// publish them to the anchor DWN so peers can find us.
-	if cfg.NodeInfoRecordID != "" && cfg.EncryptionKeyManager != nil {
+	if cfg.NodeRecordID != "" && cfg.EncryptionKeyManager != nil {
 		dwnControlConfig.EndpointUpdateFunc = makeEndpointUpdateFunc(cfg, l)
 	}
 	lb.SetControlClientGetterForTesting(
@@ -608,7 +608,7 @@ func makeEndpointUpdateFunc(cfg Config, l *slog.Logger) func(context.Context, []
 			AnchorEndpoint:       cfg.AnchorEndpoint,
 			AnchorDID:            cfg.AnchorTenant,
 			NetworkRecordID:      cfg.NetworkRecordID,
-			NodeRecordID:         cfg.NodeInfoRecordID,
+			NodeRecordID:         cfg.NodeRecordID,
 			Signer:               cfg.Signer,
 			EncryptionKeyManager: cfg.EncryptionKeyManager,
 			PublicEndpoints:      publicEPs,

--- a/internal/engine/subscribe.go
+++ b/internal/engine/subscribe.go
@@ -2,7 +2,7 @@
 //
 // Instead of polling every 30 seconds, the SubscriptionWatcher opens a
 // WebSocket subscription to the anchor DWN and triggers an immediate
-// re-poll whenever mesh records change (nodeInfo, endpoints, members).
+// re-poll whenever mesh records change (nodes, endpoints).
 //
 // The watcher subscribes to all records under the wireguard-mesh protocol
 // within the network's contextId. When an event arrives, it calls
@@ -118,7 +118,7 @@ func (w *SubscriptionWatcher) Start(ctx context.Context) error {
 	w.manager = dwn.NewSubscriptionManager(w.endpoint, w.logger)
 
 	// Subscribe to all records under the wireguard-mesh protocol for
-	// this network. This catches nodeInfo, endpoint, member, and relay
+	// this network. This catches node, endpoint, and relay
 	// record changes in a single subscription.
 	filter := dwn.RecordsFilter{
 		Protocol:  "https://enbox.org/protocols/wireguard-mesh",


### PR DESCRIPTION
## Summary

- Rename `Config.NodeInfoRecordID` → `Config.NodeRecordID` (engine config field + all usages in `cmd/meshd/main.go`)
- Rename `AutoKeyDelivery.OnMembersUpdated()` → `OnNodesUpdated()` to match node-based protocol
- Update all comments across engine layer: `nodeInfo` → `node`, `member` → `node`
- No behavioral changes — pure terminology alignment with the node-based protocol from #56-#58

## Files changed

| File | Changes |
|------|---------|
| `internal/engine/engine.go` | `NodeInfoRecordID` → `NodeRecordID` field + comment + 2 usages |
| `internal/engine/autodeliver.go` | `OnMembersUpdated` → `OnNodesUpdated`, updated all comments |
| `internal/engine/convert.go` | `memberDIDs` → `nodeDIDs`, updated comments |
| `internal/engine/dwncontrol.go` | Comment: `nodeInfo` → `node` |
| `internal/engine/subscribe.go` | Comments: `nodeInfo`/`member` → `node` |
| `cmd/meshd/main.go` | `NodeInfoRecordID` → `NodeRecordID` in engine Config |

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./... -count=1 -race` ✅

Closes #50