### PR TITLE
chore: update test fixtures for did:jwk and node protocol

### DIFF
--- a/internal/dwn/agent.go
+++ b/internal/dwn/agent.go
@@ -126,7 +126,7 @@ type WriteParams struct {
 	ParentContextID string
 
 	// ProtocolRole is the Protocol Path of a role to invoke for
-	// role-based authorization (e.g., "network/member"). Leave empty
+	// role-based authorization (e.g., "network/node"). Leave empty
 	// for owner or actor-based writes.
 	ProtocolRole string
 

--- a/internal/dwn/crypto/crypto_test.go
+++ b/internal/dwn/crypto/crypto_test.go
@@ -1496,21 +1496,17 @@ func TestInjectEncryptionDirectives(t *testing.T) {
 		"published": true,
 		"types": {
 			"network": {"schema": "https://example.com/schemas/network", "dataFormats": ["application/json"]},
-			"member": {"schema": "https://example.com/schemas/member", "dataFormats": ["application/json"], "encryptionRequired": true},
-			"nodeInfo": {"schema": "https://example.com/schemas/node-info", "dataFormats": ["application/json"], "encryptionRequired": true},
+			"node": {"schema": "https://example.com/schemas/node", "dataFormats": ["application/json"], "encryptionRequired": true},
 			"endpoint": {"schema": "https://example.com/schemas/endpoint", "dataFormats": ["application/json"], "encryptionRequired": true}
 		},
 		"structure": {
 			"network": {
 				"$actions": [{"who": "anyone", "can": ["read"]}],
-				"member": {
+				"node": {
 					"$role": true,
-					"$actions": [{"role": "network/member", "can": ["read"]}]
-				},
-				"nodeInfo": {
-					"$actions": [{"role": "network/member", "can": ["create", "read"]}],
+					"$actions": [{"role": "network/node", "can": ["read"]}],
 					"endpoint": {
-						"$actions": [{"role": "network/member", "can": ["read"]}]
+						"$actions": [{"role": "network/node", "can": ["read"]}]
 					}
 				}
 			}
@@ -1548,46 +1544,35 @@ func TestInjectEncryptionDirectives(t *testing.T) {
 		t.Fatal("network publicKeyJwk.x is empty")
 	}
 
-	// member should have $encryption.
-	member := network["member"].(map[string]any)
-	memberEnc, ok := member["$encryption"].(map[string]any)
+	// node should have $encryption.
+	node := network["node"].(map[string]any)
+	nodeEnc, ok := node["$encryption"].(map[string]any)
 	if !ok {
-		t.Fatal("member missing $encryption")
+		t.Fatal("node missing $encryption")
 	}
-	memberPubJwk := memberEnc["publicKeyJwk"].(map[string]any)
-	memberPubX := memberPubJwk["x"].(string)
-	if memberPubX == "" || memberPubX == networkPubX {
-		t.Fatalf("member publicKeyJwk.x should differ from network: member=%s, network=%s", memberPubX, networkPubX)
+	nodePubJwk := nodeEnc["publicKeyJwk"].(map[string]any)
+	nodePubX := nodePubJwk["x"].(string)
+	if nodePubX == "" || nodePubX == networkPubX {
+		t.Fatalf("node publicKeyJwk.x should differ from network: node=%s, network=%s", nodePubX, networkPubX)
 	}
 
-	// nodeInfo should have $encryption.
-	nodeInfo := network["nodeInfo"].(map[string]any)
-	nodeInfoEnc, ok := nodeInfo["$encryption"].(map[string]any)
-	if !ok {
-		t.Fatal("nodeInfo missing $encryption")
-	}
-	nodeInfoPubX := nodeInfoEnc["publicKeyJwk"].(map[string]any)["x"].(string)
-	if nodeInfoPubX == "" || nodeInfoPubX == networkPubX || nodeInfoPubX == memberPubX {
-		t.Fatal("nodeInfo publicKeyJwk.x should be unique")
-	}
-
-	// endpoint (child of nodeInfo) should have $encryption.
-	endpoint := nodeInfo["endpoint"].(map[string]any)
+	// endpoint (child of node) should have $encryption.
+	endpoint := node["endpoint"].(map[string]any)
 	endpointEnc, ok := endpoint["$encryption"].(map[string]any)
 	if !ok {
 		t.Fatal("endpoint missing $encryption")
 	}
 	endpointPubX := endpointEnc["publicKeyJwk"].(map[string]any)["x"].(string)
-	if endpointPubX == "" || endpointPubX == nodeInfoPubX {
-		t.Fatal("endpoint publicKeyJwk.x should differ from nodeInfo")
+	if endpointPubX == "" || endpointPubX == nodePubX {
+		t.Fatal("endpoint publicKeyJwk.x should differ from node")
 	}
 
 	// $actions should be preserved.
 	if _, ok := network["$actions"]; !ok {
 		t.Fatal("network.$actions was lost")
 	}
-	if _, ok := member["$role"]; !ok {
-		t.Fatal("member.$role was lost")
+	if _, ok := node["$role"]; !ok {
+		t.Fatal("node.$role was lost")
 	}
 }
 
@@ -1674,8 +1659,8 @@ func TestEncryptionKeyManager_DeriveWriteEncryption(t *testing.T) {
 		path string
 	}{
 		"root level": {path: "network"},
-		"child level": {path: "network/member"},
-		"deep level": {path: "network/nodeInfo/endpoint"},
+		"child level": {path: "network/node"},
+		"deep level": {path: "network/node/endpoint"},
 	}
 
 	for name, tc := range tests {
@@ -1719,12 +1704,11 @@ func TestEncryptionKeyManager_RoundTrip(t *testing.T) {
 
 	paths := []string{
 		"network",
-		"network/member",
-		"network/nodeInfo",
-		"network/nodeInfo/endpoint",
-		"network/admin",
+		"network/node",
+		"network/node/endpoint",
 		"network/aclPolicy",
 		"network/relay",
+		"network/preAuthKey",
 	}
 
 	for _, path := range paths {
@@ -1841,8 +1825,8 @@ func TestSplitProtocolPath(t *testing.T) {
 		expected []string
 	}{
 		"single segment": {input: "network", expected: []string{"network"}},
-		"two segments": {input: "network/member", expected: []string{"network", "member"}},
-		"three segments": {input: "network/nodeInfo/endpoint", expected: []string{"network", "nodeInfo", "endpoint"}},
+		"two segments": {input: "network/node", expected: []string{"network", "node"}},
+		"three segments": {input: "network/node/endpoint", expected: []string{"network", "node", "endpoint"}},
 		"empty": {input: "", expected: nil},
 	}
 

--- a/internal/dwn/crypto/protocol.go
+++ b/internal/dwn/crypto/protocol.go
@@ -162,8 +162,8 @@ func (m *EncryptionKeyManager) IsOwner() bool {
 // DeriveWriteEncryption derives the encryption inputs needed for a RecordsWrite
 // at the given protocol path.
 //
-// The protocolPath is slash-delimited (e.g., "network/member"). This method:
-//  1. Builds the full derivation path: ["protocolPath", protocolURI, "network", "member"]
+// The protocolPath is slash-delimited (e.g., "network/node"). This method:
+//  1. Builds the full derivation path: ["protocolPath", protocolURI, "network", "node"]
 //  2. Derives the private key and public key at that path level
 //  3. Returns a KeyEncryptionInput suitable for passing to BuildRecordsWrite
 //
@@ -271,7 +271,7 @@ func (m *EncryptionKeyManager) DeriveContextKeyJwk(contextID string) (*DerivedPr
 }
 
 // splitProtocolPath splits a slash-delimited protocol path into segments.
-// e.g., "network/member" -> ["network", "member"]
+// e.g., "network/node" -> ["network", "node"]
 func splitProtocolPath(path string) []string {
 	if path == "" {
 		return nil

--- a/internal/dwn/dwn_test.go
+++ b/internal/dwn/dwn_test.go
@@ -364,8 +364,8 @@ func TestBuildRecordsQuery(t *testing.T) {
 
 	msg, err := BuildRecordsQuery(s, RecordsFilter{
 		Protocol:     "https://enbox.org/protocols/wireguard-mesh",
-		ProtocolPath: "network/member",
-	}, "createdAscending", nil, "network/member")
+		ProtocolPath: "network/node",
+	}, "createdAscending", nil, "network/node")
 	if err != nil {
 		t.Fatalf("BuildRecordsQuery: %v", err)
 	}

--- a/internal/dwn/dwnapi.go
+++ b/internal/dwn/dwnapi.go
@@ -39,7 +39,7 @@ func (api *DwnAPI) Agent() Agent {
 // has a newly generated ID. For updates, set params.RecordID.
 //
 // To invoke role-based authorization, set params.ProtocolRole to the
-// Protocol Path of the role (e.g., "network/member").
+// Protocol Path of the role (e.g., "network/node").
 func (api *DwnAPI) Write(ctx context.Context, target string, params WriteParams) (*Record, *Status, error) {
 	resp, err := api.agent.SendDwnRequest(ctx, DwnRequest{
 		Target:       target,

--- a/internal/dwn/record_test.go
+++ b/internal/dwn/record_test.go
@@ -161,8 +161,8 @@ func TestRecordFromEntry(t *testing.T) {
 			"interface": "Records",
 			"method": "Write",
 			"protocol": "https://example.com/mesh",
-			"protocolPath": "network/member",
-			"schema": "https://example.com/schemas/member",
+			"protocolPath": "network/node",
+			"schema": "https://example.com/schemas/node",
 			"dataFormat": "application/json",
 			"dataCid": "bafy123",
 			"dataSize": 42,
@@ -188,10 +188,10 @@ func TestRecordFromEntry(t *testing.T) {
 	if record.Protocol != "https://example.com/mesh" {
 		t.Errorf("Protocol = %q", record.Protocol)
 	}
-	if record.ProtocolPath != "network/member" {
+	if record.ProtocolPath != "network/node" {
 		t.Errorf("ProtocolPath = %q", record.ProtocolPath)
 	}
-	if record.Schema != "https://example.com/schemas/member" {
+	if record.Schema != "https://example.com/schemas/node" {
 		t.Errorf("Schema = %q", record.Schema)
 	}
 	if record.DataSize != 42 {

--- a/schemas/acl-policy.json
+++ b/schemas/acl-policy.json
@@ -22,7 +22,7 @@
         "type": "array",
         "items": { "type": "string" }
       },
-      "description": "Named groups of DIDs, e.g. { 'developers': ['did:dht:abc', 'did:dht:def'] }"
+      "description": "Named groups of DIDs, e.g. { 'developers': ['did:jwk:abc', 'did:jwk:def'] }"
     },
     "tagOwners": {
       "type": "object",

--- a/testdata/interop/generate_vectors.go
+++ b/testdata/interop/generate_vectors.go
@@ -98,7 +98,7 @@ type ProtocolKeyVector struct {
 	RootKey      string   `json:"rootKey"`      // base64url
 	RootKeyID    string   `json:"rootKeyId"`
 	ProtocolURI  string   `json:"protocolUri"`
-	ProtocolPath string   `json:"protocolPath"` // e.g., "network/member"
+	ProtocolPath string   `json:"protocolPath"` // e.g., "network/node"
 	FullPath     []string `json:"fullPath"`     // The complete derivation path
 	DerivedKey   string   `json:"derivedKey"`   // base64url private key
 	PublicKey    string   `json:"publicKey"`     // base64url X25519 public key
@@ -477,7 +477,7 @@ func generateFullJWEVectors() []FullJWEVector {
 		protectedJSON, _ := json.Marshal(protectedHeader)
 		protectedB64 := b64(protectedJSON)
 
-		kid := "did:dht:interoptest123#enc"
+		kid := "did:jwk:interoptest123#0"
 
 		jwe := crypto.Encryption{
 			Protected: protectedB64,
@@ -520,7 +520,7 @@ func generateProtocolKeyVectors() []ProtocolKeyVector {
 	var vectors []ProtocolKeyVector
 
 	rootKey := deterministicKey("protocol-root-key")
-	rootKeyID := "did:dht:interoptest123#enc"
+	rootKeyID := "did:jwk:interoptest123#0"
 	protocolURI := "https://example.com/protocol/wireguard-mesh"
 
 	// Top-level type "network".
@@ -540,34 +540,34 @@ func generateProtocolKeyVectors() []ProtocolKeyVector {
 		})
 	}
 
-	// Nested type "network/member".
+	// Nested type "network/node".
 	{
-		fullPath := crypto.BuildProtocolPathDerivation(protocolURI, "network", "member")
+		fullPath := crypto.BuildProtocolPathDerivation(protocolURI, "network", "node")
 		derived, pub, err := crypto.DerivePrivateKey(rootKey, fullPath)
 		must(err)
 		vectors = append(vectors, ProtocolKeyVector{
-			Description:  "protocol path: network/member",
+			Description:  "protocol path: network/node",
 			RootKey:      b64(rootKey),
 			RootKeyID:    rootKeyID,
 			ProtocolURI:  protocolURI,
-			ProtocolPath: "network/member",
+			ProtocolPath: "network/node",
 			FullPath:     fullPath,
 			DerivedKey:   b64(derived),
 			PublicKey:    b64(pub),
 		})
 	}
 
-	// Deeply nested "network/member/nodeInfo".
+	// Deeply nested "network/node/endpoint".
 	{
-		fullPath := crypto.BuildProtocolPathDerivation(protocolURI, "network", "member", "nodeInfo")
+		fullPath := crypto.BuildProtocolPathDerivation(protocolURI, "network", "node", "endpoint")
 		derived, pub, err := crypto.DerivePrivateKey(rootKey, fullPath)
 		must(err)
 		vectors = append(vectors, ProtocolKeyVector{
-			Description:  "protocol path: network/member/nodeInfo",
+			Description:  "protocol path: network/node/endpoint",
 			RootKey:      b64(rootKey),
 			RootKeyID:    rootKeyID,
 			ProtocolURI:  protocolURI,
-			ProtocolPath: "network/member/nodeInfo",
+			ProtocolPath: "network/node/endpoint",
 			FullPath:     fullPath,
 			DerivedKey:   b64(derived),
 			PublicKey:    b64(pub),

--- a/testdata/interop/vectors.json
+++ b/testdata/interop/vectors.json
@@ -132,7 +132,7 @@
       "description": "full JWE A256GCM with deterministic keys",
       "recipientPrivateKey": "dOT30gYEUHrwV1fEUwqLCgEicWtDZp8g3H4hEeADg9A",
       "recipientPublicKey": "JI6Q3ZLIqNo2s1QrcUBsmsTyKN4F9CypnVdLYVtLax4",
-      "recipientKid": "did:dht:interoptest123#enc",
+      "recipientKid": "did:jwk:interoptest123#0",
       "derivationScheme": "protocolPath",
       "plaintext": "eyJuZXR3b3JrSWQiOiJuZXQtMDAxIiwicm9sZSI6ImFkbWluIn0",
       "cek": "t0klMC50Gzj51Ha5-ST0simRQZoQfs_U8DZMmWIVY3k",
@@ -145,7 +145,7 @@
         "recipients": [
           {
             "header": {
-              "kid": "did:dht:interoptest123#enc",
+              "kid": "did:jwk:interoptest123#0",
               "epk": {
                 "kty": "OKP",
                 "crv": "X25519",
@@ -163,7 +163,7 @@
     {
       "description": "protocol path: network",
       "rootKey": "8DBENkiUrNwT4rI1gyrIVvDYuRzzub--aWe0DhynvpU",
-      "rootKeyId": "did:dht:interoptest123#enc",
+      "rootKeyId": "did:jwk:interoptest123#0",
       "protocolUri": "https://example.com/protocol/wireguard-mesh",
       "protocolPath": "network",
       "fullPath": [
@@ -175,35 +175,35 @@
       "publicKey": "Ov44LzYHQaWmJb8MJWiyoxRJvqhrC3r6BcA9xJKBYkM"
     },
     {
-      "description": "protocol path: network/member",
+      "description": "protocol path: network/node",
       "rootKey": "8DBENkiUrNwT4rI1gyrIVvDYuRzzub--aWe0DhynvpU",
-      "rootKeyId": "did:dht:interoptest123#enc",
+      "rootKeyId": "did:jwk:interoptest123#0",
       "protocolUri": "https://example.com/protocol/wireguard-mesh",
-      "protocolPath": "network/member",
+      "protocolPath": "network/node",
       "fullPath": [
         "protocolPath",
         "https://example.com/protocol/wireguard-mesh",
         "network",
-        "member"
+        "node"
       ],
-      "derivedKey": "Z_MT1MrEmBh-DZpFGwzCFroSImix1h5Brd_r4syj1Vg",
-      "publicKey": "85-guodABi1QaMtFTygILjdjC7h79f3jZxRYIOGRVRE"
+      "derivedKey": "kXStZHQety0H3W9mCA8C18dGr2qP3f7ilC-ZfZmFWTg",
+      "publicKey": "qTaxeI98fDQhur0zw194bjm5sy91zURGcRWXbFkTczY"
     },
     {
-      "description": "protocol path: network/member/nodeInfo",
+      "description": "protocol path: network/node/endpoint",
       "rootKey": "8DBENkiUrNwT4rI1gyrIVvDYuRzzub--aWe0DhynvpU",
-      "rootKeyId": "did:dht:interoptest123#enc",
+      "rootKeyId": "did:jwk:interoptest123#0",
       "protocolUri": "https://example.com/protocol/wireguard-mesh",
-      "protocolPath": "network/member/nodeInfo",
+      "protocolPath": "network/node/endpoint",
       "fullPath": [
         "protocolPath",
         "https://example.com/protocol/wireguard-mesh",
         "network",
-        "member",
-        "nodeInfo"
+        "node",
+        "endpoint"
       ],
-      "derivedKey": "GFE2AKFQw--mZ5hvGlwxc8ylmph5Nk4WJCSqGFZWBxE",
-      "publicKey": "t9Wn-LH3fd7ARGvOgtmAbrzWev1JbDbHVn3BaPrMll4"
+      "derivedKey": "pM7VZvPn5DwwOC57cHCqpMDlKALDqVITODC98r6S4xI",
+      "publicKey": "1U6eplHmSQhRJ9krT0T6a5HanDD7hK6kDL9EnEu5kjQ"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Update all test files, doc comments, interop vectors, and schemas to reflect the `member`→`node` protocol rename and `did:dht`→`did:jwk` identity switch.

Closes #52

## Changes

- **`internal/dwn/crypto/crypto_test.go`**: Protocol paths `member`→`node`, `nodeInfo`→`endpoint`, removed `admin` role references, fixed stale `member` variable reference
- **`internal/dwn/dwn_test.go`**: Query protocol path and role `member`→`node`
- **`internal/dwn/record_test.go`**: Protocol path and schema references updated
- **`internal/dwn/agent.go`**: Doc comment example updated
- **`internal/dwn/dwnapi.go`**: Doc comment examples updated (2 places)
- **`internal/dwn/crypto/protocol.go`**: Doc comment examples updated (2 places)
- **`testdata/interop/generate_vectors.go`**: Protocol key vectors use `node`/`endpoint` paths, `did:jwk` placeholder KIDs
- **`testdata/interop/vectors.json`**: Regenerated from updated generator
- **`schemas/acl-policy.json`**: `did:dht`→`did:jwk` in schema description

## Verification

- `go build ./...` — zero errors
- `go vet ./...` — zero warnings
- `go test ./... -count=1 -race` — all tests pass, no data races