### PR TITLE
feat: ACL policy records for packet filter enforcement

### DIFF
--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/enboxorg/meshd/internal/control"
 	"github.com/enboxorg/meshd/internal/daemon"
 	"github.com/enboxorg/meshd/internal/did"
 	"github.com/enboxorg/meshd/internal/dwn"
@@ -44,6 +45,8 @@ Network:
   peer add          Add a peer to the mesh (anchor only)
   peer list         List all peers in the mesh
   peer approve      Deliver encryption keys to a peer (anchor only)
+  acl set <file>    Set ACL policy from a JSON file (anchor only)
+  acl show          Show the current ACL policy
   status            Show mesh status and identity info
   up                Start the mesh agent daemon
   down              Stop the mesh agent daemon
@@ -91,6 +94,7 @@ func main() {
 		switch combined {
 		case "network create", "network join", "network leave",
 			"peer list", "peer add", "peer remove", "peer approve",
+			"acl set", "acl show",
 			"auth login", "auth list", "auth use", "auth logout":
 			cmd = combined
 			args = os.Args[3:]
@@ -132,6 +136,10 @@ func main() {
 		err = cmdPeerList(ctx, args, flagProfile)
 	case "peer approve":
 		err = cmdPeerApprove(ctx, args, flagProfile)
+	case "acl set":
+		err = cmdACLSet(ctx, args, flagProfile)
+	case "acl show":
+		err = cmdACLShow(ctx, args, flagProfile)
 	case "status":
 		err = cmdStatus(ctx, args, flagProfile)
 	case "up":
@@ -1602,6 +1610,158 @@ func cmdAuthLogout(args []string) error {
 
 	fmt.Printf("Removed profile %q from config.\n", name)
 	fmt.Printf("Data directory preserved at: %s\n", profile.DataPath(name))
+	return nil
+}
+
+// cmdACLSet reads an ACL policy from a JSON file and writes it to the anchor DWN.
+// This is an anchor-only operation.
+//
+// Usage: meshd acl set <policy.json>
+func cmdACLSet(ctx context.Context, args []string, flagProfile string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: meshd acl set <policy.json>")
+	}
+
+	policyFile := args[0]
+	policyBytes, err := os.ReadFile(policyFile)
+	if err != nil {
+		return fmt.Errorf("reading policy file: %w", err)
+	}
+
+	// Validate the JSON is a valid ACL policy.
+	var policy control.ACLPolicyData
+	if err := json.Unmarshal(policyBytes, &policy); err != nil {
+		return fmt.Errorf("invalid ACL policy JSON: %w", err)
+	}
+	if policy.Version == 0 {
+		return fmt.Errorf("ACL policy must have a \"version\" field (integer >= 1)")
+	}
+	if len(policy.Rules) == 0 {
+		return fmt.Errorf("ACL policy must have at least one rule")
+	}
+	for i, r := range policy.Rules {
+		if r.Action != "accept" && r.Action != "drop" {
+			return fmt.Errorf("rule %d: action must be \"accept\" or \"drop\", got %q", i, r.Action)
+		}
+		if len(r.Src) == 0 {
+			return fmt.Errorf("rule %d: src must not be empty", i)
+		}
+		if len(r.Dst) == 0 {
+			return fmt.Errorf("rule %d: dst must not be empty", i)
+		}
+	}
+
+	stateDir, err := resolveStateDir(flagProfile)
+	if err != nil {
+		return err
+	}
+	identity, err := loadIdentity(stateDir)
+	if err != nil {
+		return err
+	}
+
+	ns, err := state.LoadNetworkState(stateDir)
+	if err != nil {
+		return fmt.Errorf("loading network state: %w", err)
+	}
+	if ns == nil {
+		return fmt.Errorf("not in a network. Use 'meshd network create' first.")
+	}
+
+	// Verify this is the anchor node.
+	if identity.URI != ns.AnchorDID {
+		return fmt.Errorf("only the network anchor can set ACL policy (you: %s, anchor: %s)",
+			truncate(identity.URI, 40), truncate(ns.AnchorDID, 40))
+	}
+
+	signer := &dwn.Signer{
+		DID:        identity.URI,
+		PrivateKey: identity.SigningKey,
+	}
+	encMgr := newEncryptionKeyManager(identity)
+
+	if err := mesh.WriteACLPolicy(ctx, mesh.WriteACLPolicyParams{
+		AnchorEndpoint:       ns.AnchorEndpoint,
+		AnchorDID:            ns.AnchorDID,
+		NetworkRecordID:      ns.NetworkRecordID,
+		Signer:               signer,
+		EncryptionKeyManager: encMgr,
+		PolicyData:           policyBytes,
+	}); err != nil {
+		return err
+	}
+
+	fmt.Printf("ACL policy set (version %d, %d rules).\n", policy.Version, len(policy.Rules))
+	return nil
+}
+
+// cmdACLShow reads and displays the current ACL policy from the anchor DWN.
+//
+// Usage: meshd acl show
+func cmdACLShow(ctx context.Context, args []string, flagProfile string) error {
+	stateDir, err := resolveStateDir(flagProfile)
+	if err != nil {
+		return err
+	}
+	identity, err := loadIdentity(stateDir)
+	if err != nil {
+		return err
+	}
+
+	ns, err := state.LoadNetworkState(stateDir)
+	if err != nil {
+		return fmt.Errorf("loading network state: %w", err)
+	}
+	if ns == nil {
+		return fmt.Errorf("not in a network. Use 'meshd network join' first.")
+	}
+
+	signer := &dwn.Signer{
+		DID:        identity.URI,
+		PrivateKey: identity.SigningKey,
+	}
+	encMgr := newEncryptionKeyManager(identity)
+
+	// Fetch context key if available (non-anchor nodes need this for decryption).
+	contextKey, err := fetchContextKey(ctx, identity, ns)
+	if err != nil {
+		fmt.Printf("  Warning: context key fetch failed: %v\n", err)
+	}
+	if contextKey != nil {
+		privBytes, err := contextKey.PrivateKeyBytes()
+		if err != nil {
+			return fmt.Errorf("extracting context key bytes: %w", err)
+		}
+		encMgr.StoreContextKey(ns.NetworkRecordID, privBytes)
+	}
+
+	client := control.NewDWNClient(
+		ns.AnchorEndpoint,
+		ns.AnchorDID,
+		ns.NetworkRecordID,
+		identity.URI,
+		signer,
+		control.WithEncryptionKeyManager(encMgr),
+	)
+
+	// Load state (which now includes ACL policy).
+	_, err = client.LoadState(ctx)
+	if err != nil {
+		return fmt.Errorf("loading mesh state: %w", err)
+	}
+
+	policy := client.ACLPolicy()
+	if policy == nil {
+		fmt.Println("No ACL policy configured. Default: allow all traffic.")
+		return nil
+	}
+
+	// Pretty-print the policy as JSON.
+	out, err := json.MarshalIndent(policy, "", "  ")
+	if err != nil {
+		return fmt.Errorf("formatting policy: %w", err)
+	}
+	fmt.Println(string(out))
 	return nil
 }
 

--- a/internal/control/control_test.go
+++ b/internal/control/control_test.go
@@ -520,6 +520,18 @@ func TestParseEntryData(t *testing.T) {
 		}
 	})
 
+	t.Run("flat encodedData", func(t *testing.T) {
+		flat := `{"encodedData":"eyJuYW1lIjoiZmxhdCIsIm1lc2hDSURSIjoiMTAuMjAwLjAuMC8xNiJ9"}`
+		var net NetworkConfig
+		err := parseEntryData([]byte(flat), &net, nil)
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if net.Name != "flat" {
+			t.Errorf("name = %q", net.Name)
+		}
+	})
+
 	t.Run("wrapped encrypted data", func(t *testing.T) {
 		// Test that encrypted data is decrypted when a decryptor is provided.
 		rootPriv, _, err := dwncrypto.GenerateX25519KeyPair()
@@ -568,4 +580,426 @@ func TestParseEntryData(t *testing.T) {
 			t.Errorf("name = %q, want %q", net.Name, "encrypted")
 		}
 	})
+}
+
+// =============================================================================
+// ACL policy tests
+// =============================================================================
+
+func TestParsePortRange(t *testing.T) {
+	tests := []struct {
+		input string
+		want  PortRange
+		ok    bool
+	}{
+		{"22", PortRange{22, 22}, true},
+		{"0", PortRange{0, 0}, true},
+		{"65535", PortRange{65535, 65535}, true},
+		{"80-443", PortRange{80, 443}, true},
+		{"8000-9000", PortRange{8000, 9000}, true},
+		{"0-65535", PortRange{0, 65535}, true},
+		{"443-80", PortRange{}, false},     // first > last
+		{"65536", PortRange{}, false},      // overflow
+		{"", PortRange{}, false},           // empty
+		{"abc", PortRange{}, false},        // non-numeric
+		{"80-", PortRange{}, false},        // missing last
+		{"-80", PortRange{}, false},        // missing first
+		{"80-abc", PortRange{}, false},     // non-numeric last
+		{"100000", PortRange{}, false},     // too large
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got, ok := parsePortRange(tc.input)
+			if ok != tc.ok {
+				t.Fatalf("parsePortRange(%q) ok = %v, want %v", tc.input, ok, tc.ok)
+			}
+			if got != tc.want {
+				t.Fatalf("parsePortRange(%q) = %+v, want %+v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParsePortRanges(t *testing.T) {
+	result := parsePortRanges([]string{"22", "80-443", "invalid", "8000-9000"})
+	if len(result) != 3 {
+		t.Fatalf("want 3 valid ranges, got %d", len(result))
+	}
+	if result[0] != (PortRange{22, 22}) {
+		t.Errorf("[0] = %+v", result[0])
+	}
+	if result[1] != (PortRange{80, 443}) {
+		t.Errorf("[1] = %+v", result[1])
+	}
+	if result[2] != (PortRange{8000, 9000}) {
+		t.Errorf("[2] = %+v", result[2])
+	}
+}
+
+func TestBuildFilterRules_WithACLPolicy(t *testing.T) {
+	did1, _ := testDIDJWK(t)
+	did2, _ := testDIDJWK(t)
+
+	c := &DWNClient{
+		nodes: map[string]*NodeRecord{
+			did1: {DID: did1, MeshIP: "10.200.0.2"},
+			did2: {DID: did2, MeshIP: "10.200.0.3"},
+		},
+		acl: &ACLPolicyData{
+			Version:       1,
+			DefaultAction: "drop",
+			Rules: []ACLRule{
+				{
+					Action:   "accept",
+					Src:      []string{"*"},
+					Dst:      []string{"*"},
+					DstPorts: []string{"53"},
+				},
+				{
+					Action:   "accept",
+					Src:      []string{did1},
+					Dst:      []string{did2},
+					DstPorts: []string{"22", "443", "8000-9000"},
+				},
+			},
+		},
+	}
+
+	rules := c.buildFilterRules()
+
+	if len(rules) != 2 {
+		t.Fatalf("want 2 rules, got %d", len(rules))
+	}
+
+	// Rule 0: * -> * port 53.
+	if rules[0].SrcIPs[0] != "*" {
+		t.Errorf("rule[0].SrcIPs = %v", rules[0].SrcIPs)
+	}
+	if rules[0].DstPorts[0].IP != "*" {
+		t.Errorf("rule[0].DstPorts[0].IP = %q", rules[0].DstPorts[0].IP)
+	}
+	if rules[0].DstPorts[0].Ports != (PortRange{53, 53}) {
+		t.Errorf("rule[0].DstPorts[0].Ports = %+v", rules[0].DstPorts[0].Ports)
+	}
+
+	// Rule 1: did1 -> did2, 3 port ranges.
+	if len(rules[1].SrcIPs) != 1 || rules[1].SrcIPs[0] != "10.200.0.2" {
+		t.Errorf("rule[1].SrcIPs = %v", rules[1].SrcIPs)
+	}
+	// 1 dst IP × 3 port ranges = 3 DstPorts entries.
+	if len(rules[1].DstPorts) != 3 {
+		t.Fatalf("rule[1] want 3 DstPorts, got %d", len(rules[1].DstPorts))
+	}
+	for _, dp := range rules[1].DstPorts {
+		if dp.IP != "10.200.0.3" {
+			t.Errorf("DstPorts IP = %q, want 10.200.0.3", dp.IP)
+		}
+	}
+	if rules[1].DstPorts[0].Ports != (PortRange{22, 22}) {
+		t.Errorf("port[0] = %+v", rules[1].DstPorts[0].Ports)
+	}
+	if rules[1].DstPorts[1].Ports != (PortRange{443, 443}) {
+		t.Errorf("port[1] = %+v", rules[1].DstPorts[1].Ports)
+	}
+	if rules[1].DstPorts[2].Ports != (PortRange{8000, 9000}) {
+		t.Errorf("port[2] = %+v", rules[1].DstPorts[2].Ports)
+	}
+}
+
+func TestBuildFilterRules_Groups(t *testing.T) {
+	did1, _ := testDIDJWK(t)
+	did2, _ := testDIDJWK(t)
+	did3, _ := testDIDJWK(t)
+
+	c := &DWNClient{
+		nodes: map[string]*NodeRecord{
+			did1: {DID: did1, MeshIP: "10.200.0.2"},
+			did2: {DID: did2, MeshIP: "10.200.0.3"},
+			did3: {DID: did3, MeshIP: "10.200.0.4"},
+		},
+		acl: &ACLPolicyData{
+			Version:       1,
+			DefaultAction: "drop",
+			Groups: map[string][]string{
+				"devs":    {did1, did2},
+				"servers": {did3},
+			},
+			Rules: []ACLRule{
+				{
+					Action:   "accept",
+					Src:      []string{"group:devs"},
+					Dst:      []string{"group:servers"},
+					DstPorts: []string{"22"},
+				},
+			},
+		},
+	}
+
+	rules := c.buildFilterRules()
+
+	if len(rules) != 1 {
+		t.Fatalf("want 1 rule, got %d", len(rules))
+	}
+
+	// Source should be the 2 dev IPs.
+	if len(rules[0].SrcIPs) != 2 {
+		t.Fatalf("want 2 SrcIPs, got %d: %v", len(rules[0].SrcIPs), rules[0].SrcIPs)
+	}
+
+	// Destination should be the 1 server IP × 1 port.
+	if len(rules[0].DstPorts) != 1 {
+		t.Fatalf("want 1 DstPorts, got %d", len(rules[0].DstPorts))
+	}
+	if rules[0].DstPorts[0].IP != "10.200.0.4" {
+		t.Errorf("DstPorts[0].IP = %q", rules[0].DstPorts[0].IP)
+	}
+	if rules[0].DstPorts[0].Ports != (PortRange{22, 22}) {
+		t.Errorf("DstPorts[0].Ports = %+v", rules[0].DstPorts[0].Ports)
+	}
+}
+
+func TestBuildFilterRules_NilACL(t *testing.T) {
+	c := &DWNClient{
+		nodes: map[string]*NodeRecord{},
+		acl:   nil,
+	}
+	rules := c.buildFilterRules()
+	if len(rules) != 1 || rules[0].SrcIPs[0] != "*" {
+		t.Fatalf("nil ACL should produce allow-all, got %+v", rules)
+	}
+}
+
+func TestBuildFilterRules_DefaultActionAccept(t *testing.T) {
+	c := &DWNClient{
+		nodes: map[string]*NodeRecord{},
+		acl: &ACLPolicyData{
+			Version:       1,
+			DefaultAction: "accept",
+			Rules: []ACLRule{
+				// A drop rule only — no accept rules will be produced.
+				{Action: "drop", Src: []string{"*"}, Dst: []string{"*"}},
+			},
+		},
+	}
+	rules := c.buildFilterRules()
+	// No accept rules → defaultAction=accept → allow-all fallback.
+	if len(rules) != 1 || rules[0].SrcIPs[0] != "*" {
+		t.Fatalf("defaultAction=accept with no accept rules should produce allow-all, got %+v", rules)
+	}
+}
+
+func TestBuildFilterRules_NoPorts(t *testing.T) {
+	did1, _ := testDIDJWK(t)
+
+	c := &DWNClient{
+		nodes: map[string]*NodeRecord{
+			did1: {DID: did1, MeshIP: "10.200.0.2"},
+		},
+		acl: &ACLPolicyData{
+			Version: 1,
+			Rules: []ACLRule{
+				{
+					Action: "accept",
+					Src:    []string{"*"},
+					Dst:    []string{did1},
+					// No DstPorts → all ports.
+				},
+			},
+		},
+	}
+
+	rules := c.buildFilterRules()
+	if len(rules) != 1 {
+		t.Fatalf("want 1 rule, got %d", len(rules))
+	}
+	if rules[0].DstPorts[0].Ports != (PortRange{0, 65535}) {
+		t.Errorf("no dstPorts should mean all ports, got %+v", rules[0].DstPorts[0].Ports)
+	}
+}
+
+func TestBuildFilterRules_DirectIP(t *testing.T) {
+	c := &DWNClient{
+		nodes: map[string]*NodeRecord{},
+		acl: &ACLPolicyData{
+			Version: 1,
+			Rules: []ACLRule{
+				{
+					Action: "accept",
+					Src:    []string{"10.200.0.0/16"},
+					Dst:    []string{"10.200.0.5"},
+					DstPorts: []string{"80"},
+				},
+			},
+		},
+	}
+
+	rules := c.buildFilterRules()
+	if len(rules) != 1 {
+		t.Fatalf("want 1 rule, got %d", len(rules))
+	}
+	if rules[0].SrcIPs[0] != "10.200.0.0/16" {
+		t.Errorf("SrcIPs[0] = %q", rules[0].SrcIPs[0])
+	}
+	if rules[0].DstPorts[0].IP != "10.200.0.5" {
+		t.Errorf("DstPorts[0].IP = %q", rules[0].DstPorts[0].IP)
+	}
+}
+
+func TestBuildFilterRules_UnresolvableDID(t *testing.T) {
+	c := &DWNClient{
+		nodes: map[string]*NodeRecord{},
+		acl: &ACLPolicyData{
+			Version: 1,
+			Rules: []ACLRule{
+				{
+					Action: "accept",
+					Src:    []string{"did:jwk:unknown"},
+					Dst:    []string{"*"},
+				},
+			},
+		},
+	}
+
+	rules := c.buildFilterRules()
+	// The DID can't be resolved to an IP, so the rule should produce no SrcIPs
+	// and be skipped entirely.
+	if len(rules) != 0 {
+		t.Fatalf("unresolvable DID should produce 0 rules, got %d", len(rules))
+	}
+}
+
+func TestResolveMatchers(t *testing.T) {
+	did1, _ := testDIDJWK(t)
+	did2, _ := testDIDJWK(t)
+
+	c := &DWNClient{
+		acl: &ACLPolicyData{
+			Groups: map[string][]string{
+				"servers": {did1, did2},
+			},
+		},
+	}
+
+	didToIP := map[string]string{
+		did1: "10.200.0.2",
+		did2: "10.200.0.3",
+	}
+
+	t.Run("wildcard", func(t *testing.T) {
+		result := c.resolveMatchers([]string{"*"}, didToIP)
+		if len(result) != 1 || result[0] != "*" {
+			t.Errorf("wildcard: got %v", result)
+		}
+	})
+
+	t.Run("DID", func(t *testing.T) {
+		result := c.resolveMatchers([]string{did1}, didToIP)
+		if len(result) != 1 || result[0] != "10.200.0.2" {
+			t.Errorf("DID: got %v", result)
+		}
+	})
+
+	t.Run("group", func(t *testing.T) {
+		result := c.resolveMatchers([]string{"group:servers"}, didToIP)
+		if len(result) != 2 {
+			t.Fatalf("group: want 2 IPs, got %d", len(result))
+		}
+	})
+
+	t.Run("unknown group", func(t *testing.T) {
+		result := c.resolveMatchers([]string{"group:unknown"}, didToIP)
+		if len(result) != 0 {
+			t.Errorf("unknown group: got %v", result)
+		}
+	})
+
+	t.Run("direct IP", func(t *testing.T) {
+		result := c.resolveMatchers([]string{"10.200.0.5"}, didToIP)
+		if len(result) != 1 || result[0] != "10.200.0.5" {
+			t.Errorf("direct IP: got %v", result)
+		}
+	})
+
+	t.Run("CIDR", func(t *testing.T) {
+		result := c.resolveMatchers([]string{"10.200.0.0/16"}, didToIP)
+		if len(result) != 1 || result[0] != "10.200.0.0/16" {
+			t.Errorf("CIDR: got %v", result)
+		}
+	})
+
+	t.Run("mixed", func(t *testing.T) {
+		result := c.resolveMatchers([]string{did1, "10.200.0.5", "group:servers"}, didToIP)
+		// did1 → 1 IP, direct → 1 IP, group:servers → 2 IPs = 4 total
+		if len(result) != 4 {
+			t.Errorf("mixed: want 4, got %d: %v", len(result), result)
+		}
+	})
+
+	t.Run("wildcard short-circuits", func(t *testing.T) {
+		result := c.resolveMatchers([]string{did1, "*", "10.200.0.5"}, didToIP)
+		if len(result) != 1 || result[0] != "*" {
+			t.Errorf("wildcard should short-circuit: got %v", result)
+		}
+	})
+}
+
+func TestACLPolicyAccessor(t *testing.T) {
+	c := &DWNClient{}
+	if c.ACLPolicy() != nil {
+		t.Fatal("expected nil ACL before loading")
+	}
+
+	policy := &ACLPolicyData{Version: 1, Rules: []ACLRule{{Action: "accept", Src: []string{"*"}, Dst: []string{"*"}}}}
+	c.acl = policy
+	if got := c.ACLPolicy(); got != policy {
+		t.Fatal("expected ACL policy to be set")
+	}
+}
+
+func TestACLPolicyDataSerialization(t *testing.T) {
+	policy := ACLPolicyData{
+		Version:       1,
+		DefaultAction: "drop",
+		Groups: map[string][]string{
+			"devs": {"did:jwk:abc", "did:jwk:def"},
+		},
+		Rules: []ACLRule{
+			{
+				Action:   "accept",
+				Src:      []string{"group:devs"},
+				Dst:      []string{"*"},
+				DstPorts: []string{"22", "80-443"},
+			},
+		},
+	}
+
+	data, err := json.Marshal(policy)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded ACLPolicyData
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded.Version != 1 {
+		t.Errorf("version = %d", decoded.Version)
+	}
+	if decoded.DefaultAction != "drop" {
+		t.Errorf("defaultAction = %q", decoded.DefaultAction)
+	}
+	if len(decoded.Groups) != 1 {
+		t.Fatalf("groups = %d", len(decoded.Groups))
+	}
+	if len(decoded.Groups["devs"]) != 2 {
+		t.Errorf("groups[devs] = %v", decoded.Groups["devs"])
+	}
+	if len(decoded.Rules) != 1 {
+		t.Fatalf("rules = %d", len(decoded.Rules))
+	}
+	if len(decoded.Rules[0].DstPorts) != 2 {
+		t.Errorf("dstPorts = %v", decoded.Rules[0].DstPorts)
+	}
 }

--- a/internal/control/data.go
+++ b/internal/control/data.go
@@ -54,14 +54,18 @@ type RelayData struct {
 
 // ACLPolicyData is the parsed ACL policy record data.
 type ACLPolicyData struct {
-	Rules []ACLRule `json:"rules"`
+	Version       int                `json:"version"`
+	DefaultAction string             `json:"defaultAction,omitempty"`
+	Groups        map[string][]string `json:"groups,omitempty"`
+	Rules         []ACLRule          `json:"rules"`
 }
 
 // ACLRule is a single ACL rule.
 type ACLRule struct {
-	Action string   `json:"action"`
-	Src    []string `json:"src"`
-	Dst    []string `json:"dst"`
-	Proto  string   `json:"proto,omitempty"`
-	Ports  string   `json:"ports,omitempty"`
+	Action   string   `json:"action"`
+	Src      []string `json:"src"`
+	Dst      []string `json:"dst"`
+	Proto    string   `json:"proto,omitempty"`
+	SrcPorts []string `json:"srcPorts,omitempty"`
+	DstPorts []string `json:"dstPorts,omitempty"`
 }

--- a/internal/control/dwnclient.go
+++ b/internal/control/dwnclient.go
@@ -242,7 +242,38 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 	}
 	c.mu.Unlock()
 
-	// 4. Query endpoint records for each node.
+	// 4. Query ACL policy record.
+	aclResp, err := c.anchorDWN.RecordsQuery(ctx, c.anchorTenant, dwn.RecordsFilter{
+		Protocol:     ProtocolMesh,
+		ProtocolPath: "network/aclPolicy",
+		ContextID:    c.networkRecordID,
+	}, "createdDescending", nil, "network/node")
+	if err != nil {
+		// Non-fatal: ACL policy is optional. Default to allow-all.
+		c.logger.DebugContext(ctx, "querying ACL policy failed", slog.Any("error", err))
+	} else {
+		aclEntries, err := dwn.QueryResult(aclResp)
+		if err != nil {
+			c.logger.DebugContext(ctx, "parsing ACL policy results", slog.Any("error", err))
+		} else if len(aclEntries) > 0 {
+			// $recordLimit: max 1 — take the first (most recent) entry.
+			aclDecryptor := c.makeDecryptor("network/aclPolicy")
+			var policy ACLPolicyData
+			if err := parseEntryData(aclEntries[0], &policy, aclDecryptor); err != nil {
+				c.logger.DebugContext(ctx, "parsing ACL policy entry", slog.Any("error", err))
+			} else {
+				c.mu.Lock()
+				c.acl = &policy
+				c.mu.Unlock()
+				c.logger.DebugContext(ctx, "loaded ACL policy",
+					slog.Int("version", policy.Version),
+					slog.Int("rules", len(policy.Rules)),
+				)
+			}
+		}
+	}
+
+	// 5. Query endpoint records for each node.
 	// Endpoint records are children of node records. We query all
 	// endpoint records in the network context and attach them to their
 	// parent node via the parentId descriptor field.
@@ -285,13 +316,22 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 		}
 	}
 
+	hasACL := c.acl != nil
 	c.logger.DebugContext(ctx, "mesh state loaded",
 		slog.String("network", network.Name),
 		slog.Int("nodes", len(c.nodes)),
 		slog.Int("relays", len(c.relays)),
+		slog.Bool("aclPolicy", hasACL),
 	)
 
 	return c.buildMapResponse(), nil
+}
+
+// ACLPolicy returns the loaded ACL policy, or nil if none is configured.
+func (c *DWNClient) ACLPolicy() *ACLPolicyData {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.acl
 }
 
 // BuildStaticMapResponse creates a MapResponse from explicitly provided
@@ -556,21 +596,145 @@ func (c *DWNClient) buildFilterRules() []FilterRule {
 		return defaultFilterRules()
 	}
 
+	// Build DID → mesh IP lookup from the current node map.
+	didToIP := make(map[string]string, len(c.nodes))
+	for did, node := range c.nodes {
+		if node.MeshIP != "" {
+			didToIP[did] = node.MeshIP
+		}
+	}
+
 	var rules []FilterRule
 	for _, r := range c.acl.Rules {
 		if r.Action != "accept" {
 			continue
 		}
-		rule := FilterRule{SrcIPs: r.Src}
-		for _, dst := range r.Dst {
-			rule.DstPorts = append(rule.DstPorts, NetPortRange{
-				IP:    dst,
-				Ports: PortRange{First: 0, Last: 65535},
-			})
+
+		// Resolve source matchers to IPs.
+		srcIPs := c.resolveMatchers(r.Src, didToIP)
+		if len(srcIPs) == 0 {
+			continue
+		}
+
+		// Resolve destination matchers to IPs.
+		dstIPs := c.resolveMatchers(r.Dst, didToIP)
+		if len(dstIPs) == 0 {
+			continue
+		}
+
+		// Parse destination port ranges. If none specified, allow all ports.
+		dstPorts := parsePortRanges(r.DstPorts)
+		if len(dstPorts) == 0 {
+			dstPorts = []PortRange{{First: 0, Last: 65535}}
+		}
+
+		// Build filter rule: each dst IP × each port range.
+		rule := FilterRule{SrcIPs: srcIPs}
+		for _, ip := range dstIPs {
+			for _, pr := range dstPorts {
+				rule.DstPorts = append(rule.DstPorts, NetPortRange{
+					IP:    ip,
+					Ports: pr,
+				})
+			}
 		}
 		rules = append(rules, rule)
 	}
+
+	// If no accept rules were produced but defaultAction is "accept",
+	// fall through to allow-all.
+	if len(rules) == 0 && c.acl.DefaultAction == "accept" {
+		return defaultFilterRules()
+	}
+
 	return rules
+}
+
+// resolveMatchers expands ACL source/destination matchers into IP strings
+// that the packet filter engine understands. Supported matchers:
+//   - "*"          → "*" (wildcard)
+//   - "group:name" → expanded to member DIDs, then resolved to mesh IPs
+//   - "did:..."    → resolved to mesh IP
+//   - "10.x.y.z"  → passed through as-is (direct IP)
+//   - "10.x.y.z/n"→ passed through as-is (CIDR)
+func (c *DWNClient) resolveMatchers(matchers []string, didToIP map[string]string) []string {
+	var result []string
+	for _, m := range matchers {
+		switch {
+		case m == "*":
+			return []string{"*"}
+		case len(m) > 6 && m[:6] == "group:":
+			groupName := m[6:]
+			if c.acl != nil && c.acl.Groups != nil {
+				for _, did := range c.acl.Groups[groupName] {
+					if ip, ok := didToIP[did]; ok {
+						result = append(result, ip)
+					}
+				}
+			}
+		case len(m) > 4 && m[:4] == "did:":
+			if ip, ok := didToIP[m]; ok {
+				result = append(result, ip)
+			}
+		default:
+			// Assume IP or CIDR — pass through.
+			result = append(result, m)
+		}
+	}
+	return result
+}
+
+// parsePortRanges parses port range strings like "22", "80", "8000-9000"
+// into PortRange structs. Invalid entries are silently skipped.
+func parsePortRanges(ports []string) []PortRange {
+	var result []PortRange
+	for _, p := range ports {
+		pr, ok := parsePortRange(p)
+		if ok {
+			result = append(result, pr)
+		}
+	}
+	return result
+}
+
+// parsePortRange parses a single port or port range string.
+// Returns the parsed range and true, or zero value and false on error.
+func parsePortRange(s string) (PortRange, bool) {
+	// Try "first-last" format.
+	for i := 0; i < len(s); i++ {
+		if s[i] == '-' {
+			first, ok1 := parsePort(s[:i])
+			last, ok2 := parsePort(s[i+1:])
+			if ok1 && ok2 && first <= last {
+				return PortRange{First: first, Last: last}, true
+			}
+			return PortRange{}, false
+		}
+	}
+	// Single port.
+	port, ok := parsePort(s)
+	if ok {
+		return PortRange{First: port, Last: port}, true
+	}
+	return PortRange{}, false
+}
+
+// parsePort parses a decimal port number string (0-65535).
+func parsePort(s string) (uint16, bool) {
+	if len(s) == 0 || len(s) > 5 {
+		return 0, false
+	}
+	var n uint32
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		n = n*10 + uint32(c-'0')
+	}
+	if n > 65535 {
+		return 0, false
+	}
+	return uint16(n), true
 }
 
 func defaultFilterRules() []FilterRule {

--- a/internal/mesh/register.go
+++ b/internal/mesh/register.go
@@ -17,8 +17,9 @@ import (
 const (
 	protocolMesh = "https://enbox.org/protocols/wireguard-mesh"
 
-	schemaNode     = "https://enbox.org/schemas/wireguard-mesh/node"
-	schemaEndpoint = "https://enbox.org/schemas/wireguard-mesh/endpoint"
+	schemaNode      = "https://enbox.org/schemas/wireguard-mesh/node"
+	schemaEndpoint  = "https://enbox.org/schemas/wireguard-mesh/endpoint"
+	schemaACLPolicy = "https://enbox.org/schemas/wireguard-mesh/acl-policy"
 )
 
 // NodeRegistration holds the result of registering a node on DWN.
@@ -281,6 +282,54 @@ type PublicEndpoint struct {
 	Port     int    `json:"port"`
 	Priority int    `json:"priority,omitempty"`
 	Source   string `json:"source,omitempty"`
+}
+
+// WriteACLPolicyParams configures an ACL policy write.
+type WriteACLPolicyParams struct {
+	AnchorEndpoint       string
+	AnchorDID            string
+	NetworkRecordID      string
+	Signer               *dwn.Signer
+	EncryptionKeyManager *dwncrypto.EncryptionKeyManager
+
+	// PolicyData is the JSON-encoded ACL policy payload.
+	PolicyData []byte
+}
+
+// WriteACLPolicy writes or updates the ACL policy record (encrypted) on the
+// anchor DWN. Only the network author (anchor) can create/update the ACL policy.
+// The protocol enforces $recordLimit: max 1 — newer writes replace older ones.
+func WriteACLPolicy(ctx context.Context, params WriteACLPolicyParams) error {
+	if params.EncryptionKeyManager == nil {
+		return fmt.Errorf("EncryptionKeyManager is required for encrypted writes")
+	}
+
+	// The anchor always uses Protocol Path encryption for records it owns.
+	recipients, err := params.EncryptionKeyManager.DeriveWriteEncryption("network/aclPolicy")
+	if err != nil {
+		return fmt.Errorf("deriving ACL policy encryption: %w", err)
+	}
+
+	agent := dwn.NewSimpleAgent(params.AnchorEndpoint, params.Signer)
+	api := dwn.NewDwnAPI(agent)
+
+	_, status, err := api.Write(ctx, params.AnchorDID, dwn.WriteParams{
+		Protocol:             protocolMesh,
+		ProtocolPath:         "network/aclPolicy",
+		Schema:               schemaACLPolicy,
+		DataFormat:           "application/json",
+		ParentContextID:      params.NetworkRecordID,
+		Data:                 params.PolicyData,
+		EncryptionRecipients: recipients,
+	})
+	if err != nil {
+		return fmt.Errorf("writing ACL policy: %w", err)
+	}
+	if status.Code >= 300 {
+		return fmt.Errorf("ACL policy write failed: %d %s", status.Code, status.Detail)
+	}
+
+	return nil
 }
 
 // DiscoverLocalEndpoints discovers local network endpoints for this node.

--- a/schemas/acl-policy.json
+++ b/schemas/acl-policy.json
@@ -24,14 +24,6 @@
       },
       "description": "Named groups of DIDs, e.g. { 'developers': ['did:jwk:abc', 'did:jwk:def'] }"
     },
-    "tagOwners": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "array",
-        "items": { "type": "string" }
-      },
-      "description": "Which DIDs can assign which tags to their nodes"
-    },
     "rules": {
       "type": "array",
       "items": {
@@ -46,12 +38,12 @@
           "src": {
             "type": "array",
             "items": { "type": "string" },
-            "description": "Source matchers: DID, group:name, tag:name, or '*'"
+            "description": "Source matchers: DID, group:name, meshIP, or '*'"
           },
           "dst": {
             "type": "array",
             "items": { "type": "string" },
-            "description": "Destination matchers: DID, group:name, tag:name, meshIP, or '*'"
+            "description": "Destination matchers: DID, group:name, meshIP, or '*'"
           },
           "proto": {
             "type": "string",


### PR DESCRIPTION
## Summary

Implement end-to-end ACL policy support: the anchor writes encrypted ACL policies to DWN, nodes load and enforce them as WireGuard packet filter rules. Previously, `buildFilterRules()` always returned allow-all because `c.acl` was never populated.

Closes #31

## Changes

### Data types (`internal/control/data.go`)
- `ACLPolicyData`: added `Version`, `DefaultAction`, `Groups` fields to match JSON schema
- `ACLRule`: replaced `Ports string` with `SrcPorts`/`DstPorts []string` arrays

### Loading (`internal/control/dwnclient.go`)
- `LoadState()`: new step 4 queries `network/aclPolicy` records, decrypts, populates `c.acl`
- `ACLPolicy()` read accessor for CLI use

### Rule building (`internal/control/dwnclient.go`)
- Rewrote `buildFilterRules()` with:
  - DID → mesh IP resolution from the node map
  - `group:name` expansion via `ACLPolicyData.Groups`
  - Port range parsing (`"22"`, `"80-443"`, `"8000-9000"`)
  - `defaultAction` handling (fall through to allow-all if "accept")
  - Direct IP/CIDR passthrough
  - Drop rules are filtered out (only "accept" rules produce filter entries)
- `resolveMatchers()`: handles `*`, `group:name`, `did:...`, direct IP/CIDR
- `parsePortRange()`/`parsePort()`: decimal port parsing with range validation

### Writing (`internal/mesh/register.go`)
- `WriteACLPolicy()` + `WriteACLPolicyParams`: writes encrypted `aclPolicy` records to the anchor DWN

### CLI (`cmd/meshd/main.go`)
- `acl set <file>` — validate and write ACL policy JSON (anchor only, checks identity)
- `acl show` — load mesh state and pretty-print the current ACL policy

### Schema (`schemas/acl-policy.json`)
- Removed `tagOwners` (tags were removed from the protocol for privacy)
- Updated `src`/`dst` field descriptions

### Tests (`internal/control/control_test.go`)
- 14 new test functions covering port parsing, filter rule building, DID resolution, group expansion, wildcard short-circuiting, default action fallback, direct IPs, unresolvable DIDs, JSON serialization

## Verification

- `go build ./...` — zero errors
- `go vet ./...` — zero warnings
- `go test ./... -count=1 -race` — all tests pass, no data races