### PR TITLE
fix: use Protocol Context encryption for all records so peers can decrypt (#87, #88)

### DIFF
--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -314,7 +314,10 @@ func cmdNetworkCreate(ctx context.Context, args []string, flagProfile string) er
 		return fmt.Errorf("allocating mesh IP: %w", err)
 	}
 
-	// 5. Register node on DWN (encrypted).
+	// 5. Register node on DWN (encrypted with Protocol Context).
+	// Use context encryption so that peers with the shared context key can
+	// decrypt the anchor's node record. The anchor already self-delivered the
+	// context key above, and as the DWN owner it can derive the key from root.
 	reg, err := mesh.RegisterNode(ctx, mesh.RegisterNodeParams{
 		AnchorEndpoint:       endpoint,
 		AnchorDID:            identity.URI,
@@ -323,6 +326,7 @@ func cmdNetworkCreate(ctx context.Context, args []string, flagProfile string) er
 		Signer:               signer,
 		EncryptionKeyManager: encMgr,
 		MeshIP:               meshIP.String(),
+		UseContextEncryption: true,
 	})
 	if err != nil {
 		fmt.Printf("  Warning: node registration failed: %v\n", err)
@@ -337,6 +341,7 @@ func cmdNetworkCreate(ctx context.Context, args []string, flagProfile string) er
 			NodeRecordID:         reg.NodeRecordID,
 			Signer:               signer,
 			EncryptionKeyManager: encMgr,
+			UseContextEncryption: true,
 		}); err != nil {
 			fmt.Printf("  Warning: nodeInfo write failed: %v\n", err)
 		} else {
@@ -778,6 +783,8 @@ func cmdPeerAdd(ctx context.Context, args []string, flagProfile string) error {
 
 	// 1. Create a node record for the peer (assigns the network/node role).
 	// The peer's mesh IP is derived deterministically from their DID.
+	// Use Protocol Context encryption so all peers with the shared context
+	// key can decrypt each other's node records.
 	fmt.Printf("Adding peer %s...\n", peerDID)
 	peerMeshIP, err := mesh.AllocateMeshIP(ns.MeshCIDR, peerDID)
 	if err != nil {
@@ -792,6 +799,7 @@ func cmdPeerAdd(ctx context.Context, args []string, flagProfile string) error {
 		EncryptionKeyManager: encMgr,
 		MeshIP:               peerMeshIP.String(),
 		Label:                label,
+		UseContextEncryption: true,
 	})
 	if err != nil {
 		return fmt.Errorf("creating node record: %w", err)
@@ -1115,11 +1123,16 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 
 	encMgr := newEncryptionKeyManager(identity)
 
-	// For non-anchor nodes: fetch the context key from the anchor so we
-	// can encrypt records with Protocol Context scheme (which the anchor
-	// can decrypt using the shared context key).
+	// Enable Protocol Context encryption so all nodes (including the anchor)
+	// write records that any peer with the shared context key can decrypt.
+	// The anchor derives the context key from its root key (HKDF).
+	// Non-anchor nodes fetch it from the anchor's key-delivery protocol.
 	useContextEncryption := false
-	if ns.AnchorDID != identity.URI {
+	if ns.AnchorDID == identity.URI {
+		// Anchor: always use context encryption. The EncryptionKeyManager
+		// derives the context key from the root key automatically.
+		useContextEncryption = true
+	} else {
 		contextKey, err := fetchContextKey(ctx, identity, ns)
 		if err != nil {
 			slog.Warn("context key fetch failed (will retry on next up)",

--- a/internal/control/dwnclient.go
+++ b/internal/control/dwnclient.go
@@ -581,6 +581,18 @@ func (c *DWNClient) buildMapResponse() *MapResponse {
 		node := nodeRecordToNode(nodeID, did, rec)
 		nodeID++
 
+		// Skip peers whose node records could not be decrypted. Without
+		// a mesh IP the peer has no addresses and WireGuard cannot route
+		// traffic to it. These "ghost" nodes are still tracked in c.nodes
+		// for auto key delivery purposes, but should not be injected
+		// into the network map.
+		if did != c.selfDID && !node.MeshIP.IsValid() {
+			c.logger.Debug("skipping undecryptable peer in network map",
+				slog.String("did", did),
+			)
+			continue
+		}
+
 		if did == c.selfDID {
 			resp.Node = node
 		} else {


### PR DESCRIPTION
## Summary

Two critical fixes that unblock the real-world two-machine E2E flow.

## Problem

When tracing the exact user scenario (`meshd up --create` on Machine A, `meshd up --anchor` on Machine B), we discovered that **no WireGuard tunnel can form** because:

1. **The anchor encrypts its own records with Protocol Path encryption** (derived from the anchor's root key). Peers only have the shared context key. They cannot decrypt the anchor's node, nodeInfo, or endpoint records, so they cannot discover the anchor's mesh IP or network endpoints.

2. **Undecryptable nodes pollute the network map.** When a node record can't be decrypted, `nodeRecordToNode` produces a `Node` with no mesh IP, no addresses, and no endpoints. WireGuard gets a peer entry it can't route traffic to.

## Fix

### #87: Protocol Context encryption everywhere

| Call site | Before | After |
|-----------|--------|-------|
| `network create` -> `RegisterNode` (anchor self) | Protocol Path (anchor root key) | **Protocol Context** |
| `network create` -> `WriteNodeInfo` (anchor self) | Protocol Path | **Protocol Context** |
| `peer add` -> `RegisterNode` (peer node) | Protocol Path | **Protocol Context** |
| `meshd up` (anchor) -> endpoint writes | Protocol Path (`useContextEncryption = false`) | **Protocol Context** (`useContextEncryption = true`) |
| `meshd up` (anchor) -> engine config | `UseContextEncryption: false` | `UseContextEncryption: true` |

The anchor derives the context key from its root key via HKDF (this already works in `EncryptionKeyManager.resolveContextPrivateKey`). No new key delivery or storage needed.

### #88: Skip ghost peers in network map

In `buildMapResponse`, peers with no valid mesh IP are now skipped. They remain in `c.nodes` for auto key delivery tracking but are not injected into the WireGuard network map.

## Verification

- `go build ./...` -- zero errors
- `go vet ./...` -- zero warnings
- `go test ./... -count=1 -race` -- all tests pass

Fixes #87
Fixes #88