### PR TITLE
feat: protocol-level filtering in ACL rules

### DIFF
--- a/internal/control/control_test.go
+++ b/internal/control/control_test.go
@@ -1005,3 +1005,98 @@ func TestACLPolicyDataSerialization(t *testing.T) {
 		t.Errorf("dstPorts = %v", decoded.Rules[0].DstPorts)
 	}
 }
+
+func TestProtoToIPProto(t *testing.T) {
+	tests := []struct {
+		proto string
+		want  []int
+	}{
+		{"tcp", []int{6}},
+		{"udp", []int{17}},
+		{"icmp", []int{1, 58}},
+		{"*", nil},
+		{"", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.proto, func(t *testing.T) {
+			got := protoToIPProto(tt.proto)
+			if len(got) != len(tt.want) {
+				t.Fatalf("protoToIPProto(%q) = %v, want %v", tt.proto, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("protoToIPProto(%q)[%d] = %d, want %d", tt.proto, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBuildFilterRules_Proto(t *testing.T) {
+	did1, _ := testDIDJWK(t)
+	did2, _ := testDIDJWK(t)
+
+	c := &DWNClient{
+		nodes: map[string]*NodeRecord{
+			did1: {DID: did1, MeshIP: "10.200.0.2"},
+			did2: {DID: did2, MeshIP: "10.200.0.3"},
+		},
+		acl: &ACLPolicyData{
+			Version:       1,
+			DefaultAction: "drop",
+			Rules: []ACLRule{
+				{
+					Action:   "accept",
+					Src:      []string{"*"},
+					Dst:      []string{"*"},
+					Proto:    "tcp",
+					DstPorts: []string{"22", "443"},
+				},
+				{
+					Action: "accept",
+					Src:    []string{did1},
+					Dst:    []string{did2},
+					Proto:  "udp",
+				},
+				{
+					Action: "accept",
+					Src:    []string{"*"},
+					Dst:    []string{"*"},
+					Proto:  "icmp",
+				},
+				{
+					// No proto → all protocols (nil IPProto).
+					Action:   "accept",
+					Src:      []string{did1},
+					Dst:      []string{did2},
+					DstPorts: []string{"80"},
+				},
+			},
+		},
+	}
+
+	rules := c.buildFilterRules()
+	if len(rules) != 4 {
+		t.Fatalf("want 4 rules, got %d", len(rules))
+	}
+
+	// Rule 0: TCP only (proto 6).
+	if len(rules[0].IPProto) != 1 || rules[0].IPProto[0] != 6 {
+		t.Errorf("rule[0].IPProto = %v, want [6]", rules[0].IPProto)
+	}
+
+	// Rule 1: UDP only (proto 17).
+	if len(rules[1].IPProto) != 1 || rules[1].IPProto[0] != 17 {
+		t.Errorf("rule[1].IPProto = %v, want [17]", rules[1].IPProto)
+	}
+
+	// Rule 2: ICMP (protos 1, 58).
+	if len(rules[2].IPProto) != 2 || rules[2].IPProto[0] != 1 || rules[2].IPProto[1] != 58 {
+		t.Errorf("rule[2].IPProto = %v, want [1 58]", rules[2].IPProto)
+	}
+
+	// Rule 3: No proto → nil (all protocols).
+	if rules[3].IPProto != nil {
+		t.Errorf("rule[3].IPProto = %v, want nil", rules[3].IPProto)
+	}
+}

--- a/internal/control/dwnclient.go
+++ b/internal/control/dwnclient.go
@@ -834,8 +834,14 @@ func (c *DWNClient) buildFilterRules() []FilterRule {
 			dstPorts = []PortRange{{First: 0, Last: 65535}}
 		}
 
+		// Map protocol string to IP protocol numbers.
+		ipProto := protoToIPProto(r.Proto)
+
 		// Build filter rule: each dst IP × each port range.
-		rule := FilterRule{SrcIPs: srcIPs}
+		rule := FilterRule{
+			SrcIPs:  srcIPs,
+			IPProto: ipProto,
+		}
 		for _, ip := range dstIPs {
 			for _, pr := range dstPorts {
 				rule.DstPorts = append(rule.DstPorts, NetPortRange{
@@ -854,6 +860,24 @@ func (c *DWNClient) buildFilterRules() []FilterRule {
 	}
 
 	return rules
+}
+
+// protoToIPProto maps an ACL rule's proto string to IP protocol numbers.
+// Returns nil for empty or "*" (meaning all protocols — TCP, UDP, ICMP).
+//
+// IANA protocol numbers: ICMPv4=1, TCP=6, UDP=17, ICMPv6=58.
+func protoToIPProto(proto string) []int {
+	switch proto {
+	case "tcp":
+		return []int{6} // TCP
+	case "udp":
+		return []int{17} // UDP
+	case "icmp":
+		return []int{1, 58} // ICMPv4 + ICMPv6
+	default:
+		// Empty or "*": nil means all protocols (meshnet default).
+		return nil
+	}
 }
 
 // resolveMatchers expands ACL source/destination matchers into IP strings

--- a/internal/control/types.go
+++ b/internal/control/types.go
@@ -121,6 +121,11 @@ type FilterRule struct {
 
 	// DstPorts are destination ip:port ranges.
 	DstPorts []NetPortRange
+
+	// IPProto are the IP protocol numbers to match (e.g. 6 for TCP,
+	// 17 for UDP, 1 for ICMPv4). nil or empty means all protocols
+	// (TCP, UDP, ICMP) — same semantics as tailcfg.FilterRule.IPProto.
+	IPProto []int
 }
 
 // NetPortRange is an IP + port range for filter rules.

--- a/internal/engine/convert.go
+++ b/internal/engine/convert.go
@@ -331,7 +331,8 @@ func (c *Converter) convertFilterRules(rules []control.FilterRule) []tailcfg.Fil
 	result := make([]tailcfg.FilterRule, 0, len(rules))
 	for _, r := range rules {
 		tr := tailcfg.FilterRule{
-			SrcIPs: r.SrcIPs,
+			SrcIPs:  r.SrcIPs,
+			IPProto: r.IPProto,
 		}
 		for _, dp := range r.DstPorts {
 			tr.DstPorts = append(tr.DstPorts, tailcfg.NetPortRange{

--- a/internal/engine/convert_test.go
+++ b/internal/engine/convert_test.go
@@ -629,3 +629,51 @@ func TestParseDiscoKey(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertFilterRulesIPProto(t *testing.T) {
+	conv := NewConverter("test-mesh")
+
+	rules := []control.FilterRule{
+		{
+			SrcIPs:  []string{"*"},
+			IPProto: []int{6}, // TCP
+			DstPorts: []control.NetPortRange{
+				{IP: "*", Ports: control.PortRange{First: 22, Last: 22}},
+			},
+		},
+		{
+			SrcIPs:  []string{"10.200.0.2"},
+			IPProto: []int{17}, // UDP
+			DstPorts: []control.NetPortRange{
+				{IP: "10.200.0.3", Ports: control.PortRange{First: 0, Last: 65535}},
+			},
+		},
+		{
+			SrcIPs:  []string{"*"},
+			IPProto: nil, // all protocols
+			DstPorts: []control.NetPortRange{
+				{IP: "*", Ports: control.PortRange{First: 0, Last: 65535}},
+			},
+		},
+	}
+
+	result := conv.convertFilterRules(rules)
+	if len(result) != 3 {
+		t.Fatalf("want 3 rules, got %d", len(result))
+	}
+
+	// Rule 0: TCP only.
+	if len(result[0].IPProto) != 1 || result[0].IPProto[0] != 6 {
+		t.Errorf("rule[0].IPProto = %v, want [6]", result[0].IPProto)
+	}
+
+	// Rule 1: UDP only.
+	if len(result[1].IPProto) != 1 || result[1].IPProto[0] != 17 {
+		t.Errorf("rule[1].IPProto = %v, want [17]", result[1].IPProto)
+	}
+
+	// Rule 2: nil → all protocols (meshnet default behavior).
+	if result[2].IPProto != nil {
+		t.Errorf("rule[2].IPProto = %v, want nil", result[2].IPProto)
+	}
+}


### PR DESCRIPTION
Closes #64

## Summary

- Map ACL rule `proto` field (`tcp`, `udp`, `icmp`, `*`) to IP protocol numbers in the packet filter pipeline
- The `acl-policy.json` schema already defined the `proto` field but `buildFilterRules()` was ignoring it — this change makes the engine actually enforce it

## Changes

| File | Change |
|------|--------|
| `internal/control/types.go` | Add `IPProto []int` field to `FilterRule` |
| `internal/control/dwnclient.go` | Add `protoToIPProto()` mapping function; wire `Proto` into `buildFilterRules()` |
| `internal/engine/convert.go` | Carry `IPProto` through `convertFilterRules()` → `tailcfg.FilterRule.IPProto` |
| `internal/control/control_test.go` | Tests for `protoToIPProto()` and `buildFilterRules` with protocol filtering |
| `internal/engine/convert_test.go` | Test for `convertFilterRules` carrying `IPProto` to tailcfg |

## Protocol mapping

| ACL `proto` | IANA numbers | Notes |
|-------------|-------------|-------|
| `tcp` | `[6]` | TCP only |
| `udp` | `[17]` | UDP only |
| `icmp` | `[1, 58]` | ICMPv4 + ICMPv6 |
| `*` or empty | `nil` | All protocols (meshnet default: TCP, UDP, ICMP) |

## How it works

1. `buildFilterRules()` calls `protoToIPProto(rule.Proto)` for each ACL rule
2. The resulting `[]int` is stored in `FilterRule.IPProto`
3. `convertFilterRules()` copies `IPProto` to `tailcfg.FilterRule.IPProto`
4. meshnet's `MatchesFromFilterRules()` already handles `IPProto` — it filters the protocol list to valid `ipproto.Proto` values and uses `defaultProtos` (TCP, UDP, ICMPv4, ICMPv6) when nil

## Verification

- `go build ./...` — zero errors
- `go vet ./...` — zero warnings  
- `go test ./... -count=1 -race` — all tests pass, no data races