### PR TITLE
feat: add invite-link network joining

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,22 +18,22 @@ DWN. See [DESIGN.md](DESIGN.md) for the full architecture.
 
 ```bash
 # On your first machine
-meshd up --create my-network --endpoint https://dwn.example.com
+meshd network create my-network --endpoint https://dwn.example.com
 # prints: Your device identity: did:jwk:eyJr...
 # prints: Network "my-network" created. Mesh IP: 10.200.x.x
-# prints: To add a peer: meshd peer add <their-did>
+# prints: Create a join invite with: meshd invite create
 
-# On your second machine
-meshd init
-# prints: Your device identity: did:jwk:eyJr...
+# Create an invite URL
+meshd invite create
+# prints: meshd://invite/eyJ...
 
-# Back on the first machine, add the second
-meshd peer add did:jwk:eyJr...
+# On your second machine, join from the invite
+meshd join meshd://invite/eyJ...
 
-# On the second machine, join and start
-meshd up --endpoint https://dwn.example.com --anchor <first-did> --network <network-id>
+# Start meshd on both machines
+meshd up
 
-# That's it. The machines can reach each other at 10.200.x.x
+# That's it. After the anchor approves the invite, the machines can reach each other at 10.200.x.x
 # through encrypted WireGuard tunnels. NAT traversal is automatic.
 ```
 
@@ -98,6 +98,8 @@ Network:
   network create    Create a new mesh network on a DWN
   network join      Join an existing mesh network
   network leave     Leave the current mesh network
+  invite create     Create an invite URL for joining this network
+  join <url>        Join a network from a meshd://invite URL
   peer add          Add a peer to the mesh (anchor only)
   peer list         List all peers in the mesh
   peer approve      Deliver encryption keys to a peer (anchor only)

--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/enboxorg/meshd/internal/dwn"
 	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
 	"github.com/enboxorg/meshd/internal/engine"
+	"github.com/enboxorg/meshd/internal/invite"
 	"github.com/enboxorg/meshd/internal/mesh"
 	"github.com/enboxorg/meshd/internal/profile"
 	"github.com/enboxorg/meshd/internal/state"
@@ -43,6 +44,8 @@ Network:
   network create    Create a new mesh network on a DWN
   network join      Join an existing mesh network
   network leave     Leave the current mesh network
+  invite create     Create an invite URL for joining this network
+  join <url>        Join a network from a meshd://invite URL
   peer add          Add a peer to the mesh (anchor only)
   peer list         List all peers in the mesh
   peer approve      Deliver encryption keys to a peer (anchor only)
@@ -65,7 +68,8 @@ Up flags:
 
 Quick start:
   meshd up --create my-network --endpoint https://dwn.example.com
-  meshd up --endpoint <url> --anchor <did> --network <id>
+  meshd invite create
+  meshd join meshd://invite/<token>
 
 Global flags:
   --profile <name>  Use a specific identity profile
@@ -94,6 +98,7 @@ func main() {
 		combined := os.Args[1] + " " + os.Args[2]
 		switch combined {
 		case "network create", "network join", "network leave",
+			"invite create",
 			"peer list", "peer add", "peer approve",
 			"acl set", "acl show",
 			"auth login", "auth list", "auth use", "auth logout":
@@ -131,6 +136,10 @@ func main() {
 		err = cmdNetworkJoin(ctx, args, flagProfile)
 	case "network leave":
 		err = cmdNetworkLeave(ctx, args, flagProfile)
+	case "invite create":
+		err = cmdInviteCreate(ctx, args, flagProfile)
+	case "join":
+		err = cmdJoin(ctx, args, flagProfile)
 	case "peer add":
 		err = cmdPeerAdd(ctx, args, flagProfile)
 	case "peer list":
@@ -191,8 +200,6 @@ func cmdInit(ctx context.Context, args []string, flagProfile string) error {
 	fmt.Printf("  State: %s\n", stateDir)
 	return nil
 }
-
-
 
 // cmdNetworkCreate creates a new mesh network.
 //
@@ -373,9 +380,8 @@ func cmdNetworkCreate(ctx context.Context, args []string, flagProfile string) er
 	fmt.Printf("  Mesh IP: %s\n", meshIP)
 	fmt.Printf("  Record: %s\n", record.ID)
 	fmt.Printf("  Anchor: %s\n", endpoint)
-	fmt.Printf("\nShare this join token with peers:\n")
-	fmt.Printf("  meshd network join --endpoint %s --anchor %s --network %s\n",
-		endpoint, identity.URI, record.ID)
+	fmt.Printf("\nCreate a join invite with:\n")
+	fmt.Printf("  meshd invite create\n")
 
 	return nil
 }
@@ -384,7 +390,12 @@ func cmdNetworkCreate(ctx context.Context, args []string, flagProfile string) er
 //
 // Usage: meshd network join --endpoint <url> --anchor <did> --network <id>
 func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) error {
+	if len(args) == 1 && strings.HasPrefix(strings.TrimSpace(args[0]), invite.SchemePrefix) {
+		return cmdJoin(ctx, args, flagProfile)
+	}
+
 	var endpoint, anchorDID, networkID string
+	preauthRequested := false
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--endpoint":
@@ -402,6 +413,8 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 				networkID = args[i+1]
 				i++
 			}
+		case "--preauth":
+			preauthRequested = true
 		}
 	}
 
@@ -538,8 +551,13 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 	}
 
 	if nodeRecordID == "" {
-		fmt.Printf("  No node record found — the anchor needs to run:\n")
-		fmt.Printf("    meshd peer add %s\n", identity.URI)
+		if preauthRequested {
+			fmt.Printf("  Join request submitted. Waiting for the anchor to approve this invite.\n")
+			fmt.Printf("  Run 'meshd up' again after the anchor has processed the request.\n")
+		} else {
+			fmt.Printf("  No node record found — the anchor needs to run:\n")
+			fmt.Printf("    meshd peer add %s\n", identity.URI)
+		}
 	}
 
 	// Fetch and persist context key if available.
@@ -640,6 +658,165 @@ func cmdNetworkLeave(ctx context.Context, args []string, flagProfile string) err
 	}
 	fmt.Printf("Left network %q.\n", name)
 	return nil
+}
+
+// cmdInviteCreate creates a preauth invite URL for the current network.
+//
+// Usage: meshd invite create [--label <label>] [--expires <duration>] [--reusable] [--ephemeral]
+func cmdInviteCreate(ctx context.Context, args []string, flagProfile string) error {
+	label := ""
+	expires := 24 * time.Hour
+	reusable := false
+	ephemeral := false
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--label":
+			if i+1 < len(args) {
+				label = args[i+1]
+				i++
+			}
+		case "--expires":
+			if i+1 < len(args) {
+				if args[i+1] == "never" || args[i+1] == "0" {
+					expires = 0
+				} else {
+					d, err := time.ParseDuration(args[i+1])
+					if err != nil {
+						return fmt.Errorf("invalid --expires duration %q: %w", args[i+1], err)
+					}
+					expires = d
+				}
+				i++
+			}
+		case "--reusable":
+			reusable = true
+		case "--ephemeral":
+			ephemeral = true
+		}
+	}
+
+	stateDir, err := resolveStateDir(flagProfile)
+	if err != nil {
+		return err
+	}
+	identity, err := loadIdentity(stateDir)
+	if err != nil {
+		return err
+	}
+	ns, err := state.LoadNetworkState(stateDir)
+	if err != nil {
+		return fmt.Errorf("loading network state: %w", err)
+	}
+	if ns == nil {
+		return fmt.Errorf("not in a network. Use 'meshd network create' first.")
+	}
+	if ns.AnchorDID != identity.URI {
+		return fmt.Errorf("only the network anchor (%s) can create invites", ns.AnchorDID)
+	}
+
+	expiresAt := time.Time{}
+	if expires > 0 {
+		expiresAt = time.Now().Add(expires)
+	}
+	if label == "" {
+		label = ns.NetworkName
+	}
+
+	signer := &dwn.Signer{DID: identity.URI, PrivateKey: identity.SigningKey}
+	result, err := mesh.CreatePreAuthKey(ctx, mesh.CreatePreAuthKeyParams{
+		AnchorEndpoint:       ns.AnchorEndpoint,
+		AnchorDID:            ns.AnchorDID,
+		NetworkRecordID:      ns.NetworkRecordID,
+		NetworkName:          ns.NetworkName,
+		Signer:               signer,
+		EncryptionKeyManager: newEncryptionKeyManager(identity),
+		Label:                label,
+		ExpiresAt:            expiresAt,
+		Reusable:             reusable,
+		Ephemeral:            ephemeral,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Invite created for %q.\n", ns.NetworkName)
+	if result.ExpiresAt != "" {
+		fmt.Printf("  Expires: %s\n", result.ExpiresAt)
+	}
+	if reusable {
+		fmt.Printf("  Reusable: yes\n")
+	} else {
+		fmt.Printf("  Reusable: no\n")
+	}
+	fmt.Printf("\n%s\n", result.URL)
+	fmt.Printf("\nJoin from another device with:\n")
+	fmt.Printf("  meshd join %s\n", result.URL)
+	return nil
+}
+
+// cmdJoin joins a network from a meshd://invite URL.
+//
+// Usage: meshd join <meshd://invite/...>
+func cmdJoin(ctx context.Context, args []string, flagProfile string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: meshd join <meshd://invite/...>")
+	}
+
+	payload, err := invite.Decode(args[0])
+	if err != nil {
+		return err
+	}
+
+	stateDir, identity, err := ensureIdentityForCommand(ctx, flagProfile, payload.Endpoint)
+	if err != nil {
+		return err
+	}
+	if state.HasNetwork(stateDir) {
+		ns, loadErr := state.LoadNetworkState(stateDir)
+		if loadErr != nil {
+			return fmt.Errorf("loading network state: %w", loadErr)
+		}
+		if ns != nil && ns.NetworkRecordID == payload.NetworkID && ns.AnchorDID == payload.AnchorDID && ns.NodeRecordID == "" {
+			refreshed, err := refreshPendingJoin(ctx, stateDir, ns, flagProfile)
+			if err != nil {
+				return err
+			}
+			if refreshed.NodeRecordID == "" {
+				fmt.Printf("Join request is still pending anchor approval.\n")
+			}
+			return nil
+		}
+		return fmt.Errorf("already in a network. Use 'meshd network leave' first.")
+	}
+
+	preauth := payload.TokenID != "" || payload.Secret != ""
+	if preauth {
+		if err := payload.ValidatePreAuth(); err != nil {
+			return err
+		}
+		label, _ := os.Hostname()
+		signer := &dwn.Signer{DID: identity.URI, PrivateKey: identity.SigningKey}
+		if err := mesh.WritePreAuthNodeRequest(ctx, mesh.WritePreAuthNodeRequestParams{
+			Invite:  payload,
+			NodeDID: identity.URI,
+			Signer:  signer,
+			Label:   label,
+		}); err != nil {
+			return err
+		}
+		fmt.Printf("Join request submitted for %q.\n", payload.NetworkName)
+	}
+
+	joinArgs := []string{
+		"--endpoint", payload.Endpoint,
+		"--anchor", payload.AnchorDID,
+		"--network", payload.NetworkID,
+	}
+	if preauth {
+		joinArgs = append(joinArgs, "--preauth")
+	}
+	return cmdNetworkJoin(ctx, joinArgs, flagProfile)
 }
 
 // cmdPeerList lists all peers in the current mesh network.
@@ -835,9 +1012,12 @@ func cmdPeerAdd(ctx context.Context, args []string, flagProfile string) error {
 	fmt.Printf("  Context key delivered.\n")
 
 	fmt.Printf("\nPeer added to network %q.\n", ns.NetworkName)
+	joinURL, err := invite.Encode(invite.New(ns.AnchorEndpoint, ns.AnchorDID, ns.NetworkRecordID, ns.NetworkName, "", "", ""))
+	if err != nil {
+		return err
+	}
 	fmt.Printf("The peer can now join with:\n")
-	fmt.Printf("  meshd network join --endpoint %s --anchor %s --network %s\n",
-		ns.AnchorEndpoint, ns.AnchorDID, ns.NetworkRecordID)
+	fmt.Printf("  meshd join %s\n", joinURL)
 
 	return nil
 }
@@ -984,6 +1164,7 @@ type upFlags struct {
 	endpoint      string // --endpoint <url>: DWN endpoint
 	anchorDID     string // --anchor <did>: anchor DID for joining
 	networkID     string // --network <id>: network record ID for joining
+	inviteURL     string // positional meshd://invite URL
 
 	// Engine flags.
 	tunName      string        // --tun [name]: TUN device name
@@ -1043,6 +1224,10 @@ func parseUpFlags(args []string) upFlags {
 			f.noTun = true
 		case "-v", "--verbose":
 			f.verbose = true
+		default:
+			if !strings.HasPrefix(args[i], "-") && strings.HasPrefix(strings.TrimSpace(args[i]), invite.SchemePrefix) {
+				f.inviteURL = args[i]
+			}
 		}
 	}
 
@@ -1073,28 +1258,9 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 	f := parseUpFlags(args)
 
 	// ── Step 1: Ensure identity exists ──────────────────────────────
-	stateDir, err := resolveStateDir(flagProfile)
+	stateDir, identity, err := ensureIdentityForCommand(ctx, flagProfile, f.endpoint)
 	if err != nil {
 		return err
-	}
-
-	var identity *did.DID
-	if did.Exists(stateDir) {
-		identity, err = did.Load(stateDir)
-		if err != nil {
-			return fmt.Errorf("loading identity: %w", err)
-		}
-	} else {
-		fmt.Println("No identity found. Creating one...")
-		identity, err = ensureIdentity(ctx, flagProfile, f.endpoint)
-		if err != nil {
-			return err
-		}
-		// Re-resolve stateDir after profile creation.
-		stateDir, err = resolveStateDir(flagProfile)
-		if err != nil {
-			return err
-		}
 	}
 
 	// ── Step 2: Ensure network membership ───────────────────────────
@@ -1108,6 +1274,15 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 		ns, err = ensureNetwork(ctx, f, stateDir, identity, flagProfile)
 		if err != nil {
 			return err
+		}
+	}
+	if ns.NodeRecordID == "" && ns.AnchorDID != identity.URI {
+		ns, err = refreshPendingJoin(ctx, stateDir, ns, flagProfile)
+		if err != nil {
+			return err
+		}
+		if ns.NodeRecordID == "" {
+			return fmt.Errorf("join request is still pending anchor approval; run 'meshd up' again after the anchor is online")
 		}
 	}
 
@@ -1242,6 +1417,9 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 			fmt.Printf("  Auto key delivery: enabled (anchor node)\n")
 		}
 	}
+	if ns.AnchorDID == identity.URI {
+		approvePreAuthRequests(ctx, ns, signer, encMgr, logger)
+	}
 
 	// Determine the protocol role for DWN queries. The anchor reads as
 	// author (no role needed). Non-anchor nodes use their node role.
@@ -1264,7 +1442,7 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 		AutoKeyDelivery:      autoKeyDelivery,
 		UseContextEncryption: useContextEncryption,
 		WireGuardPrivateKey:  wgKeys.PrivateKey,
-		TUNName:             f.tunName,
+		TUNName:              f.tunName,
 		Domain:               ns.NetworkName,
 		ListenPort:           f.listenPort,
 		PollInterval:         f.pollInterval,
@@ -1294,6 +1472,17 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 		logger.Warn("daemon control socket failed to start", slog.Any("error", err))
 	} else {
 		defer daemonSrv.Stop()
+	}
+
+	var stopPreAuthApproval chan struct{}
+	if ns.AnchorDID == identity.URI {
+		stopPreAuthApproval = make(chan struct{})
+		interval := f.pollInterval
+		if interval == 0 {
+			interval = 30 * time.Second
+		}
+		go runPreAuthApprovalLoop(ctx, stopPreAuthApproval, interval, ns, signer, encMgr, logger)
+		defer close(stopPreAuthApproval)
 	}
 
 	fmt.Printf("  Status: running\n")
@@ -1353,11 +1542,46 @@ func ensureIdentity(ctx context.Context, flagProfile, endpoint string) (*did.DID
 	return identity, nil
 }
 
+func ensureIdentityForCommand(ctx context.Context, flagProfile, endpoint string) (string, *did.DID, error) {
+	stateDir, err := resolveStateDir(flagProfile)
+	if err == profile.ErrNoProfiles {
+		fmt.Println("No identity found. Creating one...")
+		if _, err := ensureIdentity(ctx, flagProfile, endpoint); err != nil {
+			return "", nil, err
+		}
+		stateDir, err = resolveStateDir(flagProfile)
+	}
+	if err != nil {
+		return "", nil, err
+	}
+
+	if did.Exists(stateDir) {
+		identity, err := did.Load(stateDir)
+		if err != nil {
+			return "", nil, fmt.Errorf("loading identity: %w", err)
+		}
+		return stateDir, identity, nil
+	}
+
+	fmt.Println("No identity found. Creating one...")
+	identity, err := ensureIdentity(ctx, flagProfile, endpoint)
+	if err != nil {
+		return "", nil, err
+	}
+	stateDir, err = resolveStateDir(flagProfile)
+	if err != nil {
+		return "", nil, err
+	}
+	return stateDir, identity, nil
+}
+
 // ensureNetwork handles network setup when the user is not yet in a network.
 // It checks flags (--create, --anchor+--network) and falls back to an
 // interactive prompt.
 func ensureNetwork(ctx context.Context, f upFlags, stateDir string, identity *did.DID, flagProfile string) (*state.NetworkState, error) {
 	switch {
+	case f.inviteURL != "":
+		return setupJoinInvite(ctx, f, stateDir, identity, flagProfile)
 	case f.createNetwork != "":
 		return setupCreateNetwork(ctx, f, stateDir, identity, flagProfile)
 	case f.anchorDID != "" && f.networkID != "":
@@ -1418,6 +1642,54 @@ func setupJoinNetwork(ctx context.Context, f upFlags, stateDir string, identity 
 		return nil, fmt.Errorf("network state not found after join")
 	}
 	return ns, nil
+}
+
+// setupJoinInvite joins an existing network from an invite URL.
+func setupJoinInvite(ctx context.Context, f upFlags, stateDir string, identity *did.DID, flagProfile string) (*state.NetworkState, error) {
+	if err := cmdJoin(ctx, []string{f.inviteURL}, flagProfile); err != nil {
+		return nil, err
+	}
+	ns, err := state.LoadNetworkState(stateDir)
+	if err != nil {
+		return nil, fmt.Errorf("loading network state after invite join: %w", err)
+	}
+	if ns == nil {
+		return nil, fmt.Errorf("network state not found after invite join")
+	}
+	return ns, nil
+}
+
+func refreshPendingJoin(ctx context.Context, stateDir string, ns *state.NetworkState, flagProfile string) (*state.NetworkState, error) {
+	if ns == nil {
+		return nil, fmt.Errorf("network state is missing")
+	}
+	previous := *ns
+
+	fmt.Printf("Checking pending join approval...\n")
+	if err := state.ClearNetworkState(stateDir); err != nil {
+		return nil, fmt.Errorf("clearing pending network state: %w", err)
+	}
+	err := cmdNetworkJoin(ctx, []string{
+		"--endpoint", ns.AnchorEndpoint,
+		"--anchor", ns.AnchorDID,
+		"--network", ns.NetworkRecordID,
+		"--preauth",
+	}, flagProfile)
+	if err != nil {
+		_ = state.SaveNetworkState(stateDir, &previous)
+		return nil, err
+	}
+
+	refreshed, err := state.LoadNetworkState(stateDir)
+	if err != nil {
+		_ = state.SaveNetworkState(stateDir, &previous)
+		return nil, fmt.Errorf("loading refreshed network state: %w", err)
+	}
+	if refreshed == nil {
+		_ = state.SaveNetworkState(stateDir, &previous)
+		return &previous, nil
+	}
+	return refreshed, nil
 }
 
 // setupInteractive prompts the user to create or join a network.
@@ -1589,6 +1861,47 @@ func fetchContextKey(ctx context.Context, identity *did.DID, ns *state.NetworkSt
 		SelfDID:        identity.URI,
 		Signer:         signer,
 	})
+}
+
+func approvePreAuthRequests(ctx context.Context, ns *state.NetworkState, signer *dwn.Signer, encMgr *dwncrypto.EncryptionKeyManager, logger *slog.Logger) {
+	result, err := mesh.ApprovePreAuthRequests(ctx, mesh.ApprovePreAuthRequestsParams{
+		AnchorEndpoint:       ns.AnchorEndpoint,
+		AnchorDID:            ns.AnchorDID,
+		NetworkRecordID:      ns.NetworkRecordID,
+		MeshCIDR:             ns.MeshCIDR,
+		Signer:               signer,
+		EncryptionKeyManager: encMgr,
+	})
+	if err != nil {
+		logger.Warn("preauth approval failed", slog.Any("error", err))
+		return
+	}
+	if result.Approved > 0 {
+		fmt.Printf("  Invite requests approved: %d\n", result.Approved)
+	}
+	if result.Rejected > 0 || result.Pending > 0 {
+		logger.Debug("processed invite requests",
+			slog.Int("approved", result.Approved),
+			slog.Int("rejected", result.Rejected),
+			slog.Int("pending", result.Pending),
+		)
+	}
+}
+
+func runPreAuthApprovalLoop(ctx context.Context, stop <-chan struct{}, interval time.Duration, ns *state.NetworkState, signer *dwn.Signer, encMgr *dwncrypto.EncryptionKeyManager, logger *slog.Logger) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-stop:
+			return
+		case <-ticker.C:
+			approvePreAuthRequests(ctx, ns, signer, encMgr, logger)
+		}
+	}
 }
 
 // universalResolver adapts the pkg/dids universal resolver to the

--- a/cmd/meshd/main_test.go
+++ b/cmd/meshd/main_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/enboxorg/meshd/internal/invite"
+	"github.com/enboxorg/meshd/internal/profile"
+)
+
+func TestParseUpFlagsInviteURL(t *testing.T) {
+	u, err := invite.Encode(invite.New("https://dwn.example.com", "did:jwk:anchor", "net", "home", "", "", ""))
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	flags := parseUpFlags([]string{u, "--no-tun"})
+	if flags.inviteURL != u {
+		t.Fatalf("inviteURL = %q, want %q", flags.inviteURL, u)
+	}
+	if !flags.noTun {
+		t.Fatal("expected --no-tun to be parsed")
+	}
+}
+
+func TestEnsureIdentityForCommandCreatesDefaultProfile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("ENBOX_HOME", home)
+	t.Setenv("ENBOX_PROFILE", "")
+	t.Setenv("MESHD_STATE_DIR", "")
+
+	stateDir, identity, err := ensureIdentityForCommand(context.Background(), "", "")
+	if err != nil {
+		t.Fatalf("ensureIdentityForCommand: %v", err)
+	}
+	if identity == nil || identity.URI == "" {
+		t.Fatal("identity was not created")
+	}
+	if !strings.HasPrefix(stateDir, home) {
+		t.Fatalf("stateDir = %q, want under %q", stateDir, home)
+	}
+
+	cfg, err := profile.ReadConfig()
+	if err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+	if cfg.DefaultProfile != "default" {
+		t.Fatalf("DefaultProfile = %q, want default", cfg.DefaultProfile)
+	}
+	if cfg.Profiles["default"] == nil {
+		t.Fatal("default profile was not saved")
+	}
+}

--- a/internal/control/control_test.go
+++ b/internal/control/control_test.go
@@ -493,7 +493,7 @@ func TestDetectDerivationScheme(t *testing.T) {
 func TestParseEntryData(t *testing.T) {
 	t.Run("direct JSON", func(t *testing.T) {
 		var net NetworkConfig
-		err := parseEntryData([]byte(`{"name":"test","meshCIDR":"10.200.0.0/16"}`), &net, nil)
+		err := ParseEntryData([]byte(`{"name":"test","meshCIDR":"10.200.0.0/16"}`), &net, nil)
 		if err != nil {
 			t.Fatalf("error: %v", err)
 		}
@@ -505,7 +505,7 @@ func TestParseEntryData(t *testing.T) {
 	t.Run("wrapped encodedData", func(t *testing.T) {
 		wrapped := `{"recordsWrite":{"encodedData":"eyJuYW1lIjoid3JhcHBlZCIsIm1lc2hDSURSIjoiMTAuMjAwLjAuMC8xNiJ9"}}`
 		var net NetworkConfig
-		err := parseEntryData([]byte(wrapped), &net, nil)
+		err := ParseEntryData([]byte(wrapped), &net, nil)
 		if err != nil {
 			t.Fatalf("error: %v", err)
 		}
@@ -516,7 +516,7 @@ func TestParseEntryData(t *testing.T) {
 
 	t.Run("nil entry", func(t *testing.T) {
 		var net NetworkConfig
-		err := parseEntryData(nil, &net, nil)
+		err := ParseEntryData(nil, &net, nil)
 		if !errors.Is(err, ErrNoEntry) {
 			t.Errorf("got %v, want %v", err, ErrNoEntry)
 		}
@@ -525,7 +525,7 @@ func TestParseEntryData(t *testing.T) {
 	t.Run("flat encodedData", func(t *testing.T) {
 		flat := `{"encodedData":"eyJuYW1lIjoiZmxhdCIsIm1lc2hDSURSIjoiMTAuMjAwLjAuMC8xNiJ9"}`
 		var net NetworkConfig
-		err := parseEntryData([]byte(flat), &net, nil)
+		err := ParseEntryData([]byte(flat), &net, nil)
 		if err != nil {
 			t.Fatalf("error: %v", err)
 		}
@@ -574,7 +574,7 @@ func TestParseEntryData(t *testing.T) {
 		}
 
 		var net NetworkConfig
-		err = parseEntryData(entry, &net, decryptor)
+		err = ParseEntryData(entry, &net, decryptor)
 		if err != nil {
 			t.Fatalf("error: %v", err)
 		}
@@ -600,14 +600,14 @@ func TestParsePortRange(t *testing.T) {
 		{"80-443", PortRange{80, 443}, true},
 		{"8000-9000", PortRange{8000, 9000}, true},
 		{"0-65535", PortRange{0, 65535}, true},
-		{"443-80", PortRange{}, false},     // first > last
-		{"65536", PortRange{}, false},      // overflow
-		{"", PortRange{}, false},           // empty
-		{"abc", PortRange{}, false},        // non-numeric
-		{"80-", PortRange{}, false},        // missing last
-		{"-80", PortRange{}, false},        // missing first
-		{"80-abc", PortRange{}, false},     // non-numeric last
-		{"100000", PortRange{}, false},     // too large
+		{"443-80", PortRange{}, false}, // first > last
+		{"65536", PortRange{}, false},  // overflow
+		{"", PortRange{}, false},       // empty
+		{"abc", PortRange{}, false},    // non-numeric
+		{"80-", PortRange{}, false},    // missing last
+		{"-80", PortRange{}, false},    // missing first
+		{"80-abc", PortRange{}, false}, // non-numeric last
+		{"100000", PortRange{}, false}, // too large
 	}
 
 	for _, tc := range tests {
@@ -827,9 +827,9 @@ func TestBuildFilterRules_DirectIP(t *testing.T) {
 			Version: 1,
 			Rules: []ACLRule{
 				{
-					Action: "accept",
-					Src:    []string{"10.200.0.0/16"},
-					Dst:    []string{"10.200.0.5"},
+					Action:   "accept",
+					Src:      []string{"10.200.0.0/16"},
+					Dst:      []string{"10.200.0.5"},
 					DstPorts: []string{"80"},
 				},
 			},

--- a/internal/control/dwnclient.go
+++ b/internal/control/dwnclient.go
@@ -174,7 +174,7 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 
 	var network NetworkConfig
 	// Network record is NOT encrypted (publicly readable anchor).
-	if err := parseEntryData(netResp.Reply.Entry, &network, nil); err != nil {
+	if err := ParseEntryData(netResp.Reply.Entry, &network, nil); err != nil {
 		return nil, fmt.Errorf("parsing network: %w", err)
 	}
 
@@ -233,7 +233,7 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 				memberDID := meta.Recipient
 
 				var member MemberRecord
-				if err := parseEntryData(entry, &member, memberDecryptor); err != nil {
+				if err := ParseEntryData(entry, &member, memberDecryptor); err != nil {
 					c.logger.DebugContext(ctx, "parsing member entry",
 						slog.Any("error", err),
 						slog.String("memberDID", memberDID),
@@ -315,7 +315,7 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 	c.relays = nil // Clear stale relays before repopulating.
 	for _, entry := range relayEntries {
 		var relay RelayData
-		if err := parseEntryData(entry, &relay, relayDecryptor); err != nil {
+		if err := ParseEntryData(entry, &relay, relayDecryptor); err != nil {
 			c.logger.DebugContext(ctx, "parsing relay entry", slog.Any("error", err))
 			continue
 		}
@@ -340,7 +340,7 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 			// $recordLimit: max 1 — take the first (most recent) entry.
 			aclDecryptor := c.makeDecryptor("network/aclPolicy")
 			var policy ACLPolicyData
-			if err := parseEntryData(aclEntries[0], &policy, aclDecryptor); err != nil {
+			if err := ParseEntryData(aclEntries[0], &policy, aclDecryptor); err != nil {
 				c.logger.DebugContext(ctx, "parsing ACL policy entry", slog.Any("error", err))
 			} else {
 				c.mu.Lock()
@@ -385,12 +385,12 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 // loadNodeEntry parses a node record entry and adds it to the nodes map.
 // memberRecordID is the parent member record ID (empty for owner-provisioned nodes).
 // Caller must hold c.mu.
-func (c *DWNClient) loadNodeEntry(ctx context.Context, entry json.RawMessage, decryptor entryDecryptor, memberRecordID string) {
+func (c *DWNClient) loadNodeEntry(ctx context.Context, entry json.RawMessage, decryptor EntryDecryptor, memberRecordID string) {
 	meta := extractEntryMetadata(entry)
 	nodeDID := meta.Recipient
 
 	var node NodeRecord
-	if err := parseEntryData(entry, &node, decryptor); err != nil {
+	if err := ParseEntryData(entry, &node, decryptor); err != nil {
 		c.logger.DebugContext(ctx, "parsing node entry",
 			slog.Any("error", err),
 			slog.String("nodeDID", nodeDID),
@@ -416,7 +416,7 @@ func (c *DWNClient) loadNodeEntry(ctx context.Context, entry json.RawMessage, de
 
 // loadChildRecords queries child records at the given protocol path and
 // processes each entry with the provided handler function.
-func (c *DWNClient) loadChildRecords(ctx context.Context, protocolPath string, role string, handler func(ctx context.Context, entry json.RawMessage, decryptor entryDecryptor)) {
+func (c *DWNClient) loadChildRecords(ctx context.Context, protocolPath string, role string, handler func(ctx context.Context, entry json.RawMessage, decryptor EntryDecryptor)) {
 	resp, err := c.anchorDWN.RecordsQuery(ctx, c.anchorTenant, dwn.RecordsFilter{
 		Protocol:     protocols.MeshProtocolURI,
 		ProtocolPath: protocolPath,
@@ -454,10 +454,10 @@ func (c *DWNClient) loadChildRecords(ctx context.Context, protocolPath string, r
 
 // loadNodeInfoEntry parses a nodeInfo entry and attaches it to the parent node.
 // Caller must hold c.mu.
-func (c *DWNClient) loadNodeInfoEntry(ctx context.Context, entry json.RawMessage, decryptor entryDecryptor) {
+func (c *DWNClient) loadNodeInfoEntry(ctx context.Context, entry json.RawMessage, decryptor EntryDecryptor) {
 	meta := extractEntryMetadata(entry)
 	var info NodeInfoData
-	if err := parseEntryData(entry, &info, decryptor); err != nil {
+	if err := ParseEntryData(entry, &info, decryptor); err != nil {
 		c.logger.DebugContext(ctx, "parsing nodeInfo entry", slog.Any("error", err))
 		return
 	}
@@ -474,10 +474,10 @@ func (c *DWNClient) loadNodeInfoEntry(ctx context.Context, entry json.RawMessage
 
 // loadEndpointEntry parses an endpoint entry and attaches it to the parent node.
 // Caller must hold c.mu.
-func (c *DWNClient) loadEndpointEntry(ctx context.Context, entry json.RawMessage, decryptor entryDecryptor) {
+func (c *DWNClient) loadEndpointEntry(ctx context.Context, entry json.RawMessage, decryptor EntryDecryptor) {
 	meta := extractEntryMetadata(entry)
 	var ep EndpointData
-	if err := parseEntryData(entry, &ep, decryptor); err != nil {
+	if err := ParseEntryData(entry, &ep, decryptor); err != nil {
 		c.logger.DebugContext(ctx, "parsing endpoint entry", slog.Any("error", err))
 		return
 	}
@@ -1031,10 +1031,10 @@ func extractEntryMetadata(entry json.RawMessage) entryMetadata {
 	return meta
 }
 
-// parseEntryData extracts the data from a DWN read response entry.
+// ParseEntryData extracts the data from a DWN read response entry.
 // If the entry contains encryption metadata and a decryptor is provided,
 // the data is decrypted before unmarshaling.
-func parseEntryData(entry json.RawMessage, dst any, decryptor entryDecryptor) error {
+func ParseEntryData(entry json.RawMessage, dst any, decryptor EntryDecryptor) error {
 	if entry == nil {
 		return ErrNoEntry
 	}
@@ -1042,7 +1042,7 @@ func parseEntryData(entry json.RawMessage, dst any, decryptor entryDecryptor) er
 	// First try wrapped entry (RecordsRead response format).
 	var wrapped struct {
 		RecordsWrite struct {
-			EncodedData string               `json:"encodedData"`
+			EncodedData string                `json:"encodedData"`
 			Encryption  *dwncrypto.Encryption `json:"encryption"`
 		} `json:"recordsWrite"`
 	}
@@ -1065,7 +1065,7 @@ func parseEntryData(entry json.RawMessage, dst any, decryptor entryDecryptor) er
 
 	// Try flat entry format (query results).
 	var flat struct {
-		EncodedData string               `json:"encodedData"`
+		EncodedData string                `json:"encodedData"`
 		Encryption  *dwncrypto.Encryption `json:"encryption"`
 	}
 	if err := json.Unmarshal(entry, &flat); err == nil && flat.EncodedData != "" {
@@ -1089,8 +1089,8 @@ func parseEntryData(entry json.RawMessage, dst any, decryptor entryDecryptor) er
 	return json.Unmarshal(entry, dst)
 }
 
-// entryDecryptor is a function that decrypts ciphertext using the JWE metadata.
-type entryDecryptor func(ciphertext []byte, enc *dwncrypto.Encryption) ([]byte, error)
+// EntryDecryptor is a function that decrypts ciphertext using the JWE metadata.
+type EntryDecryptor func(ciphertext []byte, enc *dwncrypto.Encryption) ([]byte, error)
 
 // makeDecryptor creates a decryptor function from an EncryptionKeyManager
 // and a protocol path. Returns nil if no key manager is available.
@@ -1099,7 +1099,7 @@ type entryDecryptor func(ciphertext []byte, enc *dwncrypto.Encryption) ([]byte, 
 // scheme used and applies the correct decryption strategy:
 //   - protocolPath: derives the key from root via HKDF at the given path
 //   - protocolContext: uses a delivered context key (or derives from root if owner)
-func (c *DWNClient) makeDecryptor(protocolPath string) entryDecryptor {
+func (c *DWNClient) makeDecryptor(protocolPath string) EntryDecryptor {
 	if c.encManager == nil {
 		return nil
 	}

--- a/internal/invite/invite.go
+++ b/internal/invite/invite.go
@@ -1,0 +1,142 @@
+// Package invite encodes meshd network invite URLs.
+package invite
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const (
+	// SchemePrefix is the canonical URL prefix for meshd network invites.
+	SchemePrefix = "meshd://invite/"
+
+	currentVersion = 1
+	secretBytes    = 32
+)
+
+// Payload is the data carried by a meshd invite URL.
+type Payload struct {
+	Version     int    `json:"version"`
+	Endpoint    string `json:"endpoint"`
+	AnchorDID   string `json:"anchorDid"`
+	NetworkID   string `json:"networkId"`
+	NetworkName string `json:"networkName,omitempty"`
+	TokenID     string `json:"tokenId,omitempty"`
+	Secret      string `json:"secret,omitempty"`
+	ExpiresAt   string `json:"expiresAt,omitempty"`
+}
+
+// New constructs a normalized invite payload.
+func New(endpoint, anchorDID, networkID, networkName, tokenID, secret, expiresAt string) Payload {
+	return Payload{
+		Version:     currentVersion,
+		Endpoint:    strings.TrimSpace(endpoint),
+		AnchorDID:   strings.TrimSpace(anchorDID),
+		NetworkID:   strings.TrimSpace(networkID),
+		NetworkName: strings.TrimSpace(networkName),
+		TokenID:     strings.TrimSpace(tokenID),
+		Secret:      strings.TrimSpace(secret),
+		ExpiresAt:   strings.TrimSpace(expiresAt),
+	}
+}
+
+// Encode serializes a payload as a meshd://invite URL.
+func Encode(p Payload) (string, error) {
+	if p.Version == 0 {
+		p.Version = currentVersion
+	}
+	if err := p.Validate(); err != nil {
+		return "", err
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		return "", fmt.Errorf("marshal invite: %w", err)
+	}
+	return SchemePrefix + base64.RawURLEncoding.EncodeToString(data), nil
+}
+
+// Decode parses a meshd://invite URL or the raw base64url payload.
+func Decode(s string) (Payload, error) {
+	raw := strings.TrimSpace(s)
+	if strings.HasPrefix(raw, SchemePrefix) {
+		raw = strings.TrimPrefix(raw, SchemePrefix)
+	}
+	if raw == "" {
+		return Payload{}, fmt.Errorf("empty invite")
+	}
+
+	data, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return Payload{}, fmt.Errorf("decode invite payload: %w", err)
+	}
+
+	var p Payload
+	if err := json.Unmarshal(data, &p); err != nil {
+		return Payload{}, fmt.Errorf("parse invite payload: %w", err)
+	}
+	if err := p.Validate(); err != nil {
+		return Payload{}, err
+	}
+	return p, nil
+}
+
+// Validate checks that a payload has the fields needed to join a network.
+func (p Payload) Validate() error {
+	if p.Version != currentVersion {
+		return fmt.Errorf("unsupported invite version %d", p.Version)
+	}
+	if p.Endpoint == "" {
+		return fmt.Errorf("invite missing endpoint")
+	}
+	if p.AnchorDID == "" {
+		return fmt.Errorf("invite missing anchor DID")
+	}
+	if p.NetworkID == "" {
+		return fmt.Errorf("invite missing network ID")
+	}
+	return nil
+}
+
+// ValidatePreAuth checks that a payload has the token fields needed to submit a
+// self-service preauth join request.
+func (p Payload) ValidatePreAuth() error {
+	if err := p.Validate(); err != nil {
+		return err
+	}
+	if p.TokenID == "" {
+		return fmt.Errorf("invite missing token ID")
+	}
+	if p.Secret == "" {
+		return fmt.Errorf("invite missing secret")
+	}
+	return nil
+}
+
+// GenerateSecret returns a new URL-safe random invite secret.
+func GenerateSecret() (string, error) {
+	var b [secretBytes]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("generate invite secret: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b[:]), nil
+}
+
+// Proof creates a non-secret preauth proof for a joining node.
+func Proof(secret, networkID, nodeDID string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(networkID))
+	mac.Write([]byte{'\n'})
+	mac.Write([]byte(nodeDID))
+	return "hmac-sha256:" + base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+// VerifyProof checks a preauth proof without leaking timing information.
+func VerifyProof(secret, networkID, nodeDID, proof string) bool {
+	expected := Proof(secret, networkID, nodeDID)
+	return hmac.Equal([]byte(expected), []byte(proof))
+}

--- a/internal/invite/invite_test.go
+++ b/internal/invite/invite_test.go
@@ -1,0 +1,99 @@
+package invite
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEncodeDecode(t *testing.T) {
+	p := New(
+		"https://dwn.example.com",
+		"did:jwk:anchor",
+		"bafy-network",
+		"home",
+		"bafy-token",
+		"secret",
+		"2026-06-23T00:00:00Z",
+	)
+
+	u, err := Encode(p)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if !strings.HasPrefix(u, SchemePrefix) {
+		t.Fatalf("invite URL %q missing prefix %q", u, SchemePrefix)
+	}
+
+	got, err := Decode(u)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got != p {
+		t.Fatalf("decoded payload mismatch\ngot:  %#v\nwant: %#v", got, p)
+	}
+}
+
+func TestDecodeRawPayload(t *testing.T) {
+	u, err := Encode(New("https://dwn.example.com", "did:jwk:anchor", "net", "", "tok", "sec", ""))
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	raw := strings.TrimPrefix(u, SchemePrefix)
+
+	if _, err := Decode(raw); err != nil {
+		t.Fatalf("Decode(raw): %v", err)
+	}
+}
+
+func TestValidateAllowsCoordinateOnlyInvite(t *testing.T) {
+	p := New("https://dwn.example.com", "did:jwk:anchor", "net", "", "", "", "")
+	if err := p.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestValidatePreAuthRequiresPreauthFields(t *testing.T) {
+	p := New("https://dwn.example.com", "did:jwk:anchor", "net", "", "", "sec", "")
+	if err := p.ValidatePreAuth(); err == nil {
+		t.Fatal("expected missing token ID error")
+	}
+	p.TokenID = "tok"
+	p.Secret = ""
+	if err := p.ValidatePreAuth(); err == nil {
+		t.Fatal("expected missing secret error")
+	}
+}
+
+func TestGenerateSecret(t *testing.T) {
+	a, err := GenerateSecret()
+	if err != nil {
+		t.Fatalf("GenerateSecret: %v", err)
+	}
+	b, err := GenerateSecret()
+	if err != nil {
+		t.Fatalf("GenerateSecret second: %v", err)
+	}
+	if a == b {
+		t.Fatal("two generated secrets matched")
+	}
+	if strings.ContainsAny(a, "+/=") {
+		t.Fatalf("secret %q is not raw URL-safe base64", a)
+	}
+}
+
+func TestProof(t *testing.T) {
+	secret := "invite-secret"
+	networkID := "net"
+	nodeDID := "did:jwk:node"
+
+	proof := Proof(secret, networkID, nodeDID)
+	if !VerifyProof(secret, networkID, nodeDID, proof) {
+		t.Fatal("proof did not verify")
+	}
+	if VerifyProof(secret, networkID, "did:jwk:other", proof) {
+		t.Fatal("proof verified for wrong DID")
+	}
+	if VerifyProof("wrong", networkID, nodeDID, proof) {
+		t.Fatal("proof verified for wrong secret")
+	}
+}

--- a/internal/mesh/preauth.go
+++ b/internal/mesh/preauth.go
@@ -1,0 +1,445 @@
+package mesh
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/enboxorg/meshd/internal/control"
+	"github.com/enboxorg/meshd/internal/dwn"
+	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
+	"github.com/enboxorg/meshd/internal/invite"
+	"github.com/enboxorg/meshd/protocols"
+)
+
+// PreAuthKeyData is the encrypted network/preAuthKey record payload.
+type PreAuthKeyData struct {
+	Key       string   `json:"key"`
+	CreatedAt string   `json:"createdAt"`
+	ExpiresAt string   `json:"expiresAt,omitempty"`
+	Reusable  bool     `json:"reusable,omitempty"`
+	Ephemeral bool     `json:"ephemeral,omitempty"`
+	Label     string   `json:"label,omitempty"`
+	UsedBy    []string `json:"usedBy,omitempty"`
+}
+
+// NodeRequestData is the network/nodeRequest record payload written by a
+// joining node that holds a preauth invite.
+type NodeRequestData struct {
+	NodeDID      string `json:"nodeDID"`
+	SourceDWN    string `json:"sourceDWN,omitempty"`
+	Label        string `json:"label,omitempty"`
+	PreAuthKeyID string `json:"preAuthKeyId,omitempty"`
+	PreAuthProof string `json:"preAuthProof,omitempty"`
+	RequestedAt  string `json:"requestedAt,omitempty"`
+}
+
+// CreatePreAuthKeyParams configures preauth token creation.
+type CreatePreAuthKeyParams struct {
+	AnchorEndpoint       string
+	AnchorDID            string
+	NetworkRecordID      string
+	NetworkName          string
+	Signer               *dwn.Signer
+	EncryptionKeyManager *dwncrypto.EncryptionKeyManager
+	Label                string
+	ExpiresAt            time.Time
+	Reusable             bool
+	Ephemeral            bool
+}
+
+// PreAuthInvite is a created preauth key and its corresponding invite URL.
+type PreAuthInvite struct {
+	URL       string
+	TokenID   string
+	Secret    string
+	ExpiresAt string
+}
+
+// CreatePreAuthKey writes an encrypted preAuthKey record and returns an invite URL.
+func CreatePreAuthKey(ctx context.Context, params CreatePreAuthKeyParams) (*PreAuthInvite, error) {
+	if params.EncryptionKeyManager == nil {
+		return nil, fmt.Errorf("EncryptionKeyManager is required for encrypted writes")
+	}
+
+	secret, err := invite.GenerateSecret()
+	if err != nil {
+		return nil, err
+	}
+
+	expiresAt := ""
+	if !params.ExpiresAt.IsZero() {
+		expiresAt = params.ExpiresAt.UTC().Format(time.RFC3339)
+	}
+
+	data := PreAuthKeyData{
+		Key:       secret,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		ExpiresAt: expiresAt,
+		Reusable:  params.Reusable,
+		Ephemeral: params.Ephemeral,
+		Label:     params.Label,
+	}
+	dataBytes, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling preauth key: %w", err)
+	}
+
+	recipients, err := params.EncryptionKeyManager.DeriveWriteEncryption("network/preAuthKey")
+	if err != nil {
+		return nil, fmt.Errorf("deriving preauth encryption: %w", err)
+	}
+
+	agent := dwn.NewSimpleAgent(params.AnchorEndpoint, params.Signer)
+	api := dwn.NewDwnAPI(agent)
+	record, status, err := api.Write(ctx, params.AnchorDID, dwn.WriteParams{
+		Protocol:             protocols.MeshProtocolURI,
+		ProtocolPath:         "network/preAuthKey",
+		Schema:               schemaPreAuthKey,
+		DataFormat:           "application/json",
+		ParentContextID:      params.NetworkRecordID,
+		Data:                 dataBytes,
+		EncryptionRecipients: recipients,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("writing preauth key: %w", err)
+	}
+	if status.Code >= 300 {
+		return nil, fmt.Errorf("preauth key write failed: %d %s", status.Code, status.Detail)
+	}
+
+	payload := invite.New(
+		params.AnchorEndpoint,
+		params.AnchorDID,
+		params.NetworkRecordID,
+		params.NetworkName,
+		record.ID,
+		secret,
+		expiresAt,
+	)
+	url, err := invite.Encode(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PreAuthInvite{
+		URL:       url,
+		TokenID:   record.ID,
+		Secret:    secret,
+		ExpiresAt: expiresAt,
+	}, nil
+}
+
+// WritePreAuthNodeRequestParams configures a preauth join request.
+type WritePreAuthNodeRequestParams struct {
+	Invite    invite.Payload
+	NodeDID   string
+	Signer    *dwn.Signer
+	Label     string
+	SourceDWN string
+}
+
+// WritePreAuthNodeRequest writes a network/nodeRequest claim to the anchor DWN.
+func WritePreAuthNodeRequest(ctx context.Context, params WritePreAuthNodeRequestParams) error {
+	if err := params.Invite.ValidatePreAuth(); err != nil {
+		return err
+	}
+	if params.NodeDID == "" {
+		return fmt.Errorf("node DID is required")
+	}
+
+	data := NodeRequestData{
+		NodeDID:      params.NodeDID,
+		SourceDWN:    params.SourceDWN,
+		Label:        params.Label,
+		PreAuthKeyID: params.Invite.TokenID,
+		PreAuthProof: invite.Proof(params.Invite.Secret, params.Invite.NetworkID, params.NodeDID),
+		RequestedAt:  time.Now().UTC().Format(time.RFC3339),
+	}
+	dataBytes, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("marshaling node request: %w", err)
+	}
+
+	agent := dwn.NewSimpleAgent(params.Invite.Endpoint, params.Signer)
+	api := dwn.NewDwnAPI(agent)
+	_, status, err := api.Write(ctx, params.Invite.AnchorDID, dwn.WriteParams{
+		Protocol:        protocols.MeshProtocolURI,
+		ProtocolPath:    "network/nodeRequest",
+		Schema:          schemaNodeRequest,
+		DataFormat:      "application/json",
+		ParentContextID: params.Invite.NetworkID,
+		Data:            dataBytes,
+	})
+	if err != nil {
+		return fmt.Errorf("writing node request: %w", err)
+	}
+	if status.Code >= 300 {
+		return fmt.Errorf("node request write failed: %d %s", status.Code, status.Detail)
+	}
+
+	return nil
+}
+
+// ApprovePreAuthRequestsParams configures anchor-side request approval.
+type ApprovePreAuthRequestsParams struct {
+	AnchorEndpoint       string
+	AnchorDID            string
+	NetworkRecordID      string
+	MeshCIDR             string
+	Signer               *dwn.Signer
+	EncryptionKeyManager *dwncrypto.EncryptionKeyManager
+}
+
+// ApprovePreAuthResult summarizes processed preauth requests.
+type ApprovePreAuthResult struct {
+	Approved int
+	Rejected int
+	Pending  int
+}
+
+// ApprovePreAuthRequests processes pending preauth node requests.
+func ApprovePreAuthRequests(ctx context.Context, params ApprovePreAuthRequestsParams) (*ApprovePreAuthResult, error) {
+	if params.EncryptionKeyManager == nil {
+		return nil, fmt.Errorf("EncryptionKeyManager is required")
+	}
+
+	agent := dwn.NewSimpleAgent(params.AnchorEndpoint, params.Signer)
+	api := dwn.NewDwnAPI(agent)
+	result := &ApprovePreAuthResult{}
+
+	requests, status, err := api.Query(ctx, params.AnchorDID, dwn.QueryParams{
+		Filter: dwn.RecordsFilter{
+			Protocol:     protocols.MeshProtocolURI,
+			ProtocolPath: "network/nodeRequest",
+			ContextID:    params.NetworkRecordID,
+		},
+		DateSort: "createdAscending",
+	}, "")
+	if err != nil {
+		return nil, fmt.Errorf("querying node requests: %w", err)
+	}
+	if status.Code != 200 {
+		return nil, fmt.Errorf("querying node requests failed: %d %s", status.Code, status.Detail)
+	}
+
+	for _, request := range requests {
+		var req NodeRequestData
+		if err := request.Data().JSON(ctx, &req); err != nil {
+			result.Rejected++
+			_ = deleteRecord(ctx, api, params.AnchorDID, request.ID)
+			continue
+		}
+
+		keyRecord, key, err := readPreAuthKey(ctx, api, params, req.PreAuthKeyID)
+		if err != nil {
+			result.Pending++
+			continue
+		}
+		if !preAuthKeyAllows(key, req.NodeDID) || !invite.VerifyProof(key.Key, params.NetworkRecordID, req.NodeDID, req.PreAuthProof) {
+			result.Rejected++
+			_ = deleteRecord(ctx, api, params.AnchorDID, request.ID)
+			continue
+		}
+
+		exists, err := nodeRecordExists(ctx, api, params.AnchorDID, params.NetworkRecordID, req.NodeDID)
+		if err != nil {
+			result.Pending++
+			continue
+		}
+		if !exists {
+			meshIP, err := AllocateMeshIP(params.MeshCIDR, req.NodeDID)
+			if err != nil {
+				result.Rejected++
+				_ = deleteRecord(ctx, api, params.AnchorDID, request.ID)
+				continue
+			}
+			_, err = RegisterNode(ctx, RegisterNodeParams{
+				AnchorEndpoint:       params.AnchorEndpoint,
+				AnchorDID:            params.AnchorDID,
+				NetworkRecordID:      params.NetworkRecordID,
+				NodeDID:              req.NodeDID,
+				Signer:               params.Signer,
+				EncryptionKeyManager: params.EncryptionKeyManager,
+				MeshIP:               meshIP.String(),
+				Label:                firstNonEmpty(req.Label, key.Label),
+				UseContextEncryption: true,
+			})
+			if err != nil {
+				result.Pending++
+				continue
+			}
+		}
+
+		kdm := &KeyDeliveryManager{
+			Endpoint:             params.AnchorEndpoint,
+			Signer:               params.Signer,
+			EncryptionKeyManager: params.EncryptionKeyManager,
+		}
+		if err := kdm.DeliverContextKey(ctx, DeliverContextKeyParams{
+			AnchorDID:      params.AnchorDID,
+			RecipientDID:   req.NodeDID,
+			SourceProtocol: protocols.MeshProtocolURI,
+			ContextID:      params.NetworkRecordID,
+		}); err != nil {
+			result.Pending++
+			continue
+		}
+
+		if err := markPreAuthKeyUsed(ctx, api, params, keyRecord, key, req.NodeDID); err != nil {
+			result.Pending++
+			continue
+		}
+		if err := deleteRecord(ctx, api, params.AnchorDID, request.ID); err != nil {
+			result.Pending++
+			continue
+		}
+		result.Approved++
+	}
+
+	return result, nil
+}
+
+func readPreAuthKey(ctx context.Context, api *dwn.DwnAPI, params ApprovePreAuthRequestsParams, recordID string) (*dwn.Record, *PreAuthKeyData, error) {
+	if recordID == "" {
+		return nil, nil, fmt.Errorf("missing preauth key ID")
+	}
+
+	records, status, err := api.Query(ctx, params.AnchorDID, dwn.QueryParams{
+		Filter: dwn.RecordsFilter{
+			Protocol:     protocols.MeshProtocolURI,
+			ProtocolPath: "network/preAuthKey",
+			ContextID:    params.NetworkRecordID,
+		},
+		DateSort: "createdDescending",
+	}, "")
+	if err != nil {
+		return nil, nil, err
+	}
+	if status.Code != 200 {
+		return nil, nil, fmt.Errorf("querying preauth keys failed: %d %s", status.Code, status.Detail)
+	}
+
+	var record *dwn.Record
+	for _, r := range records {
+		if r.ID == recordID {
+			record = r
+			break
+		}
+	}
+	if record == nil {
+		return nil, nil, fmt.Errorf("preauth key %q not found", recordID)
+	}
+
+	var key PreAuthKeyData
+	decryptor := preAuthDecryptor(params.EncryptionKeyManager)
+	if err := control.ParseEntryData(record.RawEntry, &key, decryptor); err != nil {
+		return nil, nil, err
+	}
+	return record, &key, nil
+}
+
+func preAuthDecryptor(encMgr *dwncrypto.EncryptionKeyManager) control.EntryDecryptor {
+	return func(ciphertext []byte, enc *dwncrypto.Encryption) ([]byte, error) {
+		privKey, err := encMgr.DeriveDecryptionKey("network/preAuthKey")
+		if err != nil {
+			return nil, err
+		}
+		return dwncrypto.DecryptData(ciphertext, enc, privKey, encMgr.RootKeyID)
+	}
+}
+
+func preAuthKeyAllows(key *PreAuthKeyData, nodeDID string) bool {
+	if key == nil || key.Key == "" || nodeDID == "" {
+		return false
+	}
+	if key.ExpiresAt != "" {
+		expiresAt, err := time.Parse(time.RFC3339, key.ExpiresAt)
+		if err != nil || time.Now().After(expiresAt) {
+			return false
+		}
+	}
+	for _, used := range key.UsedBy {
+		if used == nodeDID {
+			return true
+		}
+	}
+	return key.Reusable || len(key.UsedBy) == 0
+}
+
+func markPreAuthKeyUsed(ctx context.Context, api *dwn.DwnAPI, params ApprovePreAuthRequestsParams, record *dwn.Record, key *PreAuthKeyData, nodeDID string) error {
+	for _, used := range key.UsedBy {
+		if used == nodeDID {
+			return nil
+		}
+	}
+	key.UsedBy = append(key.UsedBy, nodeDID)
+
+	data, err := json.Marshal(key)
+	if err != nil {
+		return fmt.Errorf("marshaling used preauth key: %w", err)
+	}
+	recipients, err := params.EncryptionKeyManager.DeriveWriteEncryption("network/preAuthKey")
+	if err != nil {
+		return fmt.Errorf("deriving preauth update encryption: %w", err)
+	}
+
+	_, status, err := api.Write(ctx, params.AnchorDID, dwn.WriteParams{
+		Protocol:             protocols.MeshProtocolURI,
+		ProtocolPath:         "network/preAuthKey",
+		Schema:               schemaPreAuthKey,
+		DataFormat:           "application/json",
+		ParentContextID:      params.NetworkRecordID,
+		RecordID:             record.ID,
+		DateCreated:          record.DateCreated,
+		Data:                 data,
+		EncryptionRecipients: recipients,
+	})
+	if err != nil {
+		return fmt.Errorf("updating preauth key: %w", err)
+	}
+	if status.Code >= 300 {
+		return fmt.Errorf("preauth key update failed: %d %s", status.Code, status.Detail)
+	}
+	return nil
+}
+
+func nodeRecordExists(ctx context.Context, api *dwn.DwnAPI, anchorDID, networkID, nodeDID string) (bool, error) {
+	records, status, err := api.Query(ctx, anchorDID, dwn.QueryParams{
+		Filter: dwn.RecordsFilter{
+			Protocol:     protocols.MeshProtocolURI,
+			ProtocolPath: "network/node",
+			ContextID:    networkID,
+			Recipient:    nodeDID,
+		},
+		DateSort: "createdDescending",
+	}, "")
+	if err != nil {
+		return false, err
+	}
+	if status.Code != 200 {
+		return false, fmt.Errorf("node query failed: %d %s", status.Code, status.Detail)
+	}
+	return len(records) > 0, nil
+}
+
+func deleteRecord(ctx context.Context, api *dwn.DwnAPI, target, recordID string) error {
+	status, err := api.Delete(ctx, target, recordID, false, "")
+	if err != nil {
+		return err
+	}
+	if status.Code >= 300 {
+		return fmt.Errorf("delete failed: %d %s", status.Code, status.Detail)
+	}
+	return nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/mesh/register.go
+++ b/internal/mesh/register.go
@@ -23,6 +23,7 @@ const (
 	schemaNodeInfo    = "https://enbox.org/schemas/wireguard-mesh/node-info"
 	schemaEndpoint    = "https://enbox.org/schemas/wireguard-mesh/endpoint"
 	schemaACLPolicy   = "https://enbox.org/schemas/wireguard-mesh/acl-policy"
+	schemaPreAuthKey  = "https://enbox.org/schemas/wireguard-mesh/pre-auth-key"
 )
 
 // MemberRegistration holds the result of creating a member record.

--- a/protocols/wireguard-mesh.json
+++ b/protocols/wireguard-mesh.json
@@ -122,6 +122,14 @@
         }
       },
 
+      "nodeRequest": {
+        "$size": { "max": 2000 },
+        "$actions": [
+          { "who": "anyone", "can": ["create"] },
+          { "who": "author", "of": "network", "can": ["read", "delete", "co-delete"] }
+        ]
+      },
+
       "node": {
         "$role": true,
         "$squash": true,

--- a/schemas/node-request.json
+++ b/schemas/node-request.json
@@ -18,6 +18,19 @@
       "type": "string",
       "maxLength": 128,
       "description": "Optional label for the proposed device"
+    },
+    "preAuthKeyId": {
+      "type": "string",
+      "description": "Record ID of the encrypted pre-auth key used for this request"
+    },
+    "preAuthProof": {
+      "type": "string",
+      "description": "HMAC proof derived from the pre-auth key secret, network ID, and node DID"
+    },
+    "requestedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the device requested to join"
     }
   }
 }


### PR DESCRIPTION
## Summary
- add meshd://invite URL encoding plus preauth proof generation
- add `meshd invite create`, `meshd join <url>`, and `meshd up <url>` flows
- add anchor-side preauth request processing that provisions nodes, delivers context keys, and marks tokens used
- update the wireguard-mesh protocol/schema and README quick start for invite joining

## Verification
- `GOFLAGS=-mod=vendor go build ./...`
- `GOFLAGS=-mod=vendor go vet ./...`
- `GOFLAGS=-mod=vendor go test ./... -count=1 -race`