### PR TITLE
feat: add password-encrypted identity vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,18 @@ DWN. See [DESIGN.md](DESIGN.md) for the full architecture.
 
 ```bash
 # On your first machine
-meshd network create my-network --endpoint https://dwn.example.com
-# prints: Your device identity: did:jwk:eyJr...
-# prints: Network "my-network" created. Mesh IP: 10.200.x.x
-# prints: Create a join invite with: meshd invite create
+meshd up --create my-network --endpoint https://dwn.example.com
+# prompts once to create a local vault password, creates the network, then starts meshd
 
-# Create an invite URL
+# In another terminal on the first machine, create an invite URL
 meshd invite create
 # prints: meshd://invite/eyJ...
 
 # On your second machine, join from the invite
 meshd join meshd://invite/eyJ...
+# prompts once to create a local vault password and submits a join request
 
-# Start meshd on both machines
+# Start meshd on the second machine
 meshd up
 
 # That's it. After the anchor approves the invite, the machines can reach each other at 10.200.x.x
@@ -93,6 +92,9 @@ Identity:
   auth list         List all profiles
   auth use <name>   Set the default profile
   auth logout       Remove a profile from config
+  vault status      Show local vault state
+  vault init        Encrypt a legacy plaintext identity
+  vault unlock      Verify the vault password and show identity
 
 Network:
   network create    Create a new mesh network on a DWN
@@ -143,8 +145,9 @@ mesh. They never need a public IP. They never appear in your DID document.
 ## How it works under the hood
 
 **Identity:** Each device gets a `did:jwk` identity -- an Ed25519 key pair
-encoded as a DID. The WireGuard key is derived from the same identity
-(Ed25519 to X25519 birational map), so there is exactly one key to manage.
+encoded as a DID. The private key is stored in a password-encrypted local
+vault. The WireGuard key is derived from the same identity (Ed25519 to
+X25519 birational map), so there is exactly one key to manage.
 
 **Networking:** meshd uses [meshnet](https://github.com/enboxorg/meshnet),
 a fork of Tailscale's open-source networking engine. This gives us
@@ -210,6 +213,7 @@ internal/
   engine/               WireGuard engine integration (meshnet)
   mesh/                 Mesh registration, node/endpoint/ACL writes
   did/                  DID generation (did:jwk), key derivation, persistence
+  vault/                Password-encrypted local secret storage
   state/                On-disk state management
   daemon/               Unix socket daemon for up/down/status
   profile/              Multi-identity profile management

--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/enboxorg/meshd/pkg/dids"
 	"github.com/enboxorg/meshd/pkg/dids/didcore"
 	"github.com/enboxorg/meshd/protocols"
+	"golang.org/x/term"
 )
 
 const usage = `meshd - Decentralized WireGuard mesh networking via DWN
@@ -39,6 +40,9 @@ Identity:
   auth use <name>   Set the default profile
   auth logout       Remove a profile from config
   init              Generate DID identity and store locally
+  vault status      Show local vault state
+  vault init        Encrypt a legacy plaintext identity
+  vault unlock      Verify the vault password and show identity
 
 Network:
   network create    Create a new mesh network on a DWN
@@ -80,6 +84,8 @@ Environment:
   ENBOX_HOME         Override ~/.enbox base directory
   ENBOX_PROFILE      Override active profile
   MESHD_STATE_DIR    Override state directory (bypasses profiles)
+  MESHD_VAULT_PASSWORD
+                     Unlock/create vault non-interactively
   DWN_ENDPOINT       Default DWN endpoint URL
 `
 
@@ -101,7 +107,8 @@ func main() {
 			"invite create",
 			"peer list", "peer add", "peer approve",
 			"acl set", "acl show",
-			"auth login", "auth list", "auth use", "auth logout":
+			"auth login", "auth list", "auth use", "auth logout",
+			"vault status", "vault init", "vault unlock":
 			cmd = combined
 			args = os.Args[3:]
 		}
@@ -130,6 +137,12 @@ func main() {
 		err = cmdAuthLogout(args)
 	case "init":
 		err = cmdInit(ctx, args, flagProfile)
+	case "vault status":
+		err = cmdVaultStatus(args, flagProfile)
+	case "vault init":
+		err = cmdVaultInit(args, flagProfile)
+	case "vault unlock":
+		err = cmdVaultUnlock(args, flagProfile)
 	case "network create":
 		err = cmdNetworkCreate(ctx, args, flagProfile)
 	case "network join":
@@ -170,13 +183,22 @@ func main() {
 
 // cmdInit generates a did:jwk identity and stores it locally.
 func cmdInit(ctx context.Context, args []string, flagProfile string) error {
+	profileName := ""
+	if os.Getenv("MESHD_STATE_DIR") == "" {
+		profileName = profileNameForWrite(flagProfile)
+	}
+
 	stateDir, err := resolveStateDir(flagProfile)
+	if err == profile.ErrNoProfiles {
+		stateDir = profile.DataPath(profileName)
+		err = nil
+	}
 	if err != nil {
 		return err
 	}
 
-	if did.Exists(stateDir) {
-		identity, err := did.Load(stateDir)
+	if identityExists(stateDir) {
+		identity, err := loadIdentity(stateDir)
 		if err != nil {
 			return fmt.Errorf("loading existing identity: %w", err)
 		}
@@ -191,13 +213,112 @@ func cmdInit(ctx context.Context, args []string, flagProfile string) error {
 		return fmt.Errorf("generating DID: %w", err)
 	}
 
-	if err := identity.Store(stateDir); err != nil {
+	if err := storeIdentityForCLI(identity, stateDir); err != nil {
 		return fmt.Errorf("storing identity: %w", err)
+	}
+	if profileName != "" {
+		if err := profile.UpsertProfile(profileName, identity.URI); err != nil {
+			return fmt.Errorf("saving profile: %w", err)
+		}
 	}
 
 	fmt.Printf("Initialized new identity.\n")
 	fmt.Printf("  DID: %s\n", identity.URI)
 	fmt.Printf("  State: %s\n", stateDir)
+	fmt.Printf("  Vault: encrypted\n")
+	return nil
+}
+
+func cmdVaultStatus(args []string, flagProfile string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("usage: meshd vault status")
+	}
+
+	stateDir, err := resolveStateDir(flagProfile)
+	if err == profile.ErrNoProfiles {
+		fmt.Println("Vault: uninitialized")
+		fmt.Println("Identity: none")
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case did.EncryptedExists(stateDir):
+		fmt.Println("Vault: encrypted")
+		if did.Exists(stateDir) {
+			fmt.Println("Legacy plaintext identity: present")
+			fmt.Println("Run 'meshd vault init' to remove the plaintext identity after unlock.")
+		}
+	case did.Exists(stateDir):
+		fmt.Println("Vault: plaintext legacy")
+		fmt.Println("Run 'meshd vault init' to encrypt it.")
+	default:
+		fmt.Println("Vault: uninitialized")
+		fmt.Println("Identity: none")
+	}
+	fmt.Printf("State: %s\n", stateDir)
+	return nil
+}
+
+func cmdVaultInit(args []string, flagProfile string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("usage: meshd vault init")
+	}
+
+	stateDir, err := resolveStateDir(flagProfile)
+	if err != nil {
+		return err
+	}
+	if did.EncryptedExists(stateDir) {
+		if did.Exists(stateDir) {
+			if _, err := loadIdentity(stateDir); err != nil {
+				return err
+			}
+			if err := did.RemovePlaintext(stateDir); err != nil {
+				return err
+			}
+			fmt.Println("Removed legacy plaintext identity.")
+		}
+		fmt.Println("Vault already initialized.")
+		fmt.Printf("State: %s\n", stateDir)
+		return nil
+	}
+	if !did.Exists(stateDir) {
+		return fmt.Errorf("no plaintext identity found to encrypt")
+	}
+
+	password, err := vaultPasswordForCreate()
+	if err != nil {
+		return err
+	}
+	if err := did.MigrateToEncrypted(stateDir, password); err != nil {
+		return err
+	}
+
+	fmt.Println("Vault initialized.")
+	fmt.Printf("State: %s\n", stateDir)
+	return nil
+}
+
+func cmdVaultUnlock(args []string, flagProfile string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("usage: meshd vault unlock")
+	}
+
+	stateDir, err := resolveStateDir(flagProfile)
+	if err != nil {
+		return err
+	}
+	identity, err := loadIdentity(stateDir)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Vault unlocked.")
+	fmt.Printf("DID: %s\n", identity.URI)
+	fmt.Printf("State: %s\n", stateDir)
 	return nil
 }
 
@@ -1092,12 +1213,12 @@ func cmdStatus(ctx context.Context, args []string, flagProfile string) error {
 	}
 
 	// Identity.
-	if !did.Exists(stateDir) {
+	if !identityExists(stateDir) {
 		fmt.Println("Not initialized. Run 'meshd auth login' to create a profile.")
 		return nil
 	}
 
-	identity, err := did.Load(stateDir)
+	identity, err := loadIdentity(stateDir)
 	if err != nil {
 		return fmt.Errorf("loading identity: %w", err)
 	}
@@ -1105,6 +1226,11 @@ func cmdStatus(ctx context.Context, args []string, flagProfile string) error {
 	fmt.Printf("Identity:\n")
 	fmt.Printf("  DID: %s\n", identity.URI)
 	fmt.Printf("  State: %s\n", stateDir)
+	if did.EncryptedExists(stateDir) {
+		fmt.Printf("  Vault: encrypted\n")
+	} else {
+		fmt.Printf("  Vault: plaintext legacy\n")
+	}
 
 	// Network.
 	ns, err := state.LoadNetworkState(stateDir)
@@ -1517,10 +1643,7 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 // ensureIdentity creates a new identity profile when none exists.
 // It's called by cmdUp when no identity is found.
 func ensureIdentity(ctx context.Context, flagProfile, endpoint string) (*did.DID, error) {
-	profileName := flagProfile
-	if profileName == "" {
-		profileName = "default"
-	}
+	profileName := profileNameForWrite(flagProfile)
 
 	identity, err := did.Generate()
 	if err != nil {
@@ -1528,15 +1651,24 @@ func ensureIdentity(ctx context.Context, flagProfile, endpoint string) (*did.DID
 	}
 
 	dataPath := profile.DataPath(profileName)
-	if err := identity.Store(dataPath); err != nil {
+	useProfiles := os.Getenv("MESHD_STATE_DIR") == ""
+	if !useProfiles {
+		dataPath = os.Getenv("MESHD_STATE_DIR")
+	}
+	if err := storeIdentityForCLI(identity, dataPath); err != nil {
 		return nil, fmt.Errorf("storing identity: %w", err)
 	}
-	if err := profile.UpsertProfile(profileName, identity.URI); err != nil {
-		return nil, fmt.Errorf("saving profile: %w", err)
+	if useProfiles {
+		if err := profile.UpsertProfile(profileName, identity.URI); err != nil {
+			return nil, fmt.Errorf("saving profile: %w", err)
+		}
 	}
 
-	fmt.Printf("  Profile: %s\n", profileName)
+	if useProfiles {
+		fmt.Printf("  Profile: %s\n", profileName)
+	}
 	fmt.Printf("  DID:     %s\n", identity.URI)
+	fmt.Printf("  Vault:   encrypted\n")
 	fmt.Println()
 
 	return identity, nil
@@ -1555,8 +1687,8 @@ func ensureIdentityForCommand(ctx context.Context, flagProfile, endpoint string)
 		return "", nil, err
 	}
 
-	if did.Exists(stateDir) {
-		identity, err := did.Load(stateDir)
+	if identityExists(stateDir) {
+		identity, err := loadIdentity(stateDir)
 		if err != nil {
 			return "", nil, fmt.Errorf("loading identity: %w", err)
 		}
@@ -1820,8 +1952,109 @@ func cmdDown(ctx context.Context, args []string) error {
 	return nil
 }
 
+const vaultPasswordEnv = "MESHD_VAULT_PASSWORD"
+
+func defaultProfileName(flagProfile string) string {
+	if flagProfile != "" {
+		return flagProfile
+	}
+	if env := os.Getenv("ENBOX_PROFILE"); env != "" {
+		return env
+	}
+	return "default"
+}
+
+func profileNameForWrite(flagProfile string) string {
+	if os.Getenv("MESHD_STATE_DIR") != "" {
+		return defaultProfileName(flagProfile)
+	}
+	if name, err := profile.Resolve(flagProfile); err == nil {
+		return name
+	}
+	return defaultProfileName(flagProfile)
+}
+
+func identityExists(stateDir string) bool {
+	return did.EncryptedExists(stateDir) || did.Exists(stateDir)
+}
+
+func storeIdentityForCLI(identity *did.DID, stateDir string) error {
+	password, err := vaultPasswordForCreate()
+	if err != nil {
+		return err
+	}
+	return identity.StoreEncrypted(stateDir, password)
+}
+
+func vaultPasswordForUnlock() (string, error) {
+	if password := os.Getenv(vaultPasswordEnv); password != "" {
+		return password, nil
+	}
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return "", fmt.Errorf("vault password required; run in a terminal or set %s", vaultPasswordEnv)
+	}
+
+	fmt.Print("Vault password: ")
+	passwordBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Println()
+	if err != nil {
+		return "", fmt.Errorf("reading vault password: %w", err)
+	}
+	password := string(passwordBytes)
+	if password == "" {
+		return "", fmt.Errorf("vault password is required")
+	}
+	return password, nil
+}
+
+func vaultPasswordForCreate() (string, error) {
+	if password := os.Getenv(vaultPasswordEnv); password != "" {
+		return password, nil
+	}
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return "", fmt.Errorf("vault password required; run in a terminal or set %s", vaultPasswordEnv)
+	}
+
+	fmt.Print("Create vault password: ")
+	firstBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Println()
+	if err != nil {
+		return "", fmt.Errorf("reading vault password: %w", err)
+	}
+	password := string(firstBytes)
+	if password == "" {
+		return "", fmt.Errorf("vault password is required")
+	}
+
+	fmt.Print("Confirm vault password: ")
+	confirmBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Println()
+	if err != nil {
+		return "", fmt.Errorf("reading vault password confirmation: %w", err)
+	}
+	if password != string(confirmBytes) {
+		return "", fmt.Errorf("vault passwords do not match")
+	}
+	return password, nil
+}
+
 // loadIdentity loads the DID identity, or returns an error if not initialized.
 func loadIdentity(stateDir string) (*did.DID, error) {
+	if did.EncryptedExists(stateDir) {
+		password, err := vaultPasswordForUnlock()
+		if err != nil {
+			return nil, err
+		}
+		identity, err := did.LoadEncrypted(stateDir, password)
+		if err != nil {
+			return nil, fmt.Errorf("unlocking vault: %w", err)
+		}
+		if identity == nil {
+			return nil, fmt.Errorf("encrypted identity is missing")
+		}
+		return identity, nil
+	}
+
 	if !did.Exists(stateDir) {
 		return nil, fmt.Errorf("not initialized. Run 'meshd auth login' to create a profile")
 	}
@@ -1969,7 +2202,7 @@ func cmdAuthLogin(ctx context.Context, args []string) error {
 
 	// Store identity in profile directory.
 	dataPath := profile.DataPath(profileName)
-	if err := identity.Store(dataPath); err != nil {
+	if err := storeIdentityForCLI(identity, dataPath); err != nil {
 		return fmt.Errorf("storing identity: %w", err)
 	}
 
@@ -1981,6 +2214,7 @@ func cmdAuthLogin(ctx context.Context, args []string) error {
 	fmt.Printf("Created profile %q.\n", profileName)
 	fmt.Printf("  DID:   %s\n", identity.URI)
 	fmt.Printf("  State: %s\n", dataPath)
+	fmt.Printf("  Vault: encrypted\n")
 
 	return nil
 }

--- a/cmd/meshd/main_test.go
+++ b/cmd/meshd/main_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/enboxorg/meshd/internal/did"
 	"github.com/enboxorg/meshd/internal/invite"
 	"github.com/enboxorg/meshd/internal/profile"
 )
@@ -29,6 +30,7 @@ func TestEnsureIdentityForCommandCreatesDefaultProfile(t *testing.T) {
 	t.Setenv("ENBOX_HOME", home)
 	t.Setenv("ENBOX_PROFILE", "")
 	t.Setenv("MESHD_STATE_DIR", "")
+	t.Setenv("MESHD_VAULT_PASSWORD", "test-password")
 
 	stateDir, identity, err := ensureIdentityForCommand(context.Background(), "", "")
 	if err != nil {
@@ -40,6 +42,12 @@ func TestEnsureIdentityForCommandCreatesDefaultProfile(t *testing.T) {
 	if !strings.HasPrefix(stateDir, home) {
 		t.Fatalf("stateDir = %q, want under %q", stateDir, home)
 	}
+	if !did.EncryptedExists(stateDir) {
+		t.Fatal("identity was not stored in encrypted vault")
+	}
+	if did.Exists(stateDir) {
+		t.Fatal("legacy plaintext identity should not be created")
+	}
 
 	cfg, err := profile.ReadConfig()
 	if err != nil {
@@ -50,5 +58,42 @@ func TestEnsureIdentityForCommandCreatesDefaultProfile(t *testing.T) {
 	}
 	if cfg.Profiles["default"] == nil {
 		t.Fatal("default profile was not saved")
+	}
+}
+
+func TestEnsureIdentityForCommandUsesResolvedDefaultProfile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("ENBOX_HOME", home)
+	t.Setenv("ENBOX_PROFILE", "")
+	t.Setenv("MESHD_STATE_DIR", "")
+	t.Setenv("MESHD_VAULT_PASSWORD", "test-password")
+
+	if err := profile.UpsertProfile("work", "did:jwk:placeholder"); err != nil {
+		t.Fatalf("UpsertProfile: %v", err)
+	}
+
+	stateDir, identity, err := ensureIdentityForCommand(context.Background(), "", "")
+	if err != nil {
+		t.Fatalf("ensureIdentityForCommand: %v", err)
+	}
+	if identity == nil || identity.URI == "" {
+		t.Fatal("identity was not created")
+	}
+	if stateDir != profile.DataPath("work") {
+		t.Fatalf("stateDir = %q, want %q", stateDir, profile.DataPath("work"))
+	}
+	if !did.EncryptedExists(stateDir) {
+		t.Fatal("identity was not stored in encrypted vault")
+	}
+
+	cfg, err := profile.ReadConfig()
+	if err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+	if cfg.DefaultProfile != "work" {
+		t.Fatalf("DefaultProfile = %q, want work", cfg.DefaultProfile)
+	}
+	if cfg.Profiles["work"].DID != identity.URI {
+		t.Fatalf("profile DID = %q, want %q", cfg.Profiles["work"].DID, identity.URI)
 	}
 }

--- a/internal/did/vault.go
+++ b/internal/did/vault.go
@@ -1,0 +1,123 @@
+package did
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/enboxorg/meshd/internal/vault"
+)
+
+const encryptedStateFile = "identity.vault.json"
+
+// StoreEncrypted persists the DID private key in a password-encrypted vault.
+func (d *DID) StoreEncrypted(stateDir string, password string) error {
+	return d.storeEncryptedWithParams(stateDir, password, vault.DefaultArgon2idParams)
+}
+
+func (d *DID) storeEncryptedWithParams(stateDir string, password string, params vault.Argon2idParams) error {
+	if err := os.MkdirAll(stateDir, 0700); err != nil {
+		return fmt.Errorf("create state dir: %w", err)
+	}
+
+	state := storedState{
+		URI:        d.URI,
+		PrivateKey: []byte(d.SigningKey),
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("marshal identity state: %w", err)
+	}
+
+	sealed, err := vault.SealWithParams(data, password, params)
+	if err != nil {
+		return err
+	}
+
+	target := filepath.Join(stateDir, encryptedStateFile)
+	tmp := target + ".tmp"
+	if err := os.WriteFile(tmp, sealed, 0600); err != nil {
+		return fmt.Errorf("write encrypted identity: %w", err)
+	}
+	if err := os.Rename(tmp, target); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("rename encrypted identity: %w", err)
+	}
+	return nil
+}
+
+// LoadEncrypted reads a password-encrypted DID identity.
+func LoadEncrypted(stateDir string, password string) (*DID, error) {
+	target := filepath.Join(stateDir, encryptedStateFile)
+	data, err := os.ReadFile(target)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read encrypted identity: %w", err)
+	}
+
+	plaintext, err := vault.Open(data, password)
+	if err != nil {
+		return nil, err
+	}
+
+	var state storedState
+	if err := json.Unmarshal(plaintext, &state); err != nil {
+		return nil, fmt.Errorf("unmarshal encrypted identity: %w", err)
+	}
+	if len(state.PrivateKey) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("invalid private key size: %d", len(state.PrivateKey))
+	}
+
+	d, err := FromPrivateKey(ed25519.PrivateKey(state.PrivateKey))
+	if err != nil {
+		return nil, fmt.Errorf("reconstruct DID: %w", err)
+	}
+	return d, nil
+}
+
+// EncryptedExists checks whether an encrypted DID identity file exists.
+func EncryptedExists(stateDir string) bool {
+	target := filepath.Join(stateDir, encryptedStateFile)
+	_, err := os.Stat(target)
+	return err == nil
+}
+
+// RemovePlaintext removes a legacy plaintext DID identity file.
+func RemovePlaintext(stateDir string) error {
+	if err := os.Remove(filepath.Join(stateDir, stateFile)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove plaintext identity: %w", err)
+	}
+	return nil
+}
+
+// MigrateToEncrypted encrypts a legacy plaintext identity and removes the
+// plaintext identity file after the encrypted file is safely written.
+func MigrateToEncrypted(stateDir string, password string) error {
+	return migrateToEncryptedWithParams(stateDir, password, vault.DefaultArgon2idParams)
+}
+
+func migrateToEncryptedWithParams(stateDir string, password string, params vault.Argon2idParams) error {
+	if EncryptedExists(stateDir) {
+		return nil
+	}
+
+	identity, err := Load(stateDir)
+	if err != nil {
+		return err
+	}
+	if identity == nil {
+		return fmt.Errorf("no plaintext identity to migrate")
+	}
+
+	if err := identity.storeEncryptedWithParams(stateDir, password, params); err != nil {
+		return err
+	}
+	if err := RemovePlaintext(stateDir); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/did/vault_test.go
+++ b/internal/did/vault_test.go
@@ -1,0 +1,87 @@
+package did
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/enboxorg/meshd/internal/vault"
+)
+
+func TestStoreAndLoadEncrypted(t *testing.T) {
+	dir := t.TempDir()
+
+	d1, err := Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if err := d1.storeEncryptedWithParams(dir, "password", vault.FastArgon2idParams); err != nil {
+		t.Fatalf("storeEncryptedWithParams: %v", err)
+	}
+
+	if !EncryptedExists(dir) {
+		t.Fatal("EncryptedExists returned false after StoreEncrypted")
+	}
+	if Exists(dir) {
+		t.Fatal("legacy plaintext identity should not exist after StoreEncrypted")
+	}
+
+	info, err := os.Stat(filepath.Join(dir, encryptedStateFile))
+	if err != nil {
+		t.Fatalf("stat encrypted identity: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Fatalf("encrypted file mode = %o, want 0600", info.Mode().Perm())
+	}
+
+	d2, err := LoadEncrypted(dir, "password")
+	if err != nil {
+		t.Fatalf("LoadEncrypted: %v", err)
+	}
+	if d2 == nil {
+		t.Fatal("LoadEncrypted returned nil")
+	}
+	if d1.URI != d2.URI {
+		t.Fatalf("URI = %q, want %q", d2.URI, d1.URI)
+	}
+	if string(d1.SigningKey) != string(d2.SigningKey) {
+		t.Fatal("signing key changed after encrypted round trip")
+	}
+
+	if _, err := LoadEncrypted(dir, "wrong"); err == nil {
+		t.Fatal("expected wrong password to fail")
+	}
+}
+
+func TestMigrateToEncrypted(t *testing.T) {
+	dir := t.TempDir()
+
+	d1, err := Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if err := d1.Store(dir); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if !Exists(dir) {
+		t.Fatal("legacy identity should exist before migration")
+	}
+
+	if err := migrateToEncryptedWithParams(dir, "password", vault.FastArgon2idParams); err != nil {
+		t.Fatalf("migrateToEncryptedWithParams: %v", err)
+	}
+	if Exists(dir) {
+		t.Fatal("legacy plaintext identity still exists after migration")
+	}
+	if !EncryptedExists(dir) {
+		t.Fatal("encrypted identity was not created")
+	}
+
+	d2, err := LoadEncrypted(dir, "password")
+	if err != nil {
+		t.Fatalf("LoadEncrypted: %v", err)
+	}
+	if d2 == nil || d2.URI != d1.URI {
+		t.Fatalf("migrated identity URI = %v, want %s", d2, d1.URI)
+	}
+}

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -11,7 +11,8 @@
 //	  profiles/
 //	    <name>/
 //	      meshd/                    # meshd-specific state
-//	        identity.json           # Ed25519 private key + DID URI
+//	        identity.vault.json     # password-encrypted DID private key
+//	        identity.json           # legacy plaintext DID state
 //	        network.json            # network membership state
 //
 // Override base path with ENBOX_HOME env var.
@@ -48,9 +49,9 @@ var validName = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
 // Config is the top-level ~/.enbox/config.json structure.
 type Config struct {
-	Version        int                 `json:"version"`
-	DefaultProfile string              `json:"defaultProfile"`
-	Profiles       map[string]*Entry   `json:"profiles"`
+	Version        int               `json:"version"`
+	DefaultProfile string            `json:"defaultProfile"`
+	Profiles       map[string]*Entry `json:"profiles"`
 }
 
 // Entry is a single profile entry in config.json.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -3,8 +3,9 @@
 // State is stored in a profile-specific directory:
 //
 //	~/.enbox/profiles/<name>/meshd/
-//	  identity.json   # DID private key (from the did package)
-//	  network.json    # current network membership info
+//	  identity.vault.json  # encrypted DID private key (from the did package)
+//	  identity.json        # legacy plaintext DID private key
+//	  network.json         # current network membership info
 //
 // The state directory is resolved by the profile package. The functions in
 // this package accept a stateDir parameter and are agnostic to profiles.

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -1,0 +1,189 @@
+// Package vault provides password-based encryption for local meshd secrets.
+package vault
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"golang.org/x/crypto/argon2"
+	"golang.org/x/crypto/chacha20poly1305"
+)
+
+const (
+	Version = 1
+
+	kdfArgon2id   = "argon2id"
+	cipherXChaCha = "xchacha20poly1305"
+
+	saltSize = 16
+	keySize  = chacha20poly1305.KeySize
+)
+
+// Argon2idParams are serialized with the vault so KDF settings are explicit.
+type Argon2idParams struct {
+	Time    uint32 `json:"time"`
+	Memory  uint32 `json:"memory"`
+	Threads uint8  `json:"threads"`
+	KeyLen  uint32 `json:"keyLen"`
+}
+
+// DefaultArgon2idParams is intentionally moderate for CLI unlock latency while
+// still using a memory-hard KDF for at-rest key protection.
+var DefaultArgon2idParams = Argon2idParams{
+	Time:    3,
+	Memory:  64 * 1024,
+	Threads: 4,
+	KeyLen:  keySize,
+}
+
+// FastArgon2idParams is for tests only.
+var FastArgon2idParams = Argon2idParams{
+	Time:    1,
+	Memory:  1024,
+	Threads: 1,
+	KeyLen:  keySize,
+}
+
+// Envelope is the JSON file format for an encrypted vault payload.
+type Envelope struct {
+	Version    int            `json:"version"`
+	KDF        string         `json:"kdf"`
+	KDFParams  Argon2idParams `json:"kdfParams"`
+	Cipher     string         `json:"cipher"`
+	Salt       string         `json:"salt"`
+	Nonce      string         `json:"nonce"`
+	Ciphertext string         `json:"ciphertext"`
+}
+
+// Seal encrypts plaintext using the default KDF parameters.
+func Seal(plaintext []byte, password string) ([]byte, error) {
+	return SealWithParams(plaintext, password, DefaultArgon2idParams)
+}
+
+// SealWithParams encrypts plaintext using explicit KDF parameters.
+func SealWithParams(plaintext []byte, password string, params Argon2idParams) ([]byte, error) {
+	if password == "" {
+		return nil, fmt.Errorf("vault password is required")
+	}
+	var err error
+	params, err = normalizeParams(params)
+	if err != nil {
+		return nil, err
+	}
+
+	salt := make([]byte, saltSize)
+	if _, err := rand.Read(salt); err != nil {
+		return nil, fmt.Errorf("generate vault salt: %w", err)
+	}
+
+	key := deriveKey(password, salt, params)
+	defer clear(key)
+
+	aead, err := chacha20poly1305.NewX(key)
+	if err != nil {
+		return nil, fmt.Errorf("create vault cipher: %w", err)
+	}
+
+	nonce := make([]byte, chacha20poly1305.NonceSizeX)
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("generate vault nonce: %w", err)
+	}
+
+	env := Envelope{
+		Version:    Version,
+		KDF:        kdfArgon2id,
+		KDFParams:  params,
+		Cipher:     cipherXChaCha,
+		Salt:       base64.RawURLEncoding.EncodeToString(salt),
+		Nonce:      base64.RawURLEncoding.EncodeToString(nonce),
+		Ciphertext: base64.RawURLEncoding.EncodeToString(aead.Seal(nil, nonce, plaintext, nil)),
+	}
+
+	data, err := json.MarshalIndent(env, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal vault envelope: %w", err)
+	}
+	return data, nil
+}
+
+// Open decrypts a vault envelope.
+func Open(data []byte, password string) ([]byte, error) {
+	if password == "" {
+		return nil, fmt.Errorf("vault password is required")
+	}
+
+	var env Envelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil, fmt.Errorf("parse vault envelope: %w", err)
+	}
+	if env.Version != Version {
+		return nil, fmt.Errorf("unsupported vault version %d", env.Version)
+	}
+	if env.KDF != kdfArgon2id {
+		return nil, fmt.Errorf("unsupported vault kdf %q", env.KDF)
+	}
+	if env.Cipher != cipherXChaCha {
+		return nil, fmt.Errorf("unsupported vault cipher %q", env.Cipher)
+	}
+	params, err := normalizeParams(env.KDFParams)
+	if err != nil {
+		return nil, err
+	}
+
+	salt, err := base64.RawURLEncoding.DecodeString(env.Salt)
+	if err != nil {
+		return nil, fmt.Errorf("decode vault salt: %w", err)
+	}
+	nonce, err := base64.RawURLEncoding.DecodeString(env.Nonce)
+	if err != nil {
+		return nil, fmt.Errorf("decode vault nonce: %w", err)
+	}
+	ciphertext, err := base64.RawURLEncoding.DecodeString(env.Ciphertext)
+	if err != nil {
+		return nil, fmt.Errorf("decode vault ciphertext: %w", err)
+	}
+
+	key := deriveKey(password, salt, params)
+	defer clear(key)
+
+	aead, err := chacha20poly1305.NewX(key)
+	if err != nil {
+		return nil, fmt.Errorf("create vault cipher: %w", err)
+	}
+	plaintext, err := aead.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("open vault: %w", err)
+	}
+	return plaintext, nil
+}
+
+func normalizeParams(params Argon2idParams) (Argon2idParams, error) {
+	if params.Time == 0 {
+		return params, fmt.Errorf("vault kdf time must be greater than zero")
+	}
+	if params.Memory == 0 {
+		return params, fmt.Errorf("vault kdf memory must be greater than zero")
+	}
+	if params.Threads == 0 {
+		return params, fmt.Errorf("vault kdf threads must be greater than zero")
+	}
+	if params.KeyLen == 0 {
+		params.KeyLen = keySize
+	}
+	if params.KeyLen != keySize {
+		return params, fmt.Errorf("vault key length must be %d bytes", keySize)
+	}
+	return params, nil
+}
+
+func deriveKey(password string, salt []byte, params Argon2idParams) []byte {
+	return argon2.IDKey([]byte(password), salt, params.Time, params.Memory, params.Threads, params.KeyLen)
+}
+
+func clear(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -1,0 +1,88 @@
+package vault
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestSealOpenRoundTrip(t *testing.T) {
+	plaintext := []byte(`{"secret":"value"}`)
+
+	sealed, err := SealWithParams(plaintext, "correct horse battery staple", FastArgon2idParams)
+	if err != nil {
+		t.Fatalf("SealWithParams: %v", err)
+	}
+	if bytes.Contains(sealed, []byte("value")) {
+		t.Fatal("sealed envelope contains plaintext")
+	}
+
+	got, err := Open(sealed, "correct horse battery staple")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("plaintext mismatch\ngot:  %s\nwant: %s", got, plaintext)
+	}
+}
+
+func TestOpenWrongPassword(t *testing.T) {
+	sealed, err := SealWithParams([]byte("secret"), "right", FastArgon2idParams)
+	if err != nil {
+		t.Fatalf("SealWithParams: %v", err)
+	}
+	if _, err := Open(sealed, "wrong"); err == nil {
+		t.Fatal("expected wrong password to fail")
+	}
+}
+
+func TestSealRejectsEmptyPassword(t *testing.T) {
+	if _, err := SealWithParams([]byte("secret"), "", FastArgon2idParams); err == nil {
+		t.Fatal("expected empty password error")
+	}
+}
+
+func TestEnvelopeMetadata(t *testing.T) {
+	sealed, err := SealWithParams([]byte("secret"), "password", FastArgon2idParams)
+	if err != nil {
+		t.Fatalf("SealWithParams: %v", err)
+	}
+
+	var env Envelope
+	if err := json.Unmarshal(sealed, &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	if env.Version != Version {
+		t.Fatalf("Version = %d, want %d", env.Version, Version)
+	}
+	if env.KDF != kdfArgon2id {
+		t.Fatalf("KDF = %q, want %q", env.KDF, kdfArgon2id)
+	}
+	if env.Cipher != cipherXChaCha {
+		t.Fatalf("Cipher = %q, want %q", env.Cipher, cipherXChaCha)
+	}
+	if env.Salt == "" || env.Nonce == "" || env.Ciphertext == "" {
+		t.Fatal("envelope missing salt, nonce, or ciphertext")
+	}
+}
+
+func TestOpenRejectsInvalidKDFParams(t *testing.T) {
+	sealed, err := SealWithParams([]byte("secret"), "password", FastArgon2idParams)
+	if err != nil {
+		t.Fatalf("SealWithParams: %v", err)
+	}
+
+	var env Envelope
+	if err := json.Unmarshal(sealed, &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	env.KDFParams.Threads = 0
+	corrupt, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal corrupt envelope: %v", err)
+	}
+
+	if _, err := Open(corrupt, "password"); err == nil {
+		t.Fatal("expected invalid KDF params to fail")
+	}
+}


### PR DESCRIPTION
## Summary
- add an Argon2id + XChaCha20-Poly1305 local vault envelope for meshd secrets
- store newly created DID identities in identity.vault.json by default, with legacy identity.json loading and migration
- add vault status/init/unlock commands and MESHD_VAULT_PASSWORD for non-interactive unlock/create
- update quick start and storage-layout docs

## Tests
- GOFLAGS=-mod=vendor go build ./...
- GOFLAGS=-mod=vendor go vet ./...
- GOFLAGS=-mod=vendor go test ./... -count=1 -race

Closes #93