### PR TITLE
feat: encrypt cached context keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,9 @@ mesh. They never need a public IP. They never appear in your DID document.
 
 **Identity:** Each device gets a `did:jwk` identity -- an Ed25519 key pair
 encoded as a DID. The private key is stored in a password-encrypted local
-vault. The WireGuard key is derived from the same identity (Ed25519 to
-X25519 birational map), so there is exactly one key to manage.
+vault, and delivered network context keys are stored in encrypted local
+secrets. The WireGuard key is derived from the same identity (Ed25519 to
+X25519 birational map), so there is exactly one identity key to manage.
 
 **Networking:** meshd uses [meshnet](https://github.com/enboxorg/meshnet),
 a fork of Tailscale's open-source networking engine. This gives us

--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -682,7 +682,7 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 	}
 
 	// Fetch and persist context key if available.
-	var contextKeyB64 string
+	var contextKeyPriv []byte
 	useContextEnc := false
 	if nodeRecordID != "" {
 		contextKey, ckErr := fetchContextKey(ctx, identity, &state.NetworkState{
@@ -694,7 +694,7 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 			privBytes, pbErr := contextKey.PrivateKeyBytes()
 			if pbErr == nil {
 				encMgr.StoreContextKey(networkID, privBytes)
-				contextKeyB64 = base64.StdEncoding.EncodeToString(privBytes)
+				contextKeyPriv = privBytes
 				useContextEnc = true
 			}
 		}
@@ -736,7 +736,9 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 		NodeRecordID:    nodeRecordID,
 		NodeDateCreated: nodeDateCreated,
 		MemberRecordID:  memberRecordID,
-		ContextKey:      contextKeyB64,
+	}
+	if err := attachContextKeyForNetworkSave(stateDir, ns, contextKeyPriv); err != nil {
+		return fmt.Errorf("caching context key: %w", err)
 	}
 	if err := state.SaveNetworkState(stateDir, ns); err != nil {
 		return fmt.Errorf("saving network state: %w", err)
@@ -1441,17 +1443,14 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 		useContextEncryption = true
 	} else {
 		// Try cached context key first (survives DWN outages at startup).
-		if ns.ContextKey != "" {
-			privBytes, err := base64.StdEncoding.DecodeString(ns.ContextKey)
-			if err == nil {
-				encMgr.StoreContextKey(ns.NetworkRecordID, privBytes)
-				useContextEncryption = true
-				fmt.Printf("  Context key: loaded from cache\n")
-			} else {
-				slog.Warn("cached context key decode failed, will fetch from DWN",
-					slog.Any("error", err),
-				)
-			}
+		source, ok, err := loadLocalContextKeyForCLI(stateDir, ns, encMgr)
+		if err != nil {
+			slog.Warn("cached context key load failed, will fetch from DWN",
+				slog.Any("error", err),
+			)
+		} else if ok {
+			useContextEncryption = true
+			fmt.Printf("  Context key: loaded from %s\n", source)
 		}
 
 		// Fall back to DWN fetch if not cached.
@@ -1470,8 +1469,7 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 				useContextEncryption = true
 
 				// Persist for next startup.
-				ns.ContextKey = base64.StdEncoding.EncodeToString(privBytes)
-				if saveErr := state.SaveNetworkState(stateDir, ns); saveErr != nil {
+				if saveErr := saveContextKeyForCommand(stateDir, ns, privBytes); saveErr != nil {
 					slog.Warn("failed to persist context key", slog.Any("error", saveErr))
 				}
 				fmt.Printf("  Context key: received (Protocol Context encryption enabled)\n")
@@ -1954,6 +1952,8 @@ func cmdDown(ctx context.Context, args []string) error {
 
 const vaultPasswordEnv = "MESHD_VAULT_PASSWORD"
 
+var cachedVaultPassword string
+
 func defaultProfileName(flagProfile string) string {
 	if flagProfile != "" {
 		return flagProfile
@@ -1988,7 +1988,11 @@ func storeIdentityForCLI(identity *did.DID, stateDir string) error {
 
 func vaultPasswordForUnlock() (string, error) {
 	if password := os.Getenv(vaultPasswordEnv); password != "" {
+		cachedVaultPassword = password
 		return password, nil
+	}
+	if cachedVaultPassword != "" {
+		return cachedVaultPassword, nil
 	}
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
 		return "", fmt.Errorf("vault password required; run in a terminal or set %s", vaultPasswordEnv)
@@ -2004,12 +2008,17 @@ func vaultPasswordForUnlock() (string, error) {
 	if password == "" {
 		return "", fmt.Errorf("vault password is required")
 	}
+	cachedVaultPassword = password
 	return password, nil
 }
 
 func vaultPasswordForCreate() (string, error) {
 	if password := os.Getenv(vaultPasswordEnv); password != "" {
+		cachedVaultPassword = password
 		return password, nil
+	}
+	if cachedVaultPassword != "" {
+		return cachedVaultPassword, nil
 	}
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
 		return "", fmt.Errorf("vault password required; run in a terminal or set %s", vaultPasswordEnv)
@@ -2035,6 +2044,7 @@ func vaultPasswordForCreate() (string, error) {
 	if password != string(confirmBytes) {
 		return "", fmt.Errorf("vault passwords do not match")
 	}
+	cachedVaultPassword = password
 	return password, nil
 }
 
@@ -2063,6 +2073,80 @@ func loadIdentity(stateDir string) (*did.DID, error) {
 		return nil, fmt.Errorf("loading identity: %w", err)
 	}
 	return identity, nil
+}
+
+func loadLocalContextKeyForCLI(stateDir string, ns *state.NetworkState, encMgr *dwncrypto.EncryptionKeyManager) (string, bool, error) {
+	if ns == nil || ns.NetworkRecordID == "" {
+		return "", false, nil
+	}
+
+	if did.EncryptedExists(stateDir) {
+		password, err := vaultPasswordForUnlock()
+		if err != nil {
+			return "", false, err
+		}
+		privBytes, ok, err := state.LoadContextKey(stateDir, password, ns.NetworkRecordID)
+		if err != nil {
+			return "", false, err
+		}
+		if ok {
+			encMgr.StoreContextKey(ns.NetworkRecordID, privBytes)
+			return "vault", true, nil
+		}
+	}
+
+	if ns.ContextKey == "" {
+		return "", false, nil
+	}
+	privBytes, err := base64.StdEncoding.DecodeString(ns.ContextKey)
+	if err != nil {
+		return "", false, fmt.Errorf("decode cached context key: %w", err)
+	}
+	encMgr.StoreContextKey(ns.NetworkRecordID, privBytes)
+
+	if did.EncryptedExists(stateDir) {
+		password, err := vaultPasswordForUnlock()
+		if err != nil {
+			return "", false, err
+		}
+		if err := state.StoreContextKey(stateDir, password, ns.NetworkRecordID, privBytes); err != nil {
+			return "", false, err
+		}
+		ns.ContextKey = ""
+		if err := state.SaveNetworkState(stateDir, ns); err != nil {
+			return "", false, err
+		}
+		return "legacy cache (migrated)", true, nil
+	}
+
+	return "legacy cache", true, nil
+}
+
+func attachContextKeyForNetworkSave(stateDir string, ns *state.NetworkState, privateKey []byte) error {
+	if len(privateKey) == 0 {
+		return nil
+	}
+	if did.EncryptedExists(stateDir) {
+		password, err := vaultPasswordForUnlock()
+		if err != nil {
+			return err
+		}
+		if err := state.StoreContextKey(stateDir, password, ns.NetworkRecordID, privateKey); err != nil {
+			return err
+		}
+		ns.ContextKey = ""
+		return nil
+	}
+
+	ns.ContextKey = base64.StdEncoding.EncodeToString(privateKey)
+	return nil
+}
+
+func saveContextKeyForCommand(stateDir string, ns *state.NetworkState, privateKey []byte) error {
+	if err := attachContextKeyForNetworkSave(stateDir, ns, privateKey); err != nil {
+		return err
+	}
+	return state.SaveNetworkState(stateDir, ns)
 }
 
 // newEncryptionKeyManager creates an EncryptionKeyManager from a DID identity.
@@ -2419,13 +2503,9 @@ func cmdACLShow(ctx context.Context, args []string, flagProfile string) error {
 
 	// Load context key for decryption. Try cached key first, then DWN fetch.
 	if ns.AnchorDID != identity.URI {
-		contextKeyLoaded := false
-		if ns.ContextKey != "" {
-			privBytes, decErr := base64.StdEncoding.DecodeString(ns.ContextKey)
-			if decErr == nil {
-				encMgr.StoreContextKey(ns.NetworkRecordID, privBytes)
-				contextKeyLoaded = true
-			}
+		_, contextKeyLoaded, loadErr := loadLocalContextKeyForCLI(stateDir, ns, encMgr)
+		if loadErr != nil {
+			fmt.Printf("  Warning: cached context key load failed: %v\n", loadErr)
 		}
 		if !contextKeyLoaded {
 			contextKey, ckErr := fetchContextKey(ctx, identity, ns)
@@ -2439,8 +2519,7 @@ func cmdACLShow(ctx context.Context, args []string, flagProfile string) error {
 				encMgr.StoreContextKey(ns.NetworkRecordID, privBytes)
 
 				// Persist for next time.
-				ns.ContextKey = base64.StdEncoding.EncodeToString(privBytes)
-				if saveErr := state.SaveNetworkState(stateDir, ns); saveErr != nil {
+				if saveErr := saveContextKeyForCommand(stateDir, ns, privBytes); saveErr != nil {
 					fmt.Printf("  Warning: failed to persist context key: %v\n", saveErr)
 				}
 			}

--- a/cmd/meshd/main_test.go
+++ b/cmd/meshd/main_test.go
@@ -1,13 +1,16 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"strings"
 	"testing"
 
 	"github.com/enboxorg/meshd/internal/did"
 	"github.com/enboxorg/meshd/internal/invite"
 	"github.com/enboxorg/meshd/internal/profile"
+	"github.com/enboxorg/meshd/internal/state"
 )
 
 func TestParseUpFlagsInviteURL(t *testing.T) {
@@ -25,7 +28,18 @@ func TestParseUpFlagsInviteURL(t *testing.T) {
 	}
 }
 
+func resetVaultPasswordCache(t *testing.T) {
+	t.Helper()
+	previous := cachedVaultPassword
+	cachedVaultPassword = ""
+	t.Cleanup(func() {
+		cachedVaultPassword = previous
+	})
+}
+
 func TestEnsureIdentityForCommandCreatesDefaultProfile(t *testing.T) {
+	resetVaultPasswordCache(t)
+
 	home := t.TempDir()
 	t.Setenv("ENBOX_HOME", home)
 	t.Setenv("ENBOX_PROFILE", "")
@@ -62,6 +76,8 @@ func TestEnsureIdentityForCommandCreatesDefaultProfile(t *testing.T) {
 }
 
 func TestEnsureIdentityForCommandUsesResolvedDefaultProfile(t *testing.T) {
+	resetVaultPasswordCache(t)
+
 	home := t.TempDir()
 	t.Setenv("ENBOX_HOME", home)
 	t.Setenv("ENBOX_PROFILE", "")
@@ -95,5 +111,55 @@ func TestEnsureIdentityForCommandUsesResolvedDefaultProfile(t *testing.T) {
 	}
 	if cfg.Profiles["work"].DID != identity.URI {
 		t.Fatalf("profile DID = %q, want %q", cfg.Profiles["work"].DID, identity.URI)
+	}
+}
+
+func TestLoadLocalContextKeyMigratesLegacyContextKey(t *testing.T) {
+	resetVaultPasswordCache(t)
+
+	dir := t.TempDir()
+	t.Setenv("MESHD_VAULT_PASSWORD", "test-password")
+
+	identity, err := did.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if err := identity.StoreEncrypted(dir, "test-password"); err != nil {
+		t.Fatalf("StoreEncrypted: %v", err)
+	}
+
+	key := bytes.Repeat([]byte{0x42}, 32)
+	ns := &state.NetworkState{
+		NetworkRecordID: "network-1",
+		ContextKey:      base64.StdEncoding.EncodeToString(key),
+	}
+	if err := state.SaveNetworkState(dir, ns); err != nil {
+		t.Fatalf("SaveNetworkState: %v", err)
+	}
+
+	source, ok, err := loadLocalContextKeyForCLI(dir, ns, newEncryptionKeyManager(identity))
+	if err != nil {
+		t.Fatalf("loadLocalContextKeyForCLI: %v", err)
+	}
+	if !ok {
+		t.Fatal("context key was not loaded")
+	}
+	if source != "legacy cache (migrated)" {
+		t.Fatalf("source = %q, want migrated legacy cache", source)
+	}
+
+	stored, ok, err := state.LoadContextKey(dir, "test-password", "network-1")
+	if err != nil {
+		t.Fatalf("LoadContextKey: %v", err)
+	}
+	if !ok || !bytes.Equal(stored, key) {
+		t.Fatalf("encrypted context key mismatch")
+	}
+	reloaded, err := state.LoadNetworkState(dir)
+	if err != nil {
+		t.Fatalf("LoadNetworkState: %v", err)
+	}
+	if reloaded.ContextKey != "" {
+		t.Fatalf("legacy ContextKey = %q, want empty", reloaded.ContextKey)
 	}
 }

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -14,6 +14,7 @@
 //	        identity.vault.json     # password-encrypted DID private key
 //	        identity.json           # legacy plaintext DID state
 //	        network.json            # network membership state
+//	        secrets.vault.json      # encrypted network context keys
 //
 // Override base path with ENBOX_HOME env var.
 //

--- a/internal/state/secrets.go
+++ b/internal/state/secrets.go
@@ -1,0 +1,120 @@
+package state
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/enboxorg/meshd/internal/vault"
+)
+
+const secretsFile = "secrets.vault.json"
+
+// Secrets is the encrypted local secret payload for a meshd state directory.
+type Secrets struct {
+	ContextKeys map[string]string `json:"contextKeys,omitempty"`
+}
+
+// EncryptedSecretsExist checks whether encrypted local secrets exist.
+func EncryptedSecretsExist(stateDir string) bool {
+	_, err := os.Stat(filepath.Join(stateDir, secretsFile))
+	return err == nil
+}
+
+// LoadContextKey loads an encrypted Protocol Context key for a network.
+func LoadContextKey(stateDir string, password string, networkID string) ([]byte, bool, error) {
+	if networkID == "" {
+		return nil, false, fmt.Errorf("network id is required")
+	}
+
+	secrets, err := loadSecrets(stateDir, password)
+	if err != nil {
+		return nil, false, err
+	}
+	if secrets == nil || secrets.ContextKeys == nil {
+		return nil, false, nil
+	}
+
+	encoded := secrets.ContextKeys[networkID]
+	if encoded == "" {
+		return nil, false, nil
+	}
+	key, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, false, fmt.Errorf("decode context key: %w", err)
+	}
+	return key, true, nil
+}
+
+// StoreContextKey stores a Protocol Context key in encrypted local secrets.
+func StoreContextKey(stateDir string, password string, networkID string, key []byte) error {
+	if networkID == "" {
+		return fmt.Errorf("network id is required")
+	}
+	if len(key) == 0 {
+		return fmt.Errorf("context key is required")
+	}
+
+	secrets, err := loadSecrets(stateDir, password)
+	if err != nil {
+		return err
+	}
+	if secrets == nil {
+		secrets = &Secrets{}
+	}
+	if secrets.ContextKeys == nil {
+		secrets.ContextKeys = make(map[string]string)
+	}
+	secrets.ContextKeys[networkID] = base64.StdEncoding.EncodeToString(key)
+	return saveSecrets(stateDir, password, secrets)
+}
+
+func loadSecrets(stateDir string, password string) (*Secrets, error) {
+	target := filepath.Join(stateDir, secretsFile)
+	data, err := os.ReadFile(target)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Secrets{}, nil
+		}
+		return nil, fmt.Errorf("read encrypted secrets: %w", err)
+	}
+
+	plaintext, err := vault.Open(data, password)
+	if err != nil {
+		return nil, fmt.Errorf("open encrypted secrets: %w", err)
+	}
+
+	var secrets Secrets
+	if err := json.Unmarshal(plaintext, &secrets); err != nil {
+		return nil, fmt.Errorf("unmarshal encrypted secrets: %w", err)
+	}
+	return &secrets, nil
+}
+
+func saveSecrets(stateDir string, password string, secrets *Secrets) error {
+	if err := os.MkdirAll(stateDir, 0700); err != nil {
+		return fmt.Errorf("create state dir: %w", err)
+	}
+
+	plaintext, err := json.Marshal(secrets)
+	if err != nil {
+		return fmt.Errorf("marshal encrypted secrets: %w", err)
+	}
+	sealed, err := vault.Seal(plaintext, password)
+	if err != nil {
+		return err
+	}
+
+	target := filepath.Join(stateDir, secretsFile)
+	tmp := target + ".tmp"
+	if err := os.WriteFile(tmp, sealed, 0600); err != nil {
+		return fmt.Errorf("write encrypted secrets: %w", err)
+	}
+	if err := os.Rename(tmp, target); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("rename encrypted secrets: %w", err)
+	}
+	return nil
+}

--- a/internal/state/secrets_test.go
+++ b/internal/state/secrets_test.go
@@ -1,0 +1,94 @@
+package state
+
+import (
+	"bytes"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStoreAndLoadContextKey(t *testing.T) {
+	dir := t.TempDir()
+	key := bytes.Repeat([]byte{0x42}, 32)
+
+	if err := StoreContextKey(dir, "password", "network-1", key); err != nil {
+		t.Fatalf("StoreContextKey: %v", err)
+	}
+	if !EncryptedSecretsExist(dir) {
+		t.Fatal("EncryptedSecretsExist returned false after StoreContextKey")
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, secretsFile))
+	if err != nil {
+		t.Fatalf("read secrets file: %v", err)
+	}
+	if bytes.Contains(data, key) ||
+		bytes.Contains(data, []byte(base64.StdEncoding.EncodeToString(key))) ||
+		bytes.Contains(data, []byte("network-1")) {
+		t.Fatal("encrypted secrets file contains plaintext key material")
+	}
+
+	got, ok, err := LoadContextKey(dir, "password", "network-1")
+	if err != nil {
+		t.Fatalf("LoadContextKey: %v", err)
+	}
+	if !ok {
+		t.Fatal("context key was not found")
+	}
+	if !bytes.Equal(got, key) {
+		t.Fatalf("context key mismatch\ngot:  %x\nwant: %x", got, key)
+	}
+}
+
+func TestStoreContextKeyPreservesExistingKeys(t *testing.T) {
+	dir := t.TempDir()
+	key1 := bytes.Repeat([]byte{0x01}, 32)
+	key2 := bytes.Repeat([]byte{0x02}, 32)
+
+	if err := StoreContextKey(dir, "password", "network-1", key1); err != nil {
+		t.Fatalf("StoreContextKey network-1: %v", err)
+	}
+	if err := StoreContextKey(dir, "password", "network-2", key2); err != nil {
+		t.Fatalf("StoreContextKey network-2: %v", err)
+	}
+
+	got1, ok, err := LoadContextKey(dir, "password", "network-1")
+	if err != nil {
+		t.Fatalf("LoadContextKey network-1: %v", err)
+	}
+	if !ok || !bytes.Equal(got1, key1) {
+		t.Fatalf("network-1 key mismatch")
+	}
+	got2, ok, err := LoadContextKey(dir, "password", "network-2")
+	if err != nil {
+		t.Fatalf("LoadContextKey network-2: %v", err)
+	}
+	if !ok || !bytes.Equal(got2, key2) {
+		t.Fatalf("network-2 key mismatch")
+	}
+}
+
+func TestLoadContextKeyMissing(t *testing.T) {
+	dir := t.TempDir()
+
+	got, ok, err := LoadContextKey(dir, "password", "missing")
+	if err != nil {
+		t.Fatalf("LoadContextKey: %v", err)
+	}
+	if ok || got != nil {
+		t.Fatalf("missing key returned %x, %v", got, ok)
+	}
+}
+
+func TestLoadContextKeyWrongPassword(t *testing.T) {
+	dir := t.TempDir()
+	key := bytes.Repeat([]byte{0x42}, 32)
+
+	if err := StoreContextKey(dir, "password", "network-1", key); err != nil {
+		t.Fatalf("StoreContextKey: %v", err)
+	}
+	if _, _, err := LoadContextKey(dir, "wrong", "network-1"); err == nil {
+		t.Fatal("expected wrong password to fail")
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -6,6 +6,7 @@
 //	  identity.vault.json  # encrypted DID private key (from the did package)
 //	  identity.json        # legacy plaintext DID private key
 //	  network.json         # current network membership info
+//	  secrets.vault.json   # encrypted network context keys and local secrets
 //
 // The state directory is resolved by the profile package. The functions in
 // this package accept a stateDir parameter and are agnostic to profiles.
@@ -80,10 +81,9 @@ type NetworkState struct {
 	// record write. Required for updates because dateCreated is immutable.
 	MemberDateCreated string `json:"memberDateCreated,omitempty"`
 
-	// ContextKey is the Protocol Context encryption key (base64-encoded
-	// X25519 private key). Persisted so the mesh survives DWN outages
-	// at startup — if the anchor's DWN is unreachable, the node can
-	// still encrypt/decrypt records using the cached key.
+	// ContextKey is a legacy plaintext cache of the Protocol Context
+	// encryption key (base64-encoded X25519 private key). New encrypted
+	// identity profiles store context keys in secrets.vault.json instead.
 	//
 	// For the anchor, this is empty — the anchor derives the context key
 	// from its root key via HKDF on every startup.


### PR DESCRIPTION
## Summary
- add encrypted local secrets storage for per-network Protocol Context keys
- load context keys from secrets.vault.json before falling back to legacy network.json.contextKey
- migrate legacy plaintext context keys into encrypted secrets after vault unlock
- persist newly fetched context keys encrypted for vault-backed identities

## Tests
- GOFLAGS=-mod=vendor go build ./...
- GOFLAGS=-mod=vendor go vet ./...
- GOFLAGS=-mod=vendor go test ./... -count=1 -race

Closes #95