### PR TITLE
feat: add guided network setup prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ Network:
   down              Stop the mesh agent daemon
 ```
 
+Run `meshd network create` or `meshd network join` without all arguments in
+an interactive terminal and meshd will prompt for the missing values.
+
 ## If you already have a DID and DWN
 
 meshd becomes something more: **private infrastructure for your DWN

--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -324,29 +324,30 @@ func cmdVaultUnlock(args []string, flagProfile string) error {
 
 // cmdNetworkCreate creates a new mesh network.
 //
-// Usage: meshd network create <name> --endpoint <dwn-url>
+// Usage: meshd network create [name] [--endpoint <dwn-url>]
 func cmdNetworkCreate(ctx context.Context, args []string, flagProfile string) error {
-	if len(args) < 3 {
-		return fmt.Errorf("usage: meshd network create <name> --endpoint <dwn-url>")
-	}
-
-	name := args[0]
-	endpoint := ""
-	for i := 1; i < len(args); i++ {
-		if args[i] == "--endpoint" && i+1 < len(args) {
-			endpoint = args[i+1]
-			break
+	name, endpoint := parseNetworkCreateArgs(args)
+	if name == "" || endpoint == "" {
+		if !stdinIsTerminal() {
+			return fmt.Errorf("usage: meshd network create [name] [--endpoint <dwn-url>]")
+		}
+		scanner := bufio.NewScanner(os.Stdin)
+		var err error
+		if name == "" {
+			name, err = promptRequired(scanner, "Network name")
+			if err != nil {
+				return err
+			}
+		}
+		if endpoint == "" {
+			endpoint, err = promptRequired(scanner, "DWN endpoint URL")
+			if err != nil {
+				return err
+			}
 		}
 	}
-	if endpoint == "" {
-		return fmt.Errorf("--endpoint is required")
-	}
 
-	stateDir, err := resolveStateDir(flagProfile)
-	if err != nil {
-		return err
-	}
-	identity, err := loadIdentity(stateDir)
+	stateDir, identity, err := ensureIdentityForCommand(ctx, flagProfile, endpoint)
 	if err != nil {
 		return err
 	}
@@ -507,16 +508,7 @@ func cmdNetworkCreate(ctx context.Context, args []string, flagProfile string) er
 	return nil
 }
 
-// cmdNetworkJoin joins an existing mesh network.
-//
-// Usage: meshd network join --endpoint <url> --anchor <did> --network <id>
-func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) error {
-	if len(args) == 1 && strings.HasPrefix(strings.TrimSpace(args[0]), invite.SchemePrefix) {
-		return cmdJoin(ctx, args, flagProfile)
-	}
-
-	var endpoint, anchorDID, networkID string
-	preauthRequested := false
+func parseNetworkCreateArgs(args []string) (name string, endpoint string) {
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--endpoint":
@@ -524,30 +516,69 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 				endpoint = args[i+1]
 				i++
 			}
-		case "--anchor":
-			if i+1 < len(args) {
-				anchorDID = args[i+1]
-				i++
+		default:
+			if name == "" && !strings.HasPrefix(args[i], "-") {
+				name = args[i]
 			}
-		case "--network":
-			if i+1 < len(args) {
-				networkID = args[i+1]
-				i++
+		}
+	}
+	if endpoint == "" {
+		endpoint = os.Getenv("DWN_ENDPOINT")
+	}
+	return name, endpoint
+}
+
+// cmdNetworkJoin joins an existing mesh network.
+//
+// Usage: meshd network join <invite-url>
+// Usage: meshd network join --endpoint <url> --anchor <did> --network <id>
+func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) error {
+	if len(args) == 1 && strings.HasPrefix(strings.TrimSpace(args[0]), invite.SchemePrefix) {
+		return cmdJoin(ctx, args, flagProfile)
+	}
+
+	endpoint, anchorDID, networkID, preauthRequested := parseNetworkJoinArgs(args)
+	if endpoint == "" || anchorDID == "" || networkID == "" {
+		if !stdinIsTerminal() {
+			return fmt.Errorf("usage: meshd network join <invite-url> OR meshd network join --endpoint <url> --anchor <did> --network <id>")
+		}
+		scanner := bufio.NewScanner(os.Stdin)
+		if len(args) == 0 {
+			fmt.Print("Invite URL (or press Enter for manual join): ")
+			if !scanner.Scan() {
+				return fmt.Errorf("no input received")
 			}
-		case "--preauth":
-			preauthRequested = true
+			inviteURL := strings.TrimSpace(scanner.Text())
+			if inviteURL != "" {
+				if !strings.HasPrefix(inviteURL, invite.SchemePrefix) {
+					return fmt.Errorf("invite URL must start with %s", invite.SchemePrefix)
+				}
+				return cmdJoin(ctx, []string{inviteURL}, flagProfile)
+			}
+		}
+
+		var err error
+		if endpoint == "" {
+			endpoint, err = promptRequired(scanner, "DWN endpoint URL")
+			if err != nil {
+				return err
+			}
+		}
+		if anchorDID == "" {
+			anchorDID, err = promptRequired(scanner, "Anchor DID")
+			if err != nil {
+				return err
+			}
+		}
+		if networkID == "" {
+			networkID, err = promptRequired(scanner, "Network record ID")
+			if err != nil {
+				return err
+			}
 		}
 	}
 
-	if endpoint == "" || anchorDID == "" || networkID == "" {
-		return fmt.Errorf("usage: meshd network join --endpoint <url> --anchor <did> --network <id>")
-	}
-
-	stateDir, err := resolveStateDir(flagProfile)
-	if err != nil {
-		return err
-	}
-	identity, err := loadIdentity(stateDir)
+	stateDir, identity, err := ensureIdentityForCommand(ctx, flagProfile, endpoint)
 	if err != nil {
 		return err
 	}
@@ -752,6 +783,34 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 	fmt.Printf("\nRun 'meshd up' to start the mesh.\n")
 
 	return nil
+}
+
+func parseNetworkJoinArgs(args []string) (endpoint string, anchorDID string, networkID string, preauthRequested bool) {
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--endpoint":
+			if i+1 < len(args) {
+				endpoint = args[i+1]
+				i++
+			}
+		case "--anchor":
+			if i+1 < len(args) {
+				anchorDID = args[i+1]
+				i++
+			}
+		case "--network":
+			if i+1 < len(args) {
+				networkID = args[i+1]
+				i++
+			}
+		case "--preauth":
+			preauthRequested = true
+		}
+	}
+	if endpoint == "" {
+		endpoint = os.Getenv("DWN_ENDPOINT")
+	}
+	return endpoint, anchorDID, networkID, preauthRequested
 }
 
 // cmdNetworkLeave leaves the current mesh network.
@@ -1847,6 +1906,22 @@ func setupInteractive(ctx context.Context, f upFlags, stateDir string, identity 
 	default:
 		return nil, fmt.Errorf("invalid choice %q (expected 1 or 2)", choice)
 	}
+}
+
+func stdinIsTerminal() bool {
+	return term.IsTerminal(int(os.Stdin.Fd()))
+}
+
+func promptRequired(scanner *bufio.Scanner, label string) (string, error) {
+	fmt.Printf("%s: ", label)
+	if !scanner.Scan() {
+		return "", fmt.Errorf("no input received")
+	}
+	value := strings.TrimSpace(scanner.Text())
+	if value == "" {
+		return "", fmt.Errorf("%s is required", strings.ToLower(label))
+	}
+	return value, nil
 }
 
 // interactiveCreate guides the user through creating a new network.

--- a/cmd/meshd/main_test.go
+++ b/cmd/meshd/main_test.go
@@ -28,6 +28,74 @@ func TestParseUpFlagsInviteURL(t *testing.T) {
 	}
 }
 
+func TestParseNetworkCreateArgs(t *testing.T) {
+	t.Setenv("DWN_ENDPOINT", "")
+
+	name, endpoint := parseNetworkCreateArgs([]string{"home", "--endpoint", "https://dwn.example.com"})
+	if name != "home" {
+		t.Fatalf("name = %q, want home", name)
+	}
+	if endpoint != "https://dwn.example.com" {
+		t.Fatalf("endpoint = %q, want https://dwn.example.com", endpoint)
+	}
+}
+
+func TestParseNetworkCreateArgsUsesEndpointEnv(t *testing.T) {
+	t.Setenv("DWN_ENDPOINT", "https://env.example.com")
+
+	name, endpoint := parseNetworkCreateArgs([]string{"home"})
+	if name != "home" {
+		t.Fatalf("name = %q, want home", name)
+	}
+	if endpoint != "https://env.example.com" {
+		t.Fatalf("endpoint = %q, want https://env.example.com", endpoint)
+	}
+}
+
+func TestParseNetworkJoinArgs(t *testing.T) {
+	t.Setenv("DWN_ENDPOINT", "")
+
+	endpoint, anchorDID, networkID, preauth := parseNetworkJoinArgs([]string{
+		"--endpoint", "https://dwn.example.com",
+		"--anchor", "did:jwk:anchor",
+		"--network", "net",
+		"--preauth",
+	})
+	if endpoint != "https://dwn.example.com" {
+		t.Fatalf("endpoint = %q, want https://dwn.example.com", endpoint)
+	}
+	if anchorDID != "did:jwk:anchor" {
+		t.Fatalf("anchorDID = %q, want did:jwk:anchor", anchorDID)
+	}
+	if networkID != "net" {
+		t.Fatalf("networkID = %q, want net", networkID)
+	}
+	if !preauth {
+		t.Fatal("preauth = false, want true")
+	}
+}
+
+func TestParseNetworkJoinArgsUsesEndpointEnv(t *testing.T) {
+	t.Setenv("DWN_ENDPOINT", "https://env.example.com")
+
+	endpoint, anchorDID, networkID, preauth := parseNetworkJoinArgs([]string{
+		"--anchor", "did:jwk:anchor",
+		"--network", "net",
+	})
+	if endpoint != "https://env.example.com" {
+		t.Fatalf("endpoint = %q, want https://env.example.com", endpoint)
+	}
+	if anchorDID != "did:jwk:anchor" {
+		t.Fatalf("anchorDID = %q, want did:jwk:anchor", anchorDID)
+	}
+	if networkID != "net" {
+		t.Fatalf("networkID = %q, want net", networkID)
+	}
+	if preauth {
+		t.Fatal("preauth = true, want false")
+	}
+}
+
 func resetVaultPasswordCache(t *testing.T) {
 	t.Helper()
 	previous := cachedVaultPassword


### PR DESCRIPTION
## Summary
- let `meshd network create` prompt for missing name/endpoint in an interactive terminal
- let `meshd network join` prompt for an invite URL or manual join fields when needed
- share first-run encrypted identity creation with direct create/join commands
- keep non-interactive usage errors explicit and preserve `DWN_ENDPOINT` support

## Tests
- `GOFLAGS=-mod=vendor go build ./...`
- `GOFLAGS=-mod=vendor go vet ./...`
- `GOFLAGS=-mod=vendor go test ./... -count=1 -race`

Closes #97