### PR TITLE
fix: satisfy DWN protocol delete action validation

### DIFF
--- a/protocols/protocol_test.go
+++ b/protocols/protocol_test.go
@@ -1,0 +1,59 @@
+package protocols
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func TestProtocolDeleteActionsIncludeCreate(t *testing.T) {
+	for name, data := range map[string][]byte{
+		"wireguard-mesh": MeshProtocolJSON,
+		"key-delivery":   KeyDeliveryProtocolJSON,
+	} {
+		var doc any
+		if err := json.Unmarshal(data, &doc); err != nil {
+			t.Fatalf("%s: unmarshal protocol JSON: %v", name, err)
+		}
+		assertDeleteActionsIncludeCreate(t, name, doc)
+	}
+}
+
+func assertDeleteActionsIncludeCreate(t *testing.T, path string, value any) {
+	t.Helper()
+
+	switch v := value.(type) {
+	case map[string]any:
+		if actions, ok := v["$actions"].([]any); ok {
+			for i, action := range actions {
+				actionMap, ok := action.(map[string]any)
+				if !ok {
+					continue
+				}
+				can, ok := actionMap["can"].([]any)
+				if !ok {
+					continue
+				}
+				if containsAction(can, "delete") && !containsAction(can, "create") {
+					t.Fatalf("%s.$actions[%d] grants delete without create: %v", path, i, can)
+				}
+			}
+		}
+		for key, child := range v {
+			assertDeleteActionsIncludeCreate(t, fmt.Sprintf("%s.%s", path, key), child)
+		}
+	case []any:
+		for i, child := range v {
+			assertDeleteActionsIncludeCreate(t, fmt.Sprintf("%s[%d]", path, i), child)
+		}
+	}
+}
+
+func containsAction(actions []any, want string) bool {
+	for _, action := range actions {
+		if action == want {
+			return true
+		}
+	}
+	return false
+}

--- a/protocols/wireguard-mesh.json
+++ b/protocols/wireguard-mesh.json
@@ -126,7 +126,7 @@
         "$size": { "max": 2000 },
         "$actions": [
           { "who": "anyone", "can": ["create"] },
-          { "who": "author", "of": "network", "can": ["read", "delete", "co-delete"] }
+          { "who": "author", "of": "network", "can": ["create", "read", "delete", "co-delete"] }
         ]
       },
 


### PR DESCRIPTION
## Summary
- add `create` to the `network/nodeRequest` author action rule so live DWN protocol validation accepts the `delete` grant
- add a protocol regression test that fails if any embedded protocol action grants `delete` without `create`

## Context
The post-merge integration job failed before CLI e2e could run with:

`ProtocolsConfigureInvalidActionDeleteWithoutCreate: Action rule {"can":["read","delete","co-delete"],"of":"network","who":"author"} contains 'delete' action but missing the required 'create' action.`

## Tests
- `GOFLAGS=-mod=vendor go build ./...`
- `GOFLAGS=-mod=vendor go vet ./...`
- `GOFLAGS=-mod=vendor go test ./... -count=1 -race`

Closes #101
