### PR TITLE
fix: remove unsupported record limit strategies

### DIFF
--- a/internal/control/dwnclient.go
+++ b/internal/control/dwnclient.go
@@ -337,7 +337,7 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 		if err != nil {
 			c.logger.DebugContext(ctx, "parsing ACL policy results", slog.Any("error", err))
 		} else if len(aclEntries) > 0 {
-			// $recordLimit: max 1 — take the first (most recent) entry.
+			// ACL policies are squashed snapshots; take the newest visible entry.
 			aclDecryptor := c.makeDecryptor("network/aclPolicy")
 			var policy ACLPolicyData
 			if err := ParseEntryData(aclEntries[0], &policy, aclDecryptor); err != nil {

--- a/internal/mesh/e2e_test.go
+++ b/internal/mesh/e2e_test.go
@@ -236,7 +236,7 @@ func TestE2ENetworkCreateJoinQueryDecrypt(t *testing.T) {
 		Filter: dwn.RecordsFilter{
 			Protocol:     "https://enbox.org/protocols/wireguard-mesh",
 			ProtocolPath: "network/node",
-			ParentID:     networkRecordID,
+			ContextID:    networkRecordID,
 		},
 		DateSort: "createdAscending",
 	}, "")

--- a/internal/mesh/register.go
+++ b/internal/mesh/register.go
@@ -460,9 +460,8 @@ type WriteACLPolicyParams struct {
 	PolicyData []byte
 }
 
-// WriteACLPolicy writes or updates the ACL policy record (encrypted) on the
-// anchor DWN. Only the network author (anchor) can create/update the ACL policy.
-// The protocol enforces $recordLimit: max 1 — newer writes replace older ones.
+// WriteACLPolicy writes a squashed ACL policy snapshot (encrypted) on the anchor
+// DWN. Only the network author (anchor) can create/update the ACL policy.
 func WriteACLPolicy(ctx context.Context, params WriteACLPolicyParams) error {
 	if params.EncryptionKeyManager == nil {
 		return fmt.Errorf("EncryptionKeyManager is required for encrypted writes")
@@ -485,6 +484,7 @@ func WriteACLPolicy(ctx context.Context, params WriteACLPolicyParams) error {
 		ParentContextID:      params.NetworkRecordID,
 		Data:                 params.PolicyData,
 		EncryptionRecipients: recipients,
+		Squash:               true,
 	})
 	if err != nil {
 		return fmt.Errorf("writing ACL policy: %w", err)

--- a/protocols/protocol_test.go
+++ b/protocols/protocol_test.go
@@ -7,15 +7,29 @@ import (
 )
 
 func TestProtocolDeleteActionsIncludeCreate(t *testing.T) {
-	for name, data := range map[string][]byte{
-		"wireguard-mesh": MeshProtocolJSON,
-		"key-delivery":   KeyDeliveryProtocolJSON,
-	} {
+	for name, data := range protocolFixtures() {
 		var doc any
 		if err := json.Unmarshal(data, &doc); err != nil {
 			t.Fatalf("%s: unmarshal protocol JSON: %v", name, err)
 		}
 		assertDeleteActionsIncludeCreate(t, name, doc)
+	}
+}
+
+func TestProtocolDoesNotUseUnsupportedRecordLimitStrategies(t *testing.T) {
+	for name, data := range protocolFixtures() {
+		var doc any
+		if err := json.Unmarshal(data, &doc); err != nil {
+			t.Fatalf("%s: unmarshal protocol JSON: %v", name, err)
+		}
+		assertNoUnsupportedRecordLimitStrategies(t, name, doc)
+	}
+}
+
+func protocolFixtures() map[string][]byte {
+	return map[string][]byte{
+		"wireguard-mesh": MeshProtocolJSON,
+		"key-delivery":   KeyDeliveryProtocolJSON,
 	}
 }
 
@@ -45,6 +59,26 @@ func assertDeleteActionsIncludeCreate(t *testing.T, path string, value any) {
 	case []any:
 		for i, child := range v {
 			assertDeleteActionsIncludeCreate(t, fmt.Sprintf("%s[%d]", path, i), child)
+		}
+	}
+}
+
+func assertNoUnsupportedRecordLimitStrategies(t *testing.T, path string, value any) {
+	t.Helper()
+
+	switch v := value.(type) {
+	case map[string]any:
+		if limit, ok := v["$recordLimit"].(map[string]any); ok {
+			if strategy, _ := limit["strategy"].(string); strategy == "purgeOldest" {
+				t.Fatalf("%s.$recordLimit uses unsupported strategy %q", path, strategy)
+			}
+		}
+		for key, child := range v {
+			assertNoUnsupportedRecordLimitStrategies(t, fmt.Sprintf("%s.%s", path, key), child)
+		}
+	case []any:
+		for i, child := range v {
+			assertNoUnsupportedRecordLimitStrategies(t, fmt.Sprintf("%s[%d]", path, i), child)
 		}
 	}
 }

--- a/protocols/wireguard-mesh.json
+++ b/protocols/wireguard-mesh.json
@@ -97,7 +97,6 @@
               "rootKeyId": "#dwn-enc",
               "publicKeyJwk": {}
             },
-            "$recordLimit": { "max": 1, "strategy": "purgeOldest" },
             "$actions": [
               { "who": "recipient", "of": "network/member/node", "can": ["create", "update"] },
               { "role": "network/member", "can": ["read"] },
@@ -112,7 +111,6 @@
               "rootKeyId": "#dwn-enc",
               "publicKeyJwk": {}
             },
-            "$recordLimit": { "max": 1, "strategy": "purgeOldest" },
             "$actions": [
               { "who": "recipient", "of": "network/member/node", "can": ["create", "update"] },
               { "role": "network/member", "can": ["read"] },
@@ -151,7 +149,6 @@
             "rootKeyId": "#dwn-enc",
             "publicKeyJwk": {}
           },
-          "$recordLimit": { "max": 1, "strategy": "purgeOldest" },
           "$actions": [
             { "who": "recipient", "of": "network/node", "can": ["create", "update"] },
             { "role": "network/member", "can": ["read"] },
@@ -166,7 +163,6 @@
             "rootKeyId": "#dwn-enc",
             "publicKeyJwk": {}
           },
-          "$recordLimit": { "max": 1, "strategy": "purgeOldest" },
           "$actions": [
             { "who": "recipient", "of": "network/node", "can": ["create", "update"] },
             { "role": "network/member", "can": ["read"] },
@@ -176,12 +172,12 @@
       },
 
       "aclPolicy": {
+        "$squash": true,
         "$size": { "max": 100000 },
         "$encryption": {
           "rootKeyId": "#dwn-enc",
           "publicKeyJwk": {}
         },
-        "$recordLimit": { "max": 1, "strategy": "purgeOldest" },
         "$actions": [
           { "who": "author", "of": "network", "can": ["create", "update"] },
           { "role": "network/member", "can": ["read"] },


### PR DESCRIPTION
## Summary
- remove DWN `purgeOldest` record-limit strategies from the mesh protocol
- keep ACL policy as a squashed encrypted snapshot and write it with squash enabled
- query nested `network/node` records by parent contextId in the e2e test
- add protocol regression coverage for unsupported record-limit strategies

Closes #103

## Tests
- `GOFLAGS=-mod=vendor go test ./protocols ./internal/mesh -run 'TestProtocol|TestE2EMeshIPAllocation|TestE2ENetworkCreateJoinQueryDecrypt' -count=1`\n- `GOFLAGS=-mod=vendor go build ./...`\n- `GOFLAGS=-mod=vendor go vet ./...`\n- `GOFLAGS=-mod=vendor go test ./... -count=1 -race`