### PR TITLE
fix: load node child records by direct context

### DIFF
--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -652,46 +652,71 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 		fmt.Printf("  Found node record (owner-provisioned).\n")
 	}
 
-	// If not found, try network/member/node.
+	// If not found, try member-associated nodes. DWN requires nested
+	// protocol queries to include the direct parent contextId, so first
+	// discover the member record and then query its child node records.
 	if nodeRecordID == "" {
-		memberNodeRecords, mQueryStatus, mErr := api.Query(ctx, anchorDID, dwn.QueryParams{
+		memberRecords, memStatus, memErr := api.Query(ctx, anchorDID, dwn.QueryParams{
 			Filter: dwn.RecordsFilter{
 				Protocol:     protocols.MeshProtocolURI,
-				ProtocolPath: "network/member/node",
+				ProtocolPath: "network/member",
 				ContextID:    networkID,
 				Recipient:    identity.URI,
 			},
 			DateSort: "createdDescending",
-		}, "")
-		if mErr != nil {
-			fmt.Printf("  Warning: member node query failed: %v\n", mErr)
-		} else if mQueryStatus.Code == 200 && len(memberNodeRecords) > 0 {
-			nodeRecordID = memberNodeRecords[0].ID
-			nodeDateCreated = memberNodeRecords[0].DateCreated
-			var nodeData struct {
-				MeshIP string `json:"meshIP"`
-			}
-			if err := memberNodeRecords[0].Data().JSON(ctx, &nodeData); err == nil && nodeData.MeshIP != "" {
-				meshIP = nodeData.MeshIP
-			}
-			fmt.Printf("  Found node record (member-associated).\n")
+		}, "network/member")
+		if memErr != nil {
+			fmt.Printf("  Warning: member query failed: %v\n", memErr)
+		} else if memStatus.Code == 200 {
+			for _, memberRecord := range memberRecords {
+				memberNodeRecords, mQueryStatus, mErr := api.Query(ctx, anchorDID, dwn.QueryParams{
+					Filter: dwn.RecordsFilter{
+						Protocol:     protocols.MeshProtocolURI,
+						ProtocolPath: "network/member/node",
+						ContextID:    networkID + "/" + memberRecord.ID,
+						Recipient:    identity.URI,
+					},
+					DateSort: "createdDescending",
+				}, "network/member")
+				if mErr != nil {
+					fmt.Printf("  Warning: member node query failed: %v\n", mErr)
+					continue
+				}
+				if mQueryStatus.Code != 200 || len(memberNodeRecords) == 0 {
+					continue
+				}
 
-			// Find the member record for this node.
-			memberRecords, memStatus, memErr := api.Query(ctx, anchorDID, dwn.QueryParams{
-				Filter: dwn.RecordsFilter{
-					Protocol:     protocols.MeshProtocolURI,
-					ProtocolPath: "network/member",
-					ContextID:    networkID,
-					Recipient:    identity.URI,
-				},
-				DateSort: "createdDescending",
-			}, "")
-			if memErr == nil && memStatus.Code == 200 && len(memberRecords) > 0 {
-				memberRecordID = memberRecords[0].ID
+				memberRecordID = memberRecord.ID
+				nodeRecordID = memberNodeRecords[0].ID
+				nodeDateCreated = memberNodeRecords[0].DateCreated
+				var nodeData struct {
+					MeshIP string `json:"meshIP"`
+				}
+				if err := memberNodeRecords[0].Data().JSON(ctx, &nodeData); err == nil && nodeData.MeshIP != "" {
+					meshIP = nodeData.MeshIP
+				}
+				fmt.Printf("  Found node record (member-associated).\n")
+				break
 			}
 		}
 	}
 
+	// If a member node was not found but the member record exists, keep
+	// the member record ID so future writes can use the correct protocol path.
+	if nodeRecordID == "" && memberRecordID == "" {
+		memberRecords, memStatus, memErr := api.Query(ctx, anchorDID, dwn.QueryParams{
+			Filter: dwn.RecordsFilter{
+				Protocol:     protocols.MeshProtocolURI,
+				ProtocolPath: "network/member",
+				ContextID:    networkID,
+				Recipient:    identity.URI,
+			},
+			DateSort: "createdDescending",
+		}, "network/member")
+		if memErr == nil && memStatus.Code == 200 && len(memberRecords) > 0 {
+			memberRecordID = memberRecords[0].ID
+		}
+	}
 	// If no node record found, the anchor hasn't added us yet.
 	// Allocate a mesh IP deterministically and save partial state.
 	if meshIP == "" {
@@ -733,12 +758,6 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 
 	// Write nodeInfo if we have a node record (so the network sees our hostname/OS).
 	if nodeRecordID != "" {
-		// Determine protocol role for the nodeInfo write.
-		nodeInfoRole := "network/node"
-		if memberRecordID != "" {
-			nodeInfoRole = "network/member/node"
-		}
-
 		if err := mesh.WriteNodeInfo(ctx, mesh.WriteNodeInfoParams{
 			AnchorEndpoint:       endpoint,
 			AnchorDID:            anchorDID,
@@ -747,7 +766,6 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 			NodeRecordID:         nodeRecordID,
 			Signer:               signer,
 			EncryptionKeyManager: encMgr,
-			ProtocolRole:         nodeInfoRole,
 			UseContextEncryption: useContextEnc,
 		}); err != nil {
 			fmt.Printf("  Warning: nodeInfo write failed: %v\n", err)
@@ -1051,16 +1069,29 @@ func cmdPeerList(ctx context.Context, args []string, flagProfile string) error {
 	}
 
 	// Also query member-associated node records (network/member/node).
+	// Nested protocol queries must use the direct parent member context.
 	memberRecords, mStatus, mErr := api.Query(ctx, ns.AnchorDID, dwn.QueryParams{
 		Filter: dwn.RecordsFilter{
 			Protocol:     protocols.MeshProtocolURI,
-			ProtocolPath: "network/member/node",
+			ProtocolPath: "network/member",
 			ContextID:    ns.NetworkRecordID,
 		},
 		DateSort: "createdAscending",
 	}, queryRole)
 	if mErr == nil && mStatus.Code == 200 {
-		records = append(records, memberRecords...)
+		for _, memberRecord := range memberRecords {
+			memberNodeRecords, mnStatus, mnErr := api.Query(ctx, ns.AnchorDID, dwn.QueryParams{
+				Filter: dwn.RecordsFilter{
+					Protocol:     protocols.MeshProtocolURI,
+					ProtocolPath: "network/member/node",
+					ContextID:    ns.NetworkRecordID + "/" + memberRecord.ID,
+				},
+				DateSort: "createdAscending",
+			}, queryRole)
+			if mnErr == nil && mnStatus.Code == 200 {
+				records = append(records, memberNodeRecords...)
+			}
+		}
 	}
 
 	if len(records) == 0 {
@@ -1554,15 +1585,6 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 	// Write/update endpoint record (encrypted) before starting the engine.
 	if ns.NodeRecordID != "" {
 		localEndpoints := mesh.DiscoverLocalEndpoints(f.listenPort)
-		// Determine the protocol role for the endpoint write. Devices write
-		// their own endpoint records using recipient-based authorization.
-		endpointRole := ""
-		if ns.AnchorDID != identity.URI {
-			endpointRole = "network/node"
-			if ns.MemberRecordID != "" {
-				endpointRole = "network/member/node"
-			}
-		}
 		wpParams := mesh.WriteEndpointParams{
 			AnchorEndpoint:       ns.AnchorEndpoint,
 			AnchorDID:            ns.AnchorDID,
@@ -1573,7 +1595,6 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 			EncryptionKeyManager: encMgr,
 			LocalEndpoints:       localEndpoints,
 			NATType:              "unknown",
-			ProtocolRole:         endpointRole,
 			UseContextEncryption: useContextEncryption,
 		}
 		err = mesh.WriteEndpoint(ctx, wpParams)

--- a/internal/control/control_test.go
+++ b/internal/control/control_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/netip"
+	"reflect"
 	"testing"
 	"time"
 
@@ -443,6 +444,46 @@ func TestExtractEntryMetadata(t *testing.T) {
 			t.Errorf("expected empty metadata, got %+v", meta)
 		}
 	})
+}
+
+func TestMemberNodeParentQueriesUseDirectMemberContexts(t *testing.T) {
+	c := &DWNClient{
+		networkRecordID: "net-root",
+		members: map[string]*MemberRecord{
+			"did:example:b": {RecordID: "member-b"},
+			"did:example:a": {RecordID: "member-a"},
+			"did:example:x": {},
+		},
+	}
+
+	got := c.memberNodeParentQueries()
+	want := []memberNodeParentQuery{
+		{MemberRecordID: "member-a", ParentContextID: "net-root/member-a"},
+		{MemberRecordID: "member-b", ParentContextID: "net-root/member-b"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("memberNodeParentQueries() = %#v, want %#v", got, want)
+	}
+}
+
+func TestNodeChildRecordQueriesUseDirectNodeContexts(t *testing.T) {
+	c := &DWNClient{
+		networkRecordID: "net-root",
+		nodes: map[string]*NodeRecord{
+			"did:example:owner":  {RecordID: "owner-node"},
+			"did:example:member": {RecordID: "member-node", MemberRecordID: "member-a"},
+			"did:example:empty":  {},
+		},
+	}
+
+	got := c.nodeChildRecordQueries("nodeInfo")
+	want := []nodeChildRecordQuery{
+		{ProtocolPath: "network/member/node/nodeInfo", ParentContextID: "net-root/member-a/member-node"},
+		{ProtocolPath: "network/node/nodeInfo", ParentContextID: "net-root/owner-node"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("nodeChildRecordQueries() = %#v, want %#v", got, want)
+	}
 }
 
 func TestDetectDerivationScheme(t *testing.T) {

--- a/internal/control/dwnclient.go
+++ b/internal/control/dwnclient.go
@@ -261,39 +261,40 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 	// 4. Query member-associated node records (network/member/node).
 	c.logger.DebugContext(ctx, "querying member nodes")
 
-	memberNodesResp, err := c.anchorDWN.RecordsQuery(ctx, c.anchorTenant, dwn.RecordsFilter{
-		Protocol:     protocols.MeshProtocolURI,
-		ProtocolPath: "network/member/node",
-		ContextID:    c.networkRecordID,
-	}, "createdAscending", nil, role)
-	if err != nil {
-		// Non-fatal: member nodes are optional.
-		c.logger.DebugContext(ctx, "querying member nodes failed", slog.Any("error", err))
-	} else {
+	memberNodeCount := 0
+	for _, query := range c.memberNodeParentQueries() {
+		memberNodesResp, err := c.anchorDWN.RecordsQuery(ctx, c.anchorTenant, dwn.RecordsFilter{
+			Protocol:     protocols.MeshProtocolURI,
+			ProtocolPath: "network/member/node",
+			ContextID:    query.ParentContextID,
+		}, "createdAscending", nil, role)
+		if err != nil {
+			// Non-fatal: member nodes are optional.
+			c.logger.DebugContext(ctx, "querying member nodes failed",
+				slog.String("memberRecordId", query.MemberRecordID),
+				slog.Any("error", err),
+			)
+			continue
+		}
+
 		memberNodeEntries, err := dwn.QueryResult(memberNodesResp)
 		if err != nil {
-			c.logger.DebugContext(ctx, "parsing member node results", slog.Any("error", err))
-		} else {
-			memberNodeDecryptor := c.makeDecryptor("network/member/node")
-			c.mu.Lock()
-			for _, entry := range memberNodeEntries {
-				// For member nodes, we need to find which member this node
-				// belongs to by matching the parentId to a member's recordID.
-				meta := extractEntryMetadata(entry)
-				var memberRecordID string
-				for _, m := range c.members {
-					if m.RecordID == meta.ParentID {
-						memberRecordID = m.RecordID
-						break
-					}
-				}
-				c.loadNodeEntry(ctx, entry, memberNodeDecryptor, memberRecordID)
-			}
-			c.mu.Unlock()
-
-			c.logger.DebugContext(ctx, "loaded member nodes", slog.Int("count", len(memberNodeEntries)))
+			c.logger.DebugContext(ctx, "parsing member node results",
+				slog.String("memberRecordId", query.MemberRecordID),
+				slog.Any("error", err),
+			)
+			continue
 		}
+
+		memberNodeDecryptor := c.makeDecryptor("network/member/node")
+		c.mu.Lock()
+		for _, entry := range memberNodeEntries {
+			c.loadNodeEntry(ctx, entry, memberNodeDecryptor, query.MemberRecordID)
+		}
+		c.mu.Unlock()
+		memberNodeCount += len(memberNodeEntries)
 	}
+	c.logger.DebugContext(ctx, "loaded member nodes", slog.Int("count", memberNodeCount))
 
 	// 5. Query relay records.
 	relayResp, err := c.anchorDWN.RecordsQuery(ctx, c.anchorTenant, dwn.RecordsFilter{
@@ -354,17 +355,11 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 		}
 	}
 
-	// 7. Query nodeInfo records for owner-provisioned nodes (network/node/nodeInfo).
-	c.loadChildRecords(ctx, "network/node/nodeInfo", role, c.loadNodeInfoEntry)
+	// 7. Query nodeInfo records under each node's direct parent context.
+	c.loadNodeChildRecords(ctx, "nodeInfo", role, c.loadNodeInfoEntry)
 
-	// 8. Query nodeInfo records for member nodes (network/member/node/nodeInfo).
-	c.loadChildRecords(ctx, "network/member/node/nodeInfo", role, c.loadNodeInfoEntry)
-
-	// 9. Query endpoint records for owner-provisioned nodes (network/node/endpoint).
-	c.loadChildRecords(ctx, "network/node/endpoint", role, c.loadEndpointEntry)
-
-	// 10. Query endpoint records for member nodes (network/member/node/endpoint).
-	c.loadChildRecords(ctx, "network/member/node/endpoint", role, c.loadEndpointEntry)
+	// 8. Query endpoint records under each node's direct parent context.
+	c.loadNodeChildRecords(ctx, "endpoint", role, c.loadEndpointEntry)
 
 	hasACL := c.acl != nil
 	c.logger.DebugContext(ctx, "mesh state loaded",
@@ -380,6 +375,31 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 		return nil, fmt.Errorf("self DID %q not found in network node records", c.selfDID)
 	}
 	return resp, nil
+}
+
+type memberNodeParentQuery struct {
+	MemberRecordID  string
+	ParentContextID string
+}
+
+func (c *DWNClient) memberNodeParentQueries() []memberNodeParentQuery {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	queries := make([]memberNodeParentQuery, 0, len(c.members))
+	for _, member := range c.members {
+		if member.RecordID == "" {
+			continue
+		}
+		queries = append(queries, memberNodeParentQuery{
+			MemberRecordID:  member.RecordID,
+			ParentContextID: c.networkRecordID + "/" + member.RecordID,
+		})
+	}
+	sort.Slice(queries, func(i, j int) bool {
+		return queries[i].ParentContextID < queries[j].ParentContextID
+	})
+	return queries
 }
 
 // loadNodeEntry parses a node record entry and adds it to the nodes map.
@@ -414,29 +434,79 @@ func (c *DWNClient) loadNodeEntry(ctx context.Context, entry json.RawMessage, de
 	}
 }
 
-// loadChildRecords queries child records at the given protocol path and
-// processes each entry with the provided handler function.
-func (c *DWNClient) loadChildRecords(ctx context.Context, protocolPath string, role string, handler func(ctx context.Context, entry json.RawMessage, decryptor EntryDecryptor)) {
+type nodeChildRecordQuery struct {
+	ProtocolPath    string
+	ParentContextID string
+}
+
+func (c *DWNClient) nodeChildRecordQueries(childType string) []nodeChildRecordQuery {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	queries := make([]nodeChildRecordQuery, 0, len(c.nodes))
+	for _, node := range c.nodes {
+		if node.RecordID == "" {
+			continue
+		}
+
+		if node.MemberRecordID != "" {
+			queries = append(queries, nodeChildRecordQuery{
+				ProtocolPath:    "network/member/node/" + childType,
+				ParentContextID: c.networkRecordID + "/" + node.MemberRecordID + "/" + node.RecordID,
+			})
+			continue
+		}
+
+		queries = append(queries, nodeChildRecordQuery{
+			ProtocolPath:    "network/node/" + childType,
+			ParentContextID: c.networkRecordID + "/" + node.RecordID,
+		})
+	}
+	sort.Slice(queries, func(i, j int) bool {
+		if queries[i].ParentContextID == queries[j].ParentContextID {
+			return queries[i].ProtocolPath < queries[j].ProtocolPath
+		}
+		return queries[i].ParentContextID < queries[j].ParentContextID
+	})
+	return queries
+}
+
+func (c *DWNClient) loadNodeChildRecords(ctx context.Context, childType string, role string, handler func(ctx context.Context, entry json.RawMessage, decryptor EntryDecryptor)) {
+	total := 0
+	for _, query := range c.nodeChildRecordQueries(childType) {
+		total += c.loadChildRecords(ctx, query.ProtocolPath, query.ParentContextID, role, handler)
+	}
+	c.logger.DebugContext(ctx, "loaded node child records",
+		slog.String("type", childType),
+		slog.Int("count", total),
+	)
+}
+
+// loadChildRecords queries child records at the given protocol path under a
+// direct parent context and processes each entry with the provided handler.
+func (c *DWNClient) loadChildRecords(ctx context.Context, protocolPath string, parentContextID string, role string, handler func(ctx context.Context, entry json.RawMessage, decryptor EntryDecryptor)) int {
 	resp, err := c.anchorDWN.RecordsQuery(ctx, c.anchorTenant, dwn.RecordsFilter{
 		Protocol:     protocols.MeshProtocolURI,
 		ProtocolPath: protocolPath,
-		ContextID:    c.networkRecordID,
+		ContextID:    parentContextID,
 	}, "createdDescending", nil, role)
 	if err != nil {
 		c.logger.DebugContext(ctx, "querying child records failed",
 			slog.String("path", protocolPath),
+			slog.String("parentContextId", parentContextID),
 			slog.Any("error", err),
 		)
-		return
+		return 0
 	}
 
 	entries, err := dwn.QueryResult(resp)
 	if err != nil {
 		c.logger.DebugContext(ctx, "parsing child record results",
 			slog.String("path", protocolPath),
+			slog.String("parentContextId", parentContextID),
 			slog.Any("error", err),
 		)
-		return
+		return 0
 	}
 
 	decryptor := c.makeDecryptor(protocolPath)
@@ -448,8 +518,10 @@ func (c *DWNClient) loadChildRecords(ctx context.Context, protocolPath string, r
 
 	c.logger.DebugContext(ctx, "loaded child records",
 		slog.String("path", protocolPath),
+		slog.String("parentContextId", parentContextID),
 		slog.Int("count", len(entries)),
 	)
+	return len(entries)
 }
 
 // loadNodeInfoEntry parses a nodeInfo entry and attaches it to the parent node.

--- a/internal/engine/connectivity_test.go
+++ b/internal/engine/connectivity_test.go
@@ -31,7 +31,7 @@ import (
 //  4. Node A registers its node record (encrypted, no WireGuardPubKey — derived from did:jwk)
 //  5. Node A registers Node B's node record (recipient = B's DID, assigns network/node role)
 //  6. Node A delivers context key to both nodes
-//  6b. Node B fetches context key, re-registers node + endpoint with Protocol Context encryption
+//     6b. Node B fetches context key, re-registers node + endpoint with Protocol Context encryption
 //  7. Both nodes create real engines (UserspaceEngine + netstack)
 //  8. Both engines start, poll DWN, and discover each other
 //  9. TCP connectivity test: B dials A's mesh IP, echo round-trip verified
@@ -207,7 +207,6 @@ func TestTwoNodeConnectivity(t *testing.T) {
 			EncryptionKeyManager: nodeB.encMgr,
 			LocalEndpoints:       mesh.DiscoverLocalEndpoints(0),
 			NATType:              "unknown",
-			ProtocolRole:         "network/node",
 		})
 		if err != nil {
 			t.Logf("  Warning: Node B endpoint write failed: %v", err)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -28,8 +28,8 @@ import (
 	"github.com/enboxorg/meshnet/tailcfg"
 	"github.com/enboxorg/meshnet/tsd"
 	"github.com/enboxorg/meshnet/types/key"
-	"github.com/enboxorg/meshnet/types/logid"
 	"github.com/enboxorg/meshnet/types/logger"
+	"github.com/enboxorg/meshnet/types/logid"
 	"github.com/enboxorg/meshnet/wgengine"
 	"github.com/enboxorg/meshnet/wgengine/netstack"
 	"github.com/enboxorg/meshnet/wgengine/router"
@@ -44,11 +44,11 @@ import (
 //
 // Engine is the core of `meshd up`.
 type Engine struct {
-	backend         *ipnlocal.LocalBackend
-	netMon          *netmon.Monitor
-	ns              *netstack.Impl
-	subWatcher      *SubscriptionWatcher
-	logger          *slog.Logger
+	backend    *ipnlocal.LocalBackend
+	netMon     *netmon.Monitor
+	ns         *netstack.Impl
+	subWatcher *SubscriptionWatcher
+	logger     *slog.Logger
 
 	// tunDev is the real TUN device when running in TUN mode.
 	// nil in userspace-only (netstack) mode.
@@ -300,7 +300,7 @@ func New(cfg Config) (*Engine, error) {
 	// process's own dialer for mesh connections.
 	ns, err := netstack.Create(
 		logf,
-		sys.Tun.Get(),      // the tstun.Wrapper created by the engine
+		sys.Tun.Get(),       // the tstun.Wrapper created by the engine
 		eng,                 // wgengine.Engine
 		sys.MagicSock.Get(), // magicsock.Conn for direct connections
 		dial,                // tsdial.Dialer
@@ -578,9 +578,9 @@ func makeEndpointUpdateFunc(cfg Config, l *slog.Logger) func(context.Context, []
 				localEPs = append(localEPs, ap.String())
 			} else {
 				publicEPs = append(publicEPs, control.PublicEndpoint{
-					Address:  addr.String(),
-					Port:     int(ap.Port()),
-					Source:   "stun",
+					Address: addr.String(),
+					Port:    int(ap.Port()),
+					Source:  "stun",
 				})
 			}
 		}
@@ -607,16 +607,6 @@ func makeEndpointUpdateFunc(cfg Config, l *slog.Logger) func(context.Context, []
 			slog.String("discoKey", discoKeyB64),
 		)
 
-		// Determine the protocol role for the endpoint write. Devices write
-		// their own endpoint records using recipient-based authorization:
-		//   - Owner-provisioned: recipient of network/node
-		//   - Member-associated: recipient of network/member/node
-		// The protocol role is passed to authorize the write.
-		protocolRole := "network/node"
-		if cfg.MemberRecordID != "" {
-			protocolRole = "network/member/node"
-		}
-
 		err := mesh.WriteEndpoint(ctx, mesh.WriteEndpointParams{
 			AnchorEndpoint:       cfg.AnchorEndpoint,
 			AnchorDID:            cfg.AnchorTenant,
@@ -629,7 +619,6 @@ func makeEndpointUpdateFunc(cfg Config, l *slog.Logger) func(context.Context, []
 			LocalEndpoints:       localEPs,
 			DiscoKey:             discoKeyB64,
 			NATType:              "unknown",
-			ProtocolRole:         protocolRole,
 			UseContextEncryption: cfg.UseContextEncryption,
 		})
 		if err != nil {

--- a/internal/mesh/lifecycle_test.go
+++ b/internal/mesh/lifecycle_test.go
@@ -21,7 +21,7 @@ import (
 //  3. Anchor creates member record for an external user
 //  4. Anchor registers member's node (network/member/node path)
 //  5. Owner node writes its own nodeInfo and endpoint (recipient-based auth)
-//  6. Member node writes its own nodeInfo and endpoint (recipient-based auth with role)
+//  6. Member node writes its own nodeInfo and endpoint (recipient-based auth)
 //  7. LoadState from anchor verifies both paths are merged
 //  8. LoadState from non-anchor verifies role-based reads work
 //
@@ -40,8 +40,8 @@ func TestE2EFullMeshLifecycle(t *testing.T) {
 	// Step 1: Create identities for anchor, owner device, and member
 	// ================================================================
 	t.Log("Step 1: Creating identities")
-	anchor := newNode(t, endpoint)   // network owner
-	member := newNode(t, endpoint)   // external member (person)
+	anchor := newNode(t, endpoint) // network owner
+	member := newNode(t, endpoint) // external member (person)
 	t.Logf("  Anchor: %s", anchor.DID.URI)
 	t.Logf("  Member: %s", member.DID.URI)
 
@@ -106,6 +106,7 @@ func TestE2EFullMeshLifecycle(t *testing.T) {
 		networkRecordID = records[0].ID
 	}
 	t.Logf("  Network record: %s", networkRecordID)
+	shareContextKeyForTest(t, networkRecordID, anchor, member)
 
 	// ================================================================
 	// Step 4: Register anchor's own device as an owner node (network/node)
@@ -125,6 +126,7 @@ func TestE2EFullMeshLifecycle(t *testing.T) {
 		EncryptionKeyManager: anchor.EncMgr,
 		MeshIP:               anchorIP.String(),
 		Label:                "anchor-device",
+		UseContextEncryption: true,
 	})
 	if err != nil {
 		t.Fatalf("registering anchor node: %v", err)
@@ -143,6 +145,7 @@ func TestE2EFullMeshLifecycle(t *testing.T) {
 		Signer:               anchor.Signer,
 		EncryptionKeyManager: anchor.EncMgr,
 		Hostname:             "anchor-host",
+		UseContextEncryption: true,
 	})
 	if err != nil {
 		t.Fatalf("anchor WriteNodeInfo failed: %v", err)
@@ -163,8 +166,9 @@ func TestE2EFullMeshLifecycle(t *testing.T) {
 		PublicEndpoints: []control.PublicEndpoint{
 			{Address: "198.51.100.1", Port: 51820, Source: "test"},
 		},
-		LocalEndpoints: []string{"192.168.1.10:51820"},
-		NATType:        "full-cone",
+		LocalEndpoints:       []string{"192.168.1.10:51820"},
+		NATType:              "full-cone",
+		UseContextEncryption: true,
 	})
 	if err != nil {
 		t.Fatalf("anchor WriteEndpoint failed: %v", err)
@@ -208,6 +212,7 @@ func TestE2EFullMeshLifecycle(t *testing.T) {
 		EncryptionKeyManager: anchor.EncMgr,
 		MeshIP:               memberIP.String(),
 		Label:                "alice-laptop",
+		UseContextEncryption: true,
 	})
 	if err != nil {
 		t.Fatalf("registering member node: %v", err)
@@ -215,7 +220,7 @@ func TestE2EFullMeshLifecycle(t *testing.T) {
 	t.Logf("  Member node: IP=%s, record=%s", memberIP, regMember.NodeRecordID)
 
 	// ================================================================
-	// Step 9: Member writes its own nodeInfo (recipient-based auth with role)
+	// Step 9: Member writes its own nodeInfo (recipient-based write auth)
 	// ================================================================
 	t.Log("Step 9: Member writes its own nodeInfo (recipient-based write auth)")
 	err = mesh.WriteNodeInfo(ctx, mesh.WriteNodeInfoParams{
@@ -227,7 +232,7 @@ func TestE2EFullMeshLifecycle(t *testing.T) {
 		Signer:               member.Signer, // member signs its own record
 		EncryptionKeyManager: member.EncMgr,
 		Hostname:             "alice-laptop",
-		ProtocolRole:         "network/member",
+		UseContextEncryption: true,
 	})
 	if err != nil {
 		t.Fatalf("member WriteNodeInfo failed: %v (this was the pre-PR#84 bug)", err)
@@ -249,9 +254,9 @@ func TestE2EFullMeshLifecycle(t *testing.T) {
 		PublicEndpoints: []control.PublicEndpoint{
 			{Address: "203.0.113.50", Port: 51820, Source: "test"},
 		},
-		LocalEndpoints: []string{"10.0.0.42:51820"},
-		NATType:        "symmetric",
-		ProtocolRole:   "network/member",
+		LocalEndpoints:       []string{"10.0.0.42:51820"},
+		NATType:              "symmetric",
+		UseContextEncryption: true,
 	})
 	if err != nil {
 		t.Fatalf("member WriteEndpoint failed: %v", err)
@@ -396,6 +401,16 @@ func TestE2EFullMeshLifecycle(t *testing.T) {
 	t.Log("  Recipient-based write auth: verified (member wrote own nodeInfo+endpoint)")
 }
 
+func shareContextKeyForTest(t *testing.T, contextID string, owner *nodeIdentity, recipient *nodeIdentity) {
+	t.Helper()
+
+	contextKey, err := owner.EncMgr.DeriveContextDecryptionKey(contextID)
+	if err != nil {
+		t.Fatalf("deriving context key for test: %v", err)
+	}
+	recipient.EncMgr.StoreContextKey(contextID, contextKey)
+}
+
 // TestE2ERecipientBasedOwnerNodeWrite verifies that an owner-provisioned
 // node (non-anchor) can write its own nodeInfo and endpoint records using
 // recipient-based authorization (the exact scenario that failed before PR #84).
@@ -450,6 +465,7 @@ func TestE2ERecipientBasedOwnerNodeWrite(t *testing.T) {
 			networkRecordID = records[0].ID
 		}
 	}
+	shareContextKeyForTest(t, networkRecordID, anchor, nodeB)
 
 	// Anchor registers node B (recipient = B's DID, assigns network/node role).
 	ipB, err := mesh.AllocateMeshIP("10.200.0.0/16", nodeB.DID.URI)
@@ -465,6 +481,7 @@ func TestE2ERecipientBasedOwnerNodeWrite(t *testing.T) {
 		EncryptionKeyManager: anchor.EncMgr,
 		MeshIP:               ipB.String(),
 		Label:                "node-b",
+		UseContextEncryption: true,
 	})
 	if err != nil {
 		t.Fatalf("registering node B: %v", err)
@@ -481,6 +498,7 @@ func TestE2ERecipientBasedOwnerNodeWrite(t *testing.T) {
 		Signer:               nodeB.Signer, // B signs its own record
 		EncryptionKeyManager: nodeB.EncMgr,
 		Hostname:             "node-b-host",
+		UseContextEncryption: true,
 	})
 	if err != nil {
 		t.Fatalf("Node B WriteNodeInfo failed: %v — recipient-based auth is broken!", err)
@@ -499,8 +517,9 @@ func TestE2ERecipientBasedOwnerNodeWrite(t *testing.T) {
 		PublicEndpoints: []control.PublicEndpoint{
 			{Address: "192.0.2.42", Port: 51820, Source: "test"},
 		},
-		LocalEndpoints: []string{"172.16.0.5:51820"},
-		NATType:        "port-restricted",
+		LocalEndpoints:       []string{"172.16.0.5:51820"},
+		NATType:              "port-restricted",
+		UseContextEncryption: true,
 	})
 	if err != nil {
 		t.Fatalf("Node B WriteEndpoint failed: %v — recipient-based auth is broken!", err)
@@ -519,6 +538,7 @@ func TestE2ERecipientBasedOwnerNodeWrite(t *testing.T) {
 		EncryptionKeyManager: anchor.EncMgr,
 		MeshIP:               anchorIP.String(),
 		Label:                "anchor",
+		UseContextEncryption: true,
 	})
 	if err != nil {
 		t.Fatalf("registering anchor node: %v", err)
@@ -797,6 +817,7 @@ func TestE2ELoadStateNonAnchor(t *testing.T) {
 			networkRecordID = records[0].ID
 		}
 	}
+	shareContextKeyForTest(t, networkRecordID, anchor, nodeB)
 
 	// Register both nodes.
 	anchorIP, _ := mesh.AllocateMeshIP("10.200.0.0/16", anchor.DID.URI)
@@ -805,6 +826,7 @@ func TestE2ELoadStateNonAnchor(t *testing.T) {
 		NetworkRecordID: networkRecordID, NodeDID: anchor.DID.URI,
 		Signer: anchor.Signer, EncryptionKeyManager: anchor.EncMgr,
 		MeshIP: anchorIP.String(), Label: "anchor",
+		UseContextEncryption: true,
 	})
 	if err != nil {
 		t.Fatalf("registering anchor: %v", err)
@@ -816,6 +838,7 @@ func TestE2ELoadStateNonAnchor(t *testing.T) {
 		NetworkRecordID: networkRecordID, NodeDID: nodeB.DID.URI,
 		Signer: anchor.Signer, EncryptionKeyManager: anchor.EncMgr,
 		MeshIP: ipB.String(), Label: "node-b",
+		UseContextEncryption: true,
 	})
 	if err != nil {
 		t.Fatalf("registering node B: %v", err)

--- a/internal/mesh/register.go
+++ b/internal/mesh/register.go
@@ -266,7 +266,6 @@ type WriteNodeInfoParams struct {
 	Signer               *dwn.Signer
 	EncryptionKeyManager *dwncrypto.EncryptionKeyManager
 	Hostname             string
-	ProtocolRole         string
 
 	// UseContextEncryption enables Protocol Context encryption.
 	UseContextEncryption bool
@@ -335,8 +334,8 @@ func WriteNodeInfo(ctx context.Context, params WriteNodeInfoParams) error {
 		Recipient:            params.AnchorDID,
 		ParentContextID:      nodeContextID,
 		Data:                 infoDataBytes,
-		ProtocolRole:         params.ProtocolRole,
 		EncryptionRecipients: recipients,
+		Squash:               true,
 	})
 	if err != nil {
 		return fmt.Errorf("writing nodeInfo: %w", err)
@@ -410,9 +409,8 @@ func WriteEndpoint(ctx context.Context, params WriteEndpointParams) error {
 		Recipient:            params.AnchorDID,
 		ParentContextID:      nodeContextID,
 		Data:                 endpointData,
-		ProtocolRole:         params.ProtocolRole,
 		EncryptionRecipients: recipients,
-		Squash:               params.Squash,
+		Squash:               true,
 	})
 	if err != nil {
 		return fmt.Errorf("writing endpoint: %w", err)
@@ -436,16 +434,12 @@ type WriteEndpointParams struct {
 	PublicEndpoints      []control.PublicEndpoint
 	LocalEndpoints       []string
 	NATType              string
-	ProtocolRole         string
 
 	// DiscoKey is this node's current disco public key (base64).
 	DiscoKey string
 
 	// UseContextEncryption enables Protocol Context encryption.
 	UseContextEncryption bool
-
-	// Squash indicates this is a squash (snapshot) write.
-	Squash bool
 }
 
 // WriteACLPolicyParams configures an ACL policy write.


### PR DESCRIPTION
## Summary
- query member nodes and node child records with their direct parent `contextId` instead of the network root
- make nodeInfo and endpoint writes squashed recipient-authorized snapshots without passing read roles as write roles
- update CLI member-node discovery and peer listing to follow DWN nested context rules
- update live e2e setup to use the delivered context key when non-anchor nodes read/write context-encrypted records
- add unit coverage for the direct-context query builders

Closes #105

## Tests
- `GOFLAGS=-mod=vendor go test ./internal/control ./internal/mesh ./cmd/meshd ./internal/engine -run 'TestMemberNodeParentQueries|TestNodeChildRecordQueries|TestE2EFullMeshLifecycle|TestE2ERecipientBasedOwnerNodeWrite|TestE2ELoadStateNonAnchor|TestCLIInviteJoinFlow|TestTwoNodeConnectivity' -count=1`\n- `GOFLAGS=-mod=vendor go build ./...`\n- `GOFLAGS=-mod=vendor go vet ./...`\n- `GOFLAGS=-mod=vendor go test ./... -count=1 -race`