### PR TITLE
fix: infer non-anchor DWN read role

### DIFF
--- a/internal/control/control_test.go
+++ b/internal/control/control_test.go
@@ -98,6 +98,36 @@ func TestBuildStaticMapResponse(t *testing.T) {
 	})
 }
 
+func TestNewDWNClientProtocolRoleDefaults(t *testing.T) {
+	t.Run("anchor reads without role", func(t *testing.T) {
+		c := NewDWNClient("https://dwn.example", "did:example:anchor", "network", "did:example:anchor", nil)
+		if c.protocolRole != "" {
+			t.Fatalf("protocolRole = %q, want empty", c.protocolRole)
+		}
+	})
+
+	t.Run("non-anchor infers node read role", func(t *testing.T) {
+		c := NewDWNClient("https://dwn.example", "did:example:anchor", "network", "did:example:node", nil)
+		if c.protocolRole != "network/node" {
+			t.Fatalf("protocolRole = %q, want network/node", c.protocolRole)
+		}
+	})
+
+	t.Run("explicit role wins", func(t *testing.T) {
+		c := NewDWNClient(
+			"https://dwn.example",
+			"did:example:anchor",
+			"network",
+			"did:example:member",
+			nil,
+			WithProtocolRole("network/member"),
+		)
+		if c.protocolRole != "network/member" {
+			t.Fatalf("protocolRole = %q, want network/member", c.protocolRole)
+		}
+	})
+}
+
 func TestNodeRecordToNode(t *testing.T) {
 	now := time.Now().UTC()
 	recentUpdate := now.Add(-2 * time.Minute).Format(time.RFC3339)

--- a/internal/control/dwnclient.go
+++ b/internal/control/dwnclient.go
@@ -66,8 +66,7 @@ func WithEncryptionKeyManager(mgr *dwncrypto.EncryptionKeyManager) Option {
 
 // WithProtocolRole sets the DWN protocol role used for read queries.
 // The anchor (network owner) should leave this empty (reads as author).
-// Non-anchor nodes should set "network/node" (assigned via the recipient
-// field on their node record).
+// Non-anchor nodes default to "network/node" when no explicit role is set.
 func WithProtocolRole(role string) Option {
 	return func(o *dwnClientOptions) {
 		o.protocolRole = role
@@ -88,8 +87,7 @@ type DWNClient struct {
 
 	// protocolRole is the DWN protocol role used for read queries.
 	// The anchor (network author) leaves this empty (reads as author).
-	// Non-anchor nodes use "network/node" (assigned via the recipient
-	// field on their node record).
+	// Non-anchor nodes default to "network/node" unless explicitly set.
 	protocolRole string
 
 	mu      sync.RWMutex
@@ -119,6 +117,11 @@ func NewDWNClient(
 		opt(options)
 	}
 
+	protocolRole := options.protocolRole
+	if protocolRole == "" && anchorTenant != "" && selfDID != "" && anchorTenant != selfDID {
+		protocolRole = "network/node"
+	}
+
 	return &DWNClient{
 		anchorDWN:       dwn.NewClient(anchorEndpoint, signer),
 		anchorTenant:    anchorTenant,
@@ -128,7 +131,7 @@ func NewDWNClient(
 		logger:          options.logger,
 		resolver:        options.resolver,
 		encManager:      options.encManager,
-		protocolRole:    options.protocolRole,
+		protocolRole:    protocolRole,
 		members:         make(map[string]*MemberRecord),
 		nodes:           make(map[string]*NodeRecord),
 		peerEndpoints:   make(map[string]*PeerEndpointInfo),


### PR DESCRIPTION
## Summary
- infer `network/node` as the DWN read role for non-anchor control clients when no role is explicitly supplied
- keep anchor reads role-free and preserve explicit role overrides
- add constructor coverage for anchor, inferred non-anchor, and explicit override behavior

Closes #107

## Tests
- `GOFLAGS=-mod=vendor go test ./internal/control ./internal/engine -run 'TestNewDWNClientProtocolRoleDefaults|TestTwoNodeConnectivity|TestTwoNodeNetworkMapDiscovery' -count=1`\n- `GOFLAGS=-mod=vendor go build ./...`\n- `GOFLAGS=-mod=vendor go vet ./...`\n- `GOFLAGS=-mod=vendor go test ./... -count=1 -race`