### PR TITLE
fix: replace enbox.org domain references

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -328,7 +328,7 @@ Root Key (#dwn-enc from DID document)
   |
   +-- HKDF("protocolPath")
        |
-       +-- HKDF("https://enbox.org/protocols/wireguard-mesh")
+       +-- HKDF("https://enbox.id/protocols/wireguard-mesh")
             |
             +-- HKDF("network")           -> encrypts network records
                  |
@@ -351,7 +351,7 @@ decrypt everything.
 
 Since all members need to read each other's encrypted data, the DWN owner
 distributes **context keys** to members using the key-delivery protocol
-(`https://enbox.org/protocols/key-delivery`):
+(`https://enbox.id/protocols/key-delivery`):
 
 1. When a new member is added, the anchor DWN owner derives the context
    private key using the Protocol Context scheme for that network's context.

--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -410,7 +410,7 @@ func cmdNetworkCreate(ctx context.Context, args []string, flagProfile string) er
 	record, writeStatus, err := api.Write(ctx, identity.URI, dwn.WriteParams{
 		Protocol:     protocols.MeshProtocolURI,
 		ProtocolPath: "network",
-		Schema:       "https://enbox.org/schemas/wireguard-mesh/network",
+		Schema:       "https://enbox.id/schemas/wireguard-mesh/network",
 		DataFormat:   "application/json",
 		Data:         networkData,
 	})

--- a/internal/control/control_test.go
+++ b/internal/control/control_test.go
@@ -425,7 +425,7 @@ func TestExtractEntryMetadata(t *testing.T) {
 				"descriptor": {
 					"interface": "Records",
 					"method": "Write",
-					"protocol": "https://enbox.org/protocols/wireguard-mesh",
+					"protocol": "https://enbox.id/protocols/wireguard-mesh",
 					"protocolPath": "network/node",
 					"recipient": "did:jwk:node456"
 				},

--- a/internal/dwn/crypto/crypto_test.go
+++ b/internal/dwn/crypto/crypto_test.go
@@ -1171,9 +1171,9 @@ func TestBuildJWEDefaultAlgorithm(t *testing.T) {
 func TestDecryptDataMissingEPK(t *testing.T) {
 	// Build a malformed encryption with missing EPK.
 	enc := &Encryption{
-		Protected:  base64URLEncode([]byte(`{"alg":"ECDH-ES+A256KW","enc":"A256GCM"}`)),
-		IV:         base64URLEncode(make([]byte, 12)),
-		Tag:        base64URLEncode(make([]byte, 16)),
+		Protected: base64URLEncode([]byte(`{"alg":"ECDH-ES+A256KW","enc":"A256GCM"}`)),
+		IV:        base64URLEncode(make([]byte, 12)),
+		Tag:       base64URLEncode(make([]byte, 16)),
 		Recipients: []Recipient{{
 			Header: RecipientHeader{
 				KID:              "did:test:alice#enc",
@@ -1658,9 +1658,9 @@ func TestEncryptionKeyManager_DeriveWriteEncryption(t *testing.T) {
 	tests := map[string]struct {
 		path string
 	}{
-		"root level": {path: "network"},
+		"root level":  {path: "network"},
 		"child level": {path: "network/node"},
-		"deep level": {path: "network/node/endpoint"},
+		"deep level":  {path: "network/node/endpoint"},
 	}
 
 	for name, tc := range tests {
@@ -1699,7 +1699,7 @@ func TestEncryptionKeyManager_RoundTrip(t *testing.T) {
 	mgr := &EncryptionKeyManager{
 		RootPrivateKey: rootPriv,
 		RootKeyID:      "did:dht:test#enc",
-		ProtocolURI:    "https://enbox.org/protocols/wireguard-mesh",
+		ProtocolURI:    "https://enbox.id/protocols/wireguard-mesh",
 	}
 
 	paths := []string{
@@ -1825,9 +1825,9 @@ func TestSplitProtocolPath(t *testing.T) {
 		expected []string
 	}{
 		"single segment": {input: "network", expected: []string{"network"}},
-		"two segments": {input: "network/node", expected: []string{"network", "node"}},
+		"two segments":   {input: "network/node", expected: []string{"network", "node"}},
 		"three segments": {input: "network/node/endpoint", expected: []string{"network", "node", "endpoint"}},
-		"empty": {input: "", expected: nil},
+		"empty":          {input: "", expected: nil},
 	}
 
 	for name, tc := range tests {
@@ -1864,7 +1864,7 @@ func TestContextEncryptionMultiParty(t *testing.T) {
 	anchorMgr := &EncryptionKeyManager{
 		RootPrivateKey: anchorPriv,
 		RootKeyID:      "did:dht:anchor#enc",
-		ProtocolURI:    "https://enbox.org/protocols/wireguard-mesh",
+		ProtocolURI:    "https://enbox.id/protocols/wireguard-mesh",
 	}
 
 	contextID := "bafyreiabc123networkrecordid"
@@ -1906,7 +1906,7 @@ func TestContextEncryptionMultiParty(t *testing.T) {
 		nonOwnerMgr := &EncryptionKeyManager{
 			RootPrivateKey: nonOwnerPriv,
 			RootKeyID:      "did:dht:joiner#enc",
-			ProtocolURI:    "https://enbox.org/protocols/wireguard-mesh",
+			ProtocolURI:    "https://enbox.id/protocols/wireguard-mesh",
 		}
 
 		// Simulate key delivery: anchor derives context key and delivers it.
@@ -1944,7 +1944,7 @@ func TestContextEncryptionMultiParty(t *testing.T) {
 		nonOwnerMgr := &EncryptionKeyManager{
 			RootPrivateKey: nonOwnerPriv,
 			RootKeyID:      "did:dht:joiner#enc",
-			ProtocolURI:    "https://enbox.org/protocols/wireguard-mesh",
+			ProtocolURI:    "https://enbox.id/protocols/wireguard-mesh",
 		}
 
 		// Deliver context key to non-owner.
@@ -1994,7 +1994,7 @@ func TestContextEncryptionMultiParty(t *testing.T) {
 		outsiderMgr := &EncryptionKeyManager{
 			RootPrivateKey: outsiderPriv,
 			RootKeyID:      "did:dht:outsider#enc",
-			ProtocolURI:    "https://enbox.org/protocols/wireguard-mesh",
+			ProtocolURI:    "https://enbox.id/protocols/wireguard-mesh",
 		}
 
 		// Outsider derives a context key from their own (wrong) root key.

--- a/internal/dwn/crypto/keydelivery_test.go
+++ b/internal/dwn/crypto/keydelivery_test.go
@@ -470,7 +470,7 @@ func TestKeyDeliveryProtocolEncryptionInjection(t *testing.T) {
 		}
 
 		protoJSON := []byte(`{
-			"protocol": "https://enbox.org/protocols/key-delivery",
+			"protocol": "https://enbox.id/protocols/key-delivery",
 			"published": false,
 			"types": {
 				"contextKey": {

--- a/internal/dwn/dwn_test.go
+++ b/internal/dwn/dwn_test.go
@@ -187,9 +187,9 @@ func TestBuildRecordsWrite(t *testing.T) {
 
 	t.Run("initial write", func(t *testing.T) {
 		result, err := BuildRecordsWrite(s, RecordsWriteOptions{
-			Protocol:     "https://enbox.org/protocols/wireguard-mesh",
+			Protocol:     "https://enbox.id/protocols/wireguard-mesh",
 			ProtocolPath: "network",
-			Schema:       "https://enbox.org/schemas/wireguard-mesh/network",
+			Schema:       "https://enbox.id/schemas/wireguard-mesh/network",
 			DataFormat:   "application/json",
 			Data:         []byte(`{"name":"test-net","meshCIDR":"10.200.0.0/16"}`),
 		})
@@ -242,11 +242,11 @@ func TestBuildRecordsWrite(t *testing.T) {
 
 	t.Run("protocolRole in signature payload", func(t *testing.T) {
 		result, err := BuildRecordsWrite(s, RecordsWriteOptions{
-			Protocol:     "https://example.com/test",
-			ProtocolPath: "root/child",
-			DataFormat:   "application/json",
-			Data:         []byte(`{}`),
-			ProtocolRole: "root/member",
+			Protocol:        "https://example.com/test",
+			ProtocolPath:    "root/child",
+			DataFormat:      "application/json",
+			Data:            []byte(`{}`),
+			ProtocolRole:    "root/member",
 			ParentContextID: "abc123",
 		})
 		if err != nil {
@@ -363,7 +363,7 @@ func TestBuildRecordsQuery(t *testing.T) {
 	s := newTestSigner(t)
 
 	msg, err := BuildRecordsQuery(s, RecordsFilter{
-		Protocol:     "https://enbox.org/protocols/wireguard-mesh",
+		Protocol:     "https://enbox.id/protocols/wireguard-mesh",
 		ProtocolPath: "network/node",
 	}, "createdAscending", nil, "network/node")
 	if err != nil {
@@ -511,7 +511,7 @@ func TestBuildRecordsWriteEncrypted(t *testing.T) {
 
 	kid := "did:dht:recipient#enc-1"
 	result, err := BuildRecordsWrite(s, RecordsWriteOptions{
-		Protocol:     "https://enbox.org/protocols/wireguard-mesh",
+		Protocol:     "https://enbox.id/protocols/wireguard-mesh",
 		ProtocolPath: "network",
 		DataFormat:   "application/json",
 		Data:         plaintext,

--- a/internal/dwn/integration_test.go
+++ b/internal/dwn/integration_test.go
@@ -78,11 +78,11 @@ func TestIntegrationProtocolsConfigure(t *testing.T) {
 
 	// Install a test protocol.
 	protocolDef := json.RawMessage(`{
-		"protocol": "https://enbox.org/protocols/integration-test",
+		"protocol": "https://enbox.id/protocols/integration-test",
 		"published": true,
 		"types": {
 			"note": {
-				"schema": "https://enbox.org/schemas/integration-test/note",
+				"schema": "https://enbox.id/schemas/integration-test/note",
 				"dataFormats": ["application/json"]
 			}
 		},
@@ -117,11 +117,11 @@ func TestIntegrationRecordsWriteReadQuery(t *testing.T) {
 
 	// 1. Install protocol first.
 	protocolDef := json.RawMessage(`{
-		"protocol": "https://enbox.org/protocols/integration-test",
+		"protocol": "https://enbox.id/protocols/integration-test",
 		"published": true,
 		"types": {
 			"note": {
-				"schema": "https://enbox.org/schemas/integration-test/note",
+				"schema": "https://enbox.id/schemas/integration-test/note",
 				"dataFormats": ["application/json"]
 			}
 		},
@@ -139,9 +139,9 @@ func TestIntegrationRecordsWriteReadQuery(t *testing.T) {
 	noteData := []byte(`{"title":"Integration Test","body":"This was written by meshd Go client"}`)
 
 	record, writeStatus, err := api.Write(ctx, signer.DID, dwn.WriteParams{
-		Protocol:     "https://enbox.org/protocols/integration-test",
+		Protocol:     "https://enbox.id/protocols/integration-test",
 		ProtocolPath: "note",
-		Schema:       "https://enbox.org/schemas/integration-test/note",
+		Schema:       "https://enbox.id/schemas/integration-test/note",
 		DataFormat:   "application/json",
 		Data:         noteData,
 	})
@@ -157,7 +157,7 @@ func TestIntegrationRecordsWriteReadQuery(t *testing.T) {
 	// 3. Query records — should find the one we just wrote.
 	records, queryStatus, err := api.Query(ctx, signer.DID, dwn.QueryParams{
 		Filter: dwn.RecordsFilter{
-			Protocol:     "https://enbox.org/protocols/integration-test",
+			Protocol:     "https://enbox.id/protocols/integration-test",
 			ProtocolPath: "note",
 		},
 	}, "")
@@ -201,7 +201,7 @@ func TestIntegrationRecordsWriteReadQuery(t *testing.T) {
 
 	// 5. Read the record directly.
 	readRecord, readStatus, err := api.Read(ctx, signer.DID, dwn.RecordsFilter{
-		Protocol:     "https://enbox.org/protocols/integration-test",
+		Protocol:     "https://enbox.id/protocols/integration-test",
 		ProtocolPath: "note",
 	}, "")
 	if err != nil {
@@ -240,11 +240,11 @@ func TestIntegrationRecordsDelete(t *testing.T) {
 
 	// Install protocol.
 	protocolDef := json.RawMessage(`{
-		"protocol": "https://enbox.org/protocols/integration-test",
+		"protocol": "https://enbox.id/protocols/integration-test",
 		"published": true,
 		"types": {
 			"note": {
-				"schema": "https://enbox.org/schemas/integration-test/note",
+				"schema": "https://enbox.id/schemas/integration-test/note",
 				"dataFormats": ["application/json"]
 			}
 		},
@@ -256,9 +256,9 @@ func TestIntegrationRecordsDelete(t *testing.T) {
 
 	// Write a record.
 	_, writeStatus, err := api.Write(ctx, signer.DID, dwn.WriteParams{
-		Protocol:     "https://enbox.org/protocols/integration-test",
+		Protocol:     "https://enbox.id/protocols/integration-test",
 		ProtocolPath: "note",
-		Schema:       "https://enbox.org/schemas/integration-test/note",
+		Schema:       "https://enbox.id/schemas/integration-test/note",
 		DataFormat:   "application/json",
 		Data:         []byte(`{"title":"To be deleted"}`),
 	})
@@ -272,7 +272,7 @@ func TestIntegrationRecordsDelete(t *testing.T) {
 	// Query to get the record ID.
 	records, _, err := api.Query(ctx, signer.DID, dwn.QueryParams{
 		Filter: dwn.RecordsFilter{
-			Protocol:     "https://enbox.org/protocols/integration-test",
+			Protocol:     "https://enbox.id/protocols/integration-test",
 			ProtocolPath: "note",
 		},
 	}, "")
@@ -311,11 +311,11 @@ func TestIntegrationEncryptedRecordsWrite(t *testing.T) {
 
 	// Install a protocol with encryption.
 	protocolDef := json.RawMessage(`{
-		"protocol": "https://enbox.org/protocols/encryption-test",
+		"protocol": "https://enbox.id/protocols/encryption-test",
 		"published": true,
 		"types": {
 			"secret": {
-				"schema": "https://enbox.org/schemas/encryption-test/secret",
+				"schema": "https://enbox.id/schemas/encryption-test/secret",
 				"dataFormats": ["application/json"]
 			}
 		},
@@ -347,9 +347,9 @@ func TestIntegrationEncryptedRecordsWrite(t *testing.T) {
 	plaintext := []byte(`{"message":"This is encrypted end-to-end!","code":42}`)
 
 	record, writeStatus, err := api.Write(ctx, signer.DID, dwn.WriteParams{
-		Protocol:     "https://enbox.org/protocols/encryption-test",
+		Protocol:     "https://enbox.id/protocols/encryption-test",
 		ProtocolPath: "secret",
-		Schema:       "https://enbox.org/schemas/encryption-test/secret",
+		Schema:       "https://enbox.id/schemas/encryption-test/secret",
 		DataFormat:   "application/json",
 		Data:         plaintext,
 		EncryptionRecipients: []dwncrypto.KeyEncryptionInput{{
@@ -369,7 +369,7 @@ func TestIntegrationEncryptedRecordsWrite(t *testing.T) {
 	// Query to find the record.
 	records, queryStatus, err := api.Query(ctx, signer.DID, dwn.QueryParams{
 		Filter: dwn.RecordsFilter{
-			Protocol:     "https://enbox.org/protocols/encryption-test",
+			Protocol:     "https://enbox.id/protocols/encryption-test",
 			ProtocolPath: "secret",
 		},
 	}, "")
@@ -386,7 +386,7 @@ func TestIntegrationEncryptedRecordsWrite(t *testing.T) {
 
 	// Read the encrypted record.
 	readRecord, readStatus, err := api.Read(ctx, signer.DID, dwn.RecordsFilter{
-		Protocol:     "https://enbox.org/protocols/encryption-test",
+		Protocol:     "https://enbox.id/protocols/encryption-test",
 		ProtocolPath: "secret",
 	}, "")
 	if err != nil {
@@ -461,11 +461,11 @@ func TestIntegrationEncryptedWriteQueryDelete(t *testing.T) {
 
 	// Install protocol.
 	protocolDef := json.RawMessage(`{
-		"protocol": "https://enbox.org/protocols/encryption-lifecycle-test",
+		"protocol": "https://enbox.id/protocols/encryption-lifecycle-test",
 		"published": true,
 		"types": {
 			"item": {
-				"schema": "https://enbox.org/schemas/encryption-lifecycle-test/item",
+				"schema": "https://enbox.id/schemas/encryption-lifecycle-test/item",
 				"dataFormats": ["application/json"]
 			}
 		},
@@ -493,9 +493,9 @@ func TestIntegrationEncryptedWriteQueryDelete(t *testing.T) {
 		plaintext := []byte(fmt.Sprintf(`{"index":%d,"data":"item-%d"}`, i, i))
 
 		_, ws, err := api.Write(ctx, signer.DID, dwn.WriteParams{
-			Protocol:     "https://enbox.org/protocols/encryption-lifecycle-test",
+			Protocol:     "https://enbox.id/protocols/encryption-lifecycle-test",
 			ProtocolPath: "item",
-			Schema:       "https://enbox.org/schemas/encryption-lifecycle-test/item",
+			Schema:       "https://enbox.id/schemas/encryption-lifecycle-test/item",
 			DataFormat:   "application/json",
 			Data:         plaintext,
 			EncryptionRecipients: []dwncrypto.KeyEncryptionInput{{
@@ -516,7 +516,7 @@ func TestIntegrationEncryptedWriteQueryDelete(t *testing.T) {
 	// Query all encrypted records.
 	records, qs, err := api.Query(ctx, signer.DID, dwn.QueryParams{
 		Filter: dwn.RecordsFilter{
-			Protocol:     "https://enbox.org/protocols/encryption-lifecycle-test",
+			Protocol:     "https://enbox.id/protocols/encryption-lifecycle-test",
 			ProtocolPath: "item",
 		},
 	}, "")
@@ -545,7 +545,7 @@ func TestIntegrationEncryptedWriteQueryDelete(t *testing.T) {
 	// Verify one fewer record.
 	records2, _, err := api.Query(ctx, signer.DID, dwn.QueryParams{
 		Filter: dwn.RecordsFilter{
-			Protocol:     "https://enbox.org/protocols/encryption-lifecycle-test",
+			Protocol:     "https://enbox.id/protocols/encryption-lifecycle-test",
 			ProtocolPath: "item",
 		},
 	}, "")
@@ -572,11 +572,11 @@ func TestIntegrationEncryptedMultiRecipient(t *testing.T) {
 
 	// Install protocol.
 	protocolDef := json.RawMessage(`{
-		"protocol": "https://enbox.org/protocols/multi-recipient-test",
+		"protocol": "https://enbox.id/protocols/multi-recipient-test",
 		"published": true,
 		"types": {
 			"shared": {
-				"schema": "https://enbox.org/schemas/multi-recipient-test/shared",
+				"schema": "https://enbox.id/schemas/multi-recipient-test/shared",
 				"dataFormats": ["application/json"]
 			}
 		},
@@ -607,9 +607,9 @@ func TestIntegrationEncryptedMultiRecipient(t *testing.T) {
 
 	// Write encrypted for 2 recipients.
 	_, ws, err := api.Write(ctx, signer.DID, dwn.WriteParams{
-		Protocol:     "https://enbox.org/protocols/multi-recipient-test",
+		Protocol:     "https://enbox.id/protocols/multi-recipient-test",
 		ProtocolPath: "shared",
-		Schema:       "https://enbox.org/schemas/multi-recipient-test/shared",
+		Schema:       "https://enbox.id/schemas/multi-recipient-test/shared",
 		DataFormat:   "application/json",
 		Data:         plaintext,
 		EncryptionRecipients: []dwncrypto.KeyEncryptionInput{
@@ -640,9 +640,9 @@ func TestIntegrationEncryptedMultiRecipient(t *testing.T) {
 		DID:        signer.DID,
 		PrivateKey: signer.PrivateKey,
 	}, dwn.RecordsWriteOptions{
-		Protocol:     "https://enbox.org/protocols/multi-recipient-test",
+		Protocol:     "https://enbox.id/protocols/multi-recipient-test",
 		ProtocolPath: "shared",
-		Schema:       "https://enbox.org/schemas/multi-recipient-test/shared",
+		Schema:       "https://enbox.id/schemas/multi-recipient-test/shared",
 		DataFormat:   "application/json",
 		Data:         plaintext,
 		EncryptionRecipients: []dwncrypto.KeyEncryptionInput{

--- a/internal/engine/connectivity_test.go
+++ b/internal/engine/connectivity_test.go
@@ -101,7 +101,7 @@ func TestTwoNodeConnectivity(t *testing.T) {
 	networkRecord, writeStatus, err := nodeA.api.Write(ctx, nodeA.identity.URI, dwn.WriteParams{
 		Protocol:     protocols.MeshProtocolURI,
 		ProtocolPath: "network",
-		Schema:       "https://enbox.org/schemas/wireguard-mesh/network",
+		Schema:       "https://enbox.id/schemas/wireguard-mesh/network",
 		DataFormat:   "application/json",
 		Data:         networkData,
 	})
@@ -676,7 +676,7 @@ func TestTwoNodeNetworkMapDiscovery(t *testing.T) {
 	networkRecord, ws, err := nodeA.api.Write(ctx, nodeA.identity.URI, dwn.WriteParams{
 		Protocol:     protocols.MeshProtocolURI,
 		ProtocolPath: "network",
-		Schema:       "https://enbox.org/schemas/wireguard-mesh/network",
+		Schema:       "https://enbox.id/schemas/wireguard-mesh/network",
 		DataFormat:   "application/json",
 		Data:         networkData,
 	})

--- a/internal/mesh/e2e_test.go
+++ b/internal/mesh/e2e_test.go
@@ -74,7 +74,7 @@ func newNode(t *testing.T, endpoint string) *nodeIdentity {
 	encMgr := &dwncrypto.EncryptionKeyManager{
 		RootPrivateKey: identity.EncryptionPrivateKey,
 		RootKeyID:      identity.EncryptionKeyID(),
-		ProtocolURI:    "https://enbox.org/protocols/wireguard-mesh",
+		ProtocolURI:    "https://enbox.id/protocols/wireguard-mesh",
 	}
 
 	return &nodeIdentity{
@@ -129,9 +129,9 @@ func TestE2ENetworkCreateJoinQueryDecrypt(t *testing.T) {
 	})
 
 	networkRecord, writeStatus, err := nodeA.API.Write(ctx, nodeA.DID.URI, dwn.WriteParams{
-		Protocol:     "https://enbox.org/protocols/wireguard-mesh",
+		Protocol:     "https://enbox.id/protocols/wireguard-mesh",
 		ProtocolPath: "network",
-		Schema:       "https://enbox.org/schemas/wireguard-mesh/network",
+		Schema:       "https://enbox.id/schemas/wireguard-mesh/network",
 		DataFormat:   "application/json",
 		Data:         networkData,
 	})
@@ -148,7 +148,7 @@ func TestE2ENetworkCreateJoinQueryDecrypt(t *testing.T) {
 		// Try to get the ID from a query.
 		records, qs, err := nodeA.API.Query(ctx, nodeA.DID.URI, dwn.QueryParams{
 			Filter: dwn.RecordsFilter{
-				Protocol:     "https://enbox.org/protocols/wireguard-mesh",
+				Protocol:     "https://enbox.id/protocols/wireguard-mesh",
 				ProtocolPath: "network",
 			},
 		}, "")
@@ -234,7 +234,7 @@ func TestE2ENetworkCreateJoinQueryDecrypt(t *testing.T) {
 	t.Log("Step 8: Querying node records from anchor DWN")
 	nodes, queryStatus, err := nodeA.API.Query(ctx, nodeA.DID.URI, dwn.QueryParams{
 		Filter: dwn.RecordsFilter{
-			Protocol:     "https://enbox.org/protocols/wireguard-mesh",
+			Protocol:     "https://enbox.id/protocols/wireguard-mesh",
 			ProtocolPath: "network/node",
 			ContextID:    networkRecordID,
 		},

--- a/internal/mesh/lifecycle_test.go
+++ b/internal/mesh/lifecycle_test.go
@@ -81,7 +81,7 @@ func TestE2EFullMeshLifecycle(t *testing.T) {
 	networkRecord, writeStatus, err := anchor.API.Write(ctx, anchor.DID.URI, dwn.WriteParams{
 		Protocol:     protocols.MeshProtocolURI,
 		ProtocolPath: "network",
-		Schema:       "https://enbox.org/schemas/wireguard-mesh/network",
+		Schema:       "https://enbox.id/schemas/wireguard-mesh/network",
 		DataFormat:   "application/json",
 		Data:         networkData,
 	})
@@ -449,7 +449,7 @@ func TestE2ERecipientBasedOwnerNodeWrite(t *testing.T) {
 	networkRecord, ws, err := anchor.API.Write(ctx, anchor.DID.URI, dwn.WriteParams{
 		Protocol:     protocols.MeshProtocolURI,
 		ProtocolPath: "network",
-		Schema:       "https://enbox.org/schemas/wireguard-mesh/network",
+		Schema:       "https://enbox.id/schemas/wireguard-mesh/network",
 		DataFormat:   "application/json",
 		Data:         networkData,
 	})
@@ -617,7 +617,7 @@ func TestE2EACLPolicyRoundTrip(t *testing.T) {
 	networkRecord, ws, err := anchor.API.Write(ctx, anchor.DID.URI, dwn.WriteParams{
 		Protocol:     protocols.MeshProtocolURI,
 		ProtocolPath: "network",
-		Schema:       "https://enbox.org/schemas/wireguard-mesh/network",
+		Schema:       "https://enbox.id/schemas/wireguard-mesh/network",
 		DataFormat:   "application/json",
 		Data:         networkData,
 	})
@@ -801,7 +801,7 @@ func TestE2ELoadStateNonAnchor(t *testing.T) {
 	networkRecord, ws, err := anchor.API.Write(ctx, anchor.DID.URI, dwn.WriteParams{
 		Protocol:     protocols.MeshProtocolURI,
 		ProtocolPath: "network",
-		Schema:       "https://enbox.org/schemas/wireguard-mesh/network",
+		Schema:       "https://enbox.id/schemas/wireguard-mesh/network",
 		DataFormat:   "application/json",
 		Data:         networkData,
 	})

--- a/internal/mesh/register.go
+++ b/internal/mesh/register.go
@@ -17,13 +17,13 @@ import (
 )
 
 const (
-	schemaMember      = "https://enbox.org/schemas/wireguard-mesh/member"
-	schemaNodeRequest = "https://enbox.org/schemas/wireguard-mesh/node-request"
-	schemaNode        = "https://enbox.org/schemas/wireguard-mesh/node"
-	schemaNodeInfo    = "https://enbox.org/schemas/wireguard-mesh/node-info"
-	schemaEndpoint    = "https://enbox.org/schemas/wireguard-mesh/endpoint"
-	schemaACLPolicy   = "https://enbox.org/schemas/wireguard-mesh/acl-policy"
-	schemaPreAuthKey  = "https://enbox.org/schemas/wireguard-mesh/pre-auth-key"
+	schemaMember      = "https://enbox.id/schemas/wireguard-mesh/member"
+	schemaNodeRequest = "https://enbox.id/schemas/wireguard-mesh/node-request"
+	schemaNode        = "https://enbox.id/schemas/wireguard-mesh/node"
+	schemaNodeInfo    = "https://enbox.id/schemas/wireguard-mesh/node-info"
+	schemaEndpoint    = "https://enbox.id/schemas/wireguard-mesh/endpoint"
+	schemaACLPolicy   = "https://enbox.id/schemas/wireguard-mesh/acl-policy"
+	schemaPreAuthKey  = "https://enbox.id/schemas/wireguard-mesh/pre-auth-key"
 )
 
 // MemberRegistration holds the result of creating a member record.

--- a/protocols/embed.go
+++ b/protocols/embed.go
@@ -10,7 +10,7 @@ var MeshProtocolJSON []byte
 var KeyDeliveryProtocolJSON []byte
 
 // MeshProtocolURI is the canonical URI of the wireguard-mesh protocol.
-const MeshProtocolURI = "https://enbox.org/protocols/wireguard-mesh"
+const MeshProtocolURI = "https://enbox.id/protocols/wireguard-mesh"
 
 // KeyDeliveryProtocolURI is the canonical URI of the key delivery protocol.
-const KeyDeliveryProtocolURI = "https://enbox.org/protocols/key-delivery"
+const KeyDeliveryProtocolURI = "https://enbox.id/protocols/key-delivery"

--- a/protocols/key-delivery.json
+++ b/protocols/key-delivery.json
@@ -1,5 +1,5 @@
 {
-  "protocol": "https://enbox.org/protocols/key-delivery",
+  "protocol": "https://enbox.id/protocols/key-delivery",
   "published": false,
   "types": {
     "contextKey": {

--- a/protocols/wireguard-mesh.json
+++ b/protocols/wireguard-mesh.json
@@ -1,46 +1,46 @@
 {
-  "protocol": "https://enbox.org/protocols/wireguard-mesh",
+  "protocol": "https://enbox.id/protocols/wireguard-mesh",
   "published": true,
   "types": {
     "network": {
-      "schema": "https://enbox.org/schemas/wireguard-mesh/network",
+      "schema": "https://enbox.id/schemas/wireguard-mesh/network",
       "dataFormats": ["application/json"]
     },
     "member": {
-      "schema": "https://enbox.org/schemas/wireguard-mesh/member",
+      "schema": "https://enbox.id/schemas/wireguard-mesh/member",
       "dataFormats": ["application/json"]
     },
     "nodeRequest": {
-      "schema": "https://enbox.org/schemas/wireguard-mesh/node-request",
+      "schema": "https://enbox.id/schemas/wireguard-mesh/node-request",
       "dataFormats": ["application/json"]
     },
     "node": {
-      "schema": "https://enbox.org/schemas/wireguard-mesh/node",
+      "schema": "https://enbox.id/schemas/wireguard-mesh/node",
       "dataFormats": ["application/json"],
       "encryptionRequired": true
     },
     "nodeInfo": {
-      "schema": "https://enbox.org/schemas/wireguard-mesh/node-info",
+      "schema": "https://enbox.id/schemas/wireguard-mesh/node-info",
       "dataFormats": ["application/json"],
       "encryptionRequired": true
     },
     "endpoint": {
-      "schema": "https://enbox.org/schemas/wireguard-mesh/endpoint",
+      "schema": "https://enbox.id/schemas/wireguard-mesh/endpoint",
       "dataFormats": ["application/json"],
       "encryptionRequired": true
     },
     "aclPolicy": {
-      "schema": "https://enbox.org/schemas/wireguard-mesh/acl-policy",
+      "schema": "https://enbox.id/schemas/wireguard-mesh/acl-policy",
       "dataFormats": ["application/json"],
       "encryptionRequired": true
     },
     "relay": {
-      "schema": "https://enbox.org/schemas/wireguard-mesh/relay",
+      "schema": "https://enbox.id/schemas/wireguard-mesh/relay",
       "dataFormats": ["application/json"],
       "encryptionRequired": true
     },
     "preAuthKey": {
-      "schema": "https://enbox.org/schemas/wireguard-mesh/pre-auth-key",
+      "schema": "https://enbox.id/schemas/wireguard-mesh/pre-auth-key",
       "dataFormats": ["application/json"],
       "encryptionRequired": true
     }

--- a/schemas/acl-policy.json
+++ b/schemas/acl-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://enbox.org/schemas/wireguard-mesh/acl-policy",
+  "$id": "https://enbox.id/schemas/wireguard-mesh/acl-policy",
   "type": "object",
   "required": ["version", "rules"],
   "additionalProperties": false,

--- a/schemas/endpoint.json
+++ b/schemas/endpoint.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://enbox.org/schemas/wireguard-mesh/endpoint",
+  "$id": "https://enbox.id/schemas/wireguard-mesh/endpoint",
   "type": "object",
   "required": ["updatedAt"],
   "additionalProperties": false,

--- a/schemas/member.json
+++ b/schemas/member.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://enbox.org/schemas/wireguard-mesh/member",
+  "$id": "https://enbox.id/schemas/wireguard-mesh/member",
   "type": "object",
   "required": ["addedAt"],
   "additionalProperties": false,

--- a/schemas/network.json
+++ b/schemas/network.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://enbox.org/schemas/wireguard-mesh/network",
+  "$id": "https://enbox.id/schemas/wireguard-mesh/network",
   "type": "object",
   "required": ["name", "meshCIDR"],
   "additionalProperties": false,

--- a/schemas/node-info.json
+++ b/schemas/node-info.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://enbox.org/schemas/wireguard-mesh/node-info",
+  "$id": "https://enbox.id/schemas/wireguard-mesh/node-info",
   "type": "object",
   "additionalProperties": false,
   "properties": {

--- a/schemas/node-request.json
+++ b/schemas/node-request.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://enbox.org/schemas/wireguard-mesh/node-request",
+  "$id": "https://enbox.id/schemas/wireguard-mesh/node-request",
   "type": "object",
   "required": ["nodeDID"],
   "additionalProperties": false,

--- a/schemas/node.json
+++ b/schemas/node.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://enbox.org/schemas/wireguard-mesh/node",
+  "$id": "https://enbox.id/schemas/wireguard-mesh/node",
   "type": "object",
   "required": ["meshIP", "addedAt"],
   "additionalProperties": false,

--- a/schemas/pre-auth-key.json
+++ b/schemas/pre-auth-key.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://enbox.org/schemas/wireguard-mesh/pre-auth-key",
+  "$id": "https://enbox.id/schemas/wireguard-mesh/pre-auth-key",
   "type": "object",
   "required": ["key", "createdAt"],
   "additionalProperties": false,

--- a/schemas/relay.json
+++ b/schemas/relay.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://enbox.org/schemas/wireguard-mesh/relay",
+  "$id": "https://enbox.id/schemas/wireguard-mesh/relay",
   "type": "object",
   "required": ["url", "region"],
   "additionalProperties": false,


### PR DESCRIPTION
## Summary
- replace first-party `enbox.org` protocol and schema URIs with `enbox.id`
- update protocol fixtures, schema IDs, docs, and tests to use the owned domain
- leave GitHub org/module paths such as `github.com/enboxorg/...` unchanged

Closes #109

## Verification
- `rg -n "enbox\.org" . -g '!vendor/**' -g '!.git/**'` returns no matches\n- `GOFLAGS=-mod=vendor go build ./...`\n- `GOFLAGS=-mod=vendor go vet ./...`\n- `GOFLAGS=-mod=vendor go test ./... -count=1 -race`