### PR TITLE
fix: stabilize engine connectivity integration

### DIFF
--- a/internal/engine/connectivity_test.go
+++ b/internal/engine/connectivity_test.go
@@ -7,11 +7,16 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"net/netip"
+	"net/url"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
+	"github.com/enboxorg/meshd/internal/control"
 	"github.com/enboxorg/meshd/internal/did"
 	"github.com/enboxorg/meshd/internal/dwn"
 	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
@@ -19,6 +24,7 @@ import (
 	"github.com/enboxorg/meshd/internal/mesh"
 	"github.com/enboxorg/meshd/protocols"
 
+	"github.com/enboxorg/meshnet/derp/derpserver"
 	"github.com/enboxorg/meshnet/types/key"
 	go4mem "go4.org/mem"
 )
@@ -270,6 +276,22 @@ func TestTwoNodeConnectivity(t *testing.T) {
 	}
 	t.Logf("  Node A re-registered with context encryption: %s", regA2.NodeRecordID)
 
+	err = mesh.WriteEndpoint(ctx, mesh.WriteEndpointParams{
+		AnchorEndpoint:       endpoint,
+		AnchorDID:            nodeA.identity.URI,
+		NetworkRecordID:      networkRecordID,
+		NodeRecordID:         regA2.NodeRecordID,
+		Signer:               nodeA.signer,
+		EncryptionKeyManager: nodeA.encMgr,
+		LocalEndpoints:       mesh.DiscoverLocalEndpoints(0),
+		NATType:              "unknown",
+		UseContextEncryption: true,
+	})
+	if err != nil {
+		t.Fatalf("rewriting Node A endpoint with context encryption: %v", err)
+	}
+	t.Log("  Node A endpoint re-written with context encryption")
+
 	// ================================================================
 	// Step 6b: Node B fetches and stores context key, re-registers with context encryption
 	// ================================================================
@@ -373,6 +395,8 @@ func TestTwoNodeConnectivity(t *testing.T) {
 	// Shared disco key registry: both engines publish and look up disco keys
 	// through this registry, replacing Tailscale's control server role.
 	discoReg := engine.NewInMemoryDiscoRegistry()
+	derpMap, derpCleanup := startLocalTestDERP(t)
+	defer derpCleanup()
 
 	engA, err := engine.New(engine.Config{
 		AnchorEndpoint:       endpoint,
@@ -381,12 +405,14 @@ func TestTwoNodeConnectivity(t *testing.T) {
 		SelfDID:              nodeA.identity.URI,
 		Signer:               nodeA.signer,
 		EncryptionKeyManager: nodeA.encMgr,
+		NodeRecordID:         regA2.NodeRecordID,
 		Domain:               "e2e-test",
 		PollInterval:         5 * time.Second,
 		ListenPort:           0,
 		UseContextEncryption: true,
 		WireGuardPrivateKey:  wgKeysA.PrivateKey,
 		DiscoKeyRegistry:     discoReg,
+		DERPMap:              derpMap,
 	})
 	if err != nil {
 		t.Fatalf("creating engine A: %v", err)
@@ -401,12 +427,14 @@ func TestTwoNodeConnectivity(t *testing.T) {
 		SelfDID:              nodeB.identity.URI,
 		Signer:               nodeB.signer,
 		EncryptionKeyManager: nodeB.encMgr,
+		NodeRecordID:         regB2.NodeRecordID,
 		Domain:               "e2e-test",
 		PollInterval:         5 * time.Second,
 		ListenPort:           0,
 		UseContextEncryption: true,
 		WireGuardPrivateKey:  wgKeysB.PrivateKey,
 		DiscoKeyRegistry:     discoReg,
+		DERPMap:              derpMap,
 	})
 	if err != nil {
 		t.Fatalf("creating engine B: %v", err)
@@ -921,6 +949,61 @@ func parseTestWireGuardKey(b64Key string) (key.NodePublic, error) {
 		return key.NodePublic{}, fmt.Errorf("key must be 32 bytes, got %d", len(raw))
 	}
 	return key.NodePublicFromRaw32(go4mem.B(raw)), nil
+}
+
+func startLocalTestDERP(t *testing.T) (*control.DERPMap, func()) {
+	t.Helper()
+
+	derpKey := key.NewNode()
+	logf := func(format string, args ...any) {
+		t.Logf("[derp] "+format, args...)
+	}
+	ds := derpserver.New(derpKey, logf)
+
+	mux := http.NewServeMux()
+	mux.Handle("/derp", derpserver.Handler(ds))
+	mux.HandleFunc("/derp/probe", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+	})
+	mux.HandleFunc("/derp/latency-check", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+	})
+	mux.HandleFunc("/generate_204", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	ts := httptest.NewTLSServer(mux)
+	u, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("parsing local DERP URL: %v", err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("parsing local DERP port: %v", err)
+	}
+
+	t.Logf("  Local DERP server: %s", ts.URL)
+	dm := &control.DERPMap{
+		Regions: map[int]*control.DERPRegion{
+			1: {
+				RegionID:   1,
+				RegionCode: "test",
+				RegionName: "Local Test",
+				Nodes: []control.DERPNode{{
+					Name:             "1a",
+					RegionID:         1,
+					HostName:         u.Hostname(),
+					DERPPort:         port,
+					InsecureForTests: true,
+				}},
+			},
+		},
+	}
+
+	return dm, func() {
+		ds.Close()
+		ts.Close()
+	}
 }
 
 // Ensure testNode fields are used to satisfy the compiler.

--- a/internal/engine/convert.go
+++ b/internal/engine/convert.go
@@ -31,6 +31,11 @@ type Converter struct {
 	// MagicDNSSuffix is the suffix for mesh-local DNS (e.g. "mesh.local").
 	MagicDNSSuffix string
 
+	// DERPMapOverride, when set, replaces the DERP map loaded from DWN.
+	// This is primarily useful for embedded deployments and deterministic
+	// integration tests that provide their own relay map.
+	DERPMapOverride *control.DERPMap
+
 	logger *slog.Logger
 }
 
@@ -116,8 +121,12 @@ func (c *Converter) Convert(resp *control.MapResponse) (*netmap.NetworkMap, erro
 	nm.Peers = peerViews
 
 	// Convert DERP map.
-	if resp.DERPMap != nil {
-		nm.DERPMap = c.convertDERPMap(resp.DERPMap)
+	derpMap := resp.DERPMap
+	if c.DERPMapOverride != nil {
+		derpMap = c.DERPMapOverride
+	}
+	if derpMap != nil {
+		nm.DERPMap = c.convertDERPMap(derpMap)
 	}
 
 	// Convert DNS config.

--- a/internal/engine/convert_test.go
+++ b/internal/engine/convert_test.go
@@ -268,6 +268,72 @@ func TestConvertFullMapResponse(t *testing.T) {
 	}
 }
 
+func TestConverterDERPMapOverride(t *testing.T) {
+	resp := &control.MapResponse{
+		Node: &control.Node{
+			ID:            1,
+			Name:          "node-a",
+			DID:           "did:example:self",
+			Key:           testWireGuardKey(),
+			MeshIP:        netip.MustParseAddr("10.200.0.2"),
+			PreferredDERP: 1,
+		},
+		DERPMap: &control.DERPMap{
+			Regions: map[int]*control.DERPRegion{
+				1: {
+					RegionID:   1,
+					RegionCode: "public",
+					RegionName: "Public",
+					Nodes: []control.DERPNode{{
+						Name:     "public-1",
+						RegionID: 1,
+						HostName: "derp1.example.com",
+						DERPPort: 443,
+					}},
+				},
+			},
+		},
+	}
+
+	override := &control.DERPMap{
+		Regions: map[int]*control.DERPRegion{
+			1: {
+				RegionID:   1,
+				RegionCode: "local",
+				RegionName: "Local Test",
+				Nodes: []control.DERPNode{{
+					Name:             "local-1",
+					RegionID:         1,
+					HostName:         "127.0.0.1",
+					DERPPort:         12345,
+					InsecureForTests: true,
+				}},
+			},
+		},
+	}
+
+	conv := NewConverter("test-mesh")
+	conv.DERPMapOverride = override
+
+	nm, err := conv.Convert(resp)
+	if err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+	if nm.DERPMap == nil {
+		t.Fatal("DERPMap is nil")
+	}
+	node := nm.DERPMap.Regions[1].Nodes[0]
+	if node.HostName != "127.0.0.1" {
+		t.Fatalf("DERP override hostname = %q, want 127.0.0.1", node.HostName)
+	}
+	if node.DERPPort != 12345 {
+		t.Fatalf("DERP override port = %d, want 12345", node.DERPPort)
+	}
+	if !node.InsecureForTests {
+		t.Fatal("DERP override should preserve InsecureForTests")
+	}
+}
+
 func TestConvertNilMapResponse(t *testing.T) {
 	conv := NewConverter("test")
 	_, err := conv.Convert(nil)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -133,6 +133,11 @@ type Config struct {
 	// won't be exchanged, which prevents DERP relay between peers).
 	DiscoKeyRegistry DiscoKeyRegistry
 
+	// DERPMap, when non-nil, overrides relay records loaded from DWN.
+	// Normal CLI operation should use DWN relay records; this hook is useful
+	// for embedded callers and deterministic integration tests.
+	DERPMap *control.DERPMap
+
 	// TUNName, if non-empty, creates a real OS TUN device with this name
 	// (e.g., "meshd0") instead of using a fake TUN. This enables regular
 	// applications (ping, ssh, curl) to route through the mesh tunnel.
@@ -212,6 +217,7 @@ func New(cfg Config) (*Engine, error) {
 	// Create the converter that bridges meshd types to meshnet types.
 	converter := NewConverter(domain, WithConverterLogger(l))
 	converter.MagicDNSSuffix = magicDNS
+	converter.DERPMapOverride = cfg.DERPMap
 
 	// Create the meshnet system container.
 	sys := tsd.NewSystem()


### PR DESCRIPTION
## Summary
- add an explicit DERP map override path for engine construction so deterministic tests can provide their own relay map
- update the DWN-backed two-node connectivity test to use an in-process DERP relay instead of public bootstrap relays
- wire the test engines with node record IDs and context-encrypted endpoint records so endpoint writeback matches production startup

## Verification
- GOFLAGS=-mod=vendor go test ./internal/engine/ -run 'TestConverterDERPMapOverride|TestMinimalTwoEngineConnectivity' -v -count=1 -timeout 120s
- GOFLAGS=-mod=vendor go test ./internal/engine/ -run TestConvert -count=1
- GOFLAGS=-mod=vendor go build ./...
- GOFLAGS=-mod=vendor go vet ./...
- GOFLAGS=-mod=vendor go test ./... -count=1 -race

Closes #111