### PR TITLE
fix: make TUN startup sudo-aware

### DIFF
--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -8,8 +8,11 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -65,8 +68,8 @@ Up flags:
   --endpoint <url>  DWN endpoint (or set DWN_ENDPOINT env var)
   --anchor <did>    Anchor DID when joining a network
   --network <id>    Network record ID when joining a network
-  --tun [name]      Create a real TUN device (auto if root; macOS: utun)
-  --no-tun          Disable auto TUN even when running as root
+  --tun [name]      Create a real TUN device (default; asks sudo when needed)
+  --no-tun          Use userspace mode without OS routes
   --port <n>        WireGuard UDP listen port (default: auto)
   --poll-interval   DWN poll interval (default: 30s)
   -v, --verbose     Enable debug logging
@@ -91,6 +94,8 @@ Environment:
 `
 
 var version = "dev"
+
+const sudoChildEnv = "MESHD_SUDO_CHILD"
 
 func main() {
 	if len(os.Args) < 2 {
@@ -1470,6 +1475,142 @@ func defaultTUNName(goos string) string {
 	return "meshd0"
 }
 
+func supportsRealTUN(goos string) bool {
+	return goos == "darwin" || goos == "linux"
+}
+
+func shouldReexecWithSudoForTun(f upFlags, uid int, goos string, stdinTTY bool) bool {
+	if uid == 0 || f.noTun || !stdinTTY || !supportsRealTUN(goos) {
+		return false
+	}
+	return true
+}
+
+func reexecUpWithSudo(args []string, flagProfile string) error {
+	sudoPath, err := exec.LookPath("sudo")
+	if err != nil {
+		return fmt.Errorf("system routing requires administrator privileges, but sudo was not found; run meshd as root or use --no-tun")
+	}
+
+	exePath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolving meshd executable for sudo handoff: %w", err)
+	}
+
+	sudoArgs := []string{"env"}
+	sudoArgs = append(sudoArgs, sudoEnvironmentAssignments()...)
+	sudoArgs = append(sudoArgs, exePath, "up")
+	if flagProfile != "" {
+		sudoArgs = append(sudoArgs, "--profile", flagProfile)
+	}
+	sudoArgs = append(sudoArgs, args...)
+
+	fmt.Fprintln(os.Stderr, "meshd: system routing needs administrator privileges; asking sudo to start the tunnel.")
+
+	cmd := exec.Command(sudoPath, sudoArgs...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func sudoEnvironmentAssignments() []string {
+	assignments := []string{sudoChildEnv + "=1"}
+
+	home := os.Getenv("HOME")
+	if home == "" {
+		if userHome, err := os.UserHomeDir(); err == nil {
+			home = userHome
+		}
+	}
+	if home != "" {
+		assignments = append(assignments, "HOME="+home)
+	}
+
+	enboxHome := os.Getenv("ENBOX_HOME")
+	if enboxHome == "" && home != "" {
+		enboxHome = filepath.Join(home, ".enbox")
+	}
+	if enboxHome != "" {
+		assignments = append(assignments, "ENBOX_HOME="+enboxHome)
+	}
+
+	for _, key := range []string{"PATH", "DWN_ENDPOINT", "ENBOX_PROFILE", "MESHD_STATE_DIR"} {
+		if value := os.Getenv(key); value != "" {
+			assignments = append(assignments, key+"="+value)
+		}
+	}
+
+	return assignments
+}
+
+func restoreSudoUserOwnership() {
+	uid, gid, ok := sudoOriginalIDs()
+	if !ok {
+		return
+	}
+
+	for _, root := range sudoOwnershipRoots() {
+		if root == "" {
+			continue
+		}
+		_ = filepath.WalkDir(root, func(path string, _ os.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			_ = os.Lchown(path, uid, gid)
+			return nil
+		})
+	}
+}
+
+func sudoOriginalIDs() (uid int, gid int, ok bool) {
+	uid64, uidErr := strconv.ParseInt(os.Getenv("SUDO_UID"), 10, 32)
+	gid64, gidErr := strconv.ParseInt(os.Getenv("SUDO_GID"), 10, 32)
+	if uidErr != nil || gidErr != nil || uid64 <= 0 || gid64 < 0 {
+		return 0, 0, false
+	}
+	return int(uid64), int(gid64), true
+}
+
+func sudoOwnershipRoots() []string {
+	home := os.Getenv("HOME")
+	if home == "" {
+		return nil
+	}
+
+	var candidates []string
+	if stateDir := os.Getenv("MESHD_STATE_DIR"); stateDir != "" {
+		candidates = append(candidates, stateDir)
+	} else if enboxHome := os.Getenv("ENBOX_HOME"); enboxHome != "" {
+		candidates = append(candidates, enboxHome)
+	}
+
+	roots := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		if isSafeSudoOwnershipRoot(candidate, home) {
+			roots = append(roots, candidate)
+		}
+	}
+	return roots
+}
+
+func isSafeSudoOwnershipRoot(root string, home string) bool {
+	absRoot, rootErr := filepath.Abs(root)
+	absHome, homeErr := filepath.Abs(home)
+	if rootErr != nil || homeErr != nil {
+		return false
+	}
+	if absRoot == absHome {
+		return false
+	}
+	rel, err := filepath.Rel(absHome, absRoot)
+	if err != nil || rel == "." {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
 // cmdUp starts the mesh agent daemon.
 //
 // This is the main entry point for meshd. It handles the full lifecycle:
@@ -1482,6 +1623,10 @@ func defaultTUNName(goos string) string {
 // setup. Without flags, it guides the user interactively.
 func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 	f := parseUpFlags(args)
+	if os.Getenv(sudoChildEnv) == "1" {
+		defer restoreSudoUserOwnership()
+	}
+	shouldElevate := shouldReexecWithSudoForTun(f, os.Getuid(), runtime.GOOS, stdinIsTerminal())
 
 	// ── Step 1: Ensure identity exists ──────────────────────────────
 	stateDir, identity, err := ensureIdentityForCommand(ctx, flagProfile, f.endpoint)
@@ -1510,6 +1655,9 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 		if ns.NodeRecordID == "" {
 			return fmt.Errorf("join request is still pending anchor approval; run 'meshd up' again after the anchor is online")
 		}
+	}
+	if shouldElevate {
+		return reexecUpWithSudo(args, flagProfile)
 	}
 
 	// ── Step 3: Start the engine ────────────────────────────────────

--- a/cmd/meshd/main_test.go
+++ b/cmd/meshd/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -44,6 +45,130 @@ func TestParseUpFlagsTunUsesPlatformDefault(t *testing.T) {
 	if flags.tunName != want {
 		t.Fatalf("tunName = %q, want %q", flags.tunName, want)
 	}
+}
+
+func TestShouldReexecWithSudoForTun(t *testing.T) {
+	if !shouldReexecWithSudoForTun(upFlags{}, 501, "darwin", true) {
+		t.Fatal("expected interactive non-root darwin up to reexec with sudo")
+	}
+	if !shouldReexecWithSudoForTun(upFlags{}, 1000, "linux", true) {
+		t.Fatal("expected interactive non-root linux up to reexec with sudo")
+	}
+	if shouldReexecWithSudoForTun(upFlags{}, 0, "linux", true) {
+		t.Fatal("did not expect root to reexec with sudo")
+	}
+	if shouldReexecWithSudoForTun(upFlags{noTun: true}, 1000, "linux", true) {
+		t.Fatal("did not expect --no-tun to reexec with sudo")
+	}
+	if shouldReexecWithSudoForTun(upFlags{}, 1000, "linux", false) {
+		t.Fatal("did not expect non-interactive up to reexec with sudo")
+	}
+	if shouldReexecWithSudoForTun(upFlags{}, 1000, "freebsd", true) {
+		t.Fatal("did not expect unsupported OS to reexec with sudo")
+	}
+}
+
+func TestSudoEnvironmentAssignments(t *testing.T) {
+	home := t.TempDir()
+	enboxHome := filepath.Join(home, ".enbox-custom")
+	t.Setenv("HOME", home)
+	t.Setenv("ENBOX_HOME", enboxHome)
+	t.Setenv("PATH", "/tmp/test-path")
+	t.Setenv("DWN_ENDPOINT", "https://dwn.example")
+	t.Setenv("ENBOX_PROFILE", "work")
+	t.Setenv("MESHD_STATE_DIR", filepath.Join(home, "state"))
+	t.Setenv("MESHD_VAULT_PASSWORD", "secret")
+
+	assignments := sudoEnvironmentAssignments()
+	for _, want := range []string{
+		sudoChildEnv + "=1",
+		"HOME=" + home,
+		"ENBOX_HOME=" + enboxHome,
+		"PATH=/tmp/test-path",
+		"DWN_ENDPOINT=https://dwn.example",
+		"ENBOX_PROFILE=work",
+		"MESHD_STATE_DIR=" + filepath.Join(home, "state"),
+	} {
+		if !hasString(assignments, want) {
+			t.Fatalf("sudoEnvironmentAssignments() missing %q in %v", want, assignments)
+		}
+	}
+	for _, got := range assignments {
+		if strings.HasPrefix(got, "MESHD_VAULT_PASSWORD=") {
+			t.Fatal("sudoEnvironmentAssignments must not expose MESHD_VAULT_PASSWORD")
+		}
+	}
+}
+
+func TestSudoEnvironmentAssignmentsDefaultsEnboxHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ENBOX_HOME", "")
+
+	assignments := sudoEnvironmentAssignments()
+	want := "ENBOX_HOME=" + filepath.Join(home, ".enbox")
+	if !hasString(assignments, want) {
+		t.Fatalf("sudoEnvironmentAssignments() missing %q in %v", want, assignments)
+	}
+}
+
+func TestSudoOriginalIDs(t *testing.T) {
+	t.Setenv("SUDO_UID", "501")
+	t.Setenv("SUDO_GID", "20")
+
+	uid, gid, ok := sudoOriginalIDs()
+	if !ok || uid != 501 || gid != 20 {
+		t.Fatalf("sudoOriginalIDs() = %d, %d, %v; want 501, 20, true", uid, gid, ok)
+	}
+
+	t.Setenv("SUDO_UID", "0")
+	if _, _, ok := sudoOriginalIDs(); ok {
+		t.Fatal("sudoOriginalIDs() should reject root SUDO_UID")
+	}
+}
+
+func TestSudoOwnershipRoots(t *testing.T) {
+	home := t.TempDir()
+	stateDir := filepath.Join(home, "state")
+	enboxHome := filepath.Join(home, ".enbox")
+	t.Setenv("HOME", home)
+	t.Setenv("MESHD_STATE_DIR", stateDir)
+	t.Setenv("ENBOX_HOME", enboxHome)
+
+	roots := sudoOwnershipRoots()
+	if len(roots) != 1 || roots[0] != stateDir {
+		t.Fatalf("sudoOwnershipRoots() = %v, want [%s]", roots, stateDir)
+	}
+
+	t.Setenv("MESHD_STATE_DIR", "")
+	roots = sudoOwnershipRoots()
+	if len(roots) != 1 || roots[0] != enboxHome {
+		t.Fatalf("sudoOwnershipRoots() = %v, want [%s]", roots, enboxHome)
+	}
+}
+
+func TestSudoOwnershipRootsRejectsOutsideHome(t *testing.T) {
+	home := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "state")
+	t.Setenv("HOME", home)
+	t.Setenv("MESHD_STATE_DIR", outside)
+	t.Setenv("ENBOX_HOME", "")
+
+	if roots := sudoOwnershipRoots(); len(roots) != 0 {
+		t.Fatalf("sudoOwnershipRoots() = %v, want empty for path outside HOME", roots)
+	}
+	if isSafeSudoOwnershipRoot(home, home) {
+		t.Fatal("home itself must not be accepted as an ownership root")
+	}
+}
+
+func hasString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestParseNetworkCreateArgs(t *testing.T) {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -26,9 +26,13 @@ import (
 
 // DefaultSocketPath returns the default Unix socket path for the daemon.
 //
+// ENBOX_HOME set: $ENBOX_HOME/meshd.sock
 // Root: /var/run/meshd/meshd.sock
 // User: ~/.enbox/meshd.sock
 func DefaultSocketPath() string {
+	if d := os.Getenv("ENBOX_HOME"); d != "" {
+		return filepath.Join(d, "meshd.sock")
+	}
 	if os.Getuid() == 0 {
 		return "/var/run/meshd/meshd.sock"
 	}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -16,6 +16,17 @@ func testSocketPath(t *testing.T) string {
 	return filepath.Join(t.TempDir(), "meshd.sock")
 }
 
+func TestDefaultSocketPathUsesEnboxHome(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ENBOX_HOME", dir)
+
+	got := DefaultSocketPath()
+	want := filepath.Join(dir, "meshd.sock")
+	if got != want {
+		t.Fatalf("DefaultSocketPath() = %q, want %q", got, want)
+	}
+}
+
 func TestServerStartStop(t *testing.T) {
 	sock := testSocketPath(t)
 	srv := NewServer(sock, nil, nil)


### PR DESCRIPTION
## Summary\n- Make interactive non-root `meshd up` on macOS/Linux finish user-owned setup, then re-run itself under `sudo` for real TUN routing unless `--no-tun` is set.\n- Preserve `HOME`, `ENBOX_HOME`, `PATH`, `DWN_ENDPOINT`, `ENBOX_PROFILE`, and `MESHD_STATE_DIR` through the sudo handoff so the elevated process uses the user's profile/vault instead of root's empty state.\n- Keep `MESHD_VAULT_PASSWORD` out of sudo command arguments.\n- Make the daemon socket honor `ENBOX_HOME`, so normal `meshd status` and `meshd down` can find an elevated daemon.\n- Restore root-created profile files back to the original sudo user when the elevated process exits, constrained to safe roots under the preserved HOME.\n\nCloses #116.\n\n## Verification\n- `GOFLAGS=-mod=vendor go build ./...`\n- `GOFLAGS=-mod=vendor go vet ./...`\n- `GOFLAGS=-mod=vendor go test ./... -count=1 -race`\n- `GOFLAGS=-mod=vendor GOOS=darwin GOARCH=arm64 go build -o /tmp/meshd-darwin-arm64 ./cmd/meshd`\n- `GOFLAGS=-mod=vendor GOOS=windows GOARCH=amd64 go build -o /tmp/meshd-windows-amd64.exe ./cmd/meshd`