### PR TITLE
Register DWN tenant during setup

### DIFF
--- a/cmd/meshd/cli_integration_test.go
+++ b/cmd/meshd/cli_integration_test.go
@@ -32,8 +32,8 @@ func TestCLIInviteJoinFlow(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 
-	anchorStateDir, anchorIdentity := createRegisteredCLIIdentity(t, ctx, endpoint, "anchor")
-	joinerStateDir, joinerIdentity := createRegisteredCLIIdentity(t, ctx, endpoint, "joiner")
+	anchorStateDir, anchorIdentity := createCLIIdentity(t, ctx, "anchor")
+	joinerStateDir, joinerIdentity := createCLIIdentity(t, ctx, "joiner")
 
 	networkName := "cli-e2e-" + time.Now().UTC().Format("20060102-150405")
 	if err := cmdNetworkCreate(ctx, []string{networkName, "--endpoint", endpoint}, "anchor"); err != nil {
@@ -116,15 +116,12 @@ func TestCLIInviteJoinFlow(t *testing.T) {
 	}
 }
 
-func createRegisteredCLIIdentity(t *testing.T, ctx context.Context, endpoint string, profileName string) (string, *did.DID) {
+func createCLIIdentity(t *testing.T, ctx context.Context, profileName string) (string, *did.DID) {
 	t.Helper()
 
-	stateDir, identity, err := ensureIdentityForCommand(ctx, profileName, endpoint)
+	stateDir, identity, err := ensureIdentityForCommand(ctx, profileName, "")
 	if err != nil {
 		t.Fatalf("ensureIdentityForCommand(%s): %v", profileName, err)
-	}
-	if err := dwn.RegisterTenant(ctx, endpoint, identity.URI); err != nil {
-		t.Fatalf("RegisterTenant(%s): %v", profileName, err)
 	}
 	return stateDir, identity
 }

--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -361,6 +361,9 @@ func cmdNetworkCreate(ctx context.Context, args []string, flagProfile string) er
 	if state.HasNetwork(stateDir) {
 		return fmt.Errorf("already in a network. Use 'meshd network leave' first.")
 	}
+	if err := ensureDWNTenantRegistered(ctx, endpoint, identity); err != nil {
+		return err
+	}
 
 	signer := &dwn.Signer{
 		DID:        identity.URI,
@@ -591,6 +594,9 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 
 	if state.HasNetwork(stateDir) {
 		return fmt.Errorf("already in a network. Use 'meshd network leave' first.")
+	}
+	if err := ensureDWNTenantRegistered(ctx, endpoint, identity); err != nil {
+		return err
 	}
 
 	signer := &dwn.Signer{
@@ -984,6 +990,9 @@ func cmdJoin(ctx context.Context, args []string, flagProfile string) error {
 			return fmt.Errorf("loading network state: %w", loadErr)
 		}
 		if ns != nil && ns.NetworkRecordID == payload.NetworkID && ns.AnchorDID == payload.AnchorDID && ns.NodeRecordID == "" {
+			if err := ensureDWNTenantRegistered(ctx, payload.Endpoint, identity); err != nil {
+				return err
+			}
 			refreshed, err := refreshPendingJoin(ctx, stateDir, ns, flagProfile)
 			if err != nil {
 				return err
@@ -994,6 +1003,9 @@ func cmdJoin(ctx context.Context, args []string, flagProfile string) error {
 			return nil
 		}
 		return fmt.Errorf("already in a network. Use 'meshd network leave' first.")
+	}
+	if err := ensureDWNTenantRegistered(ctx, payload.Endpoint, identity); err != nil {
+		return err
 	}
 
 	preauth := payload.TokenID != "" || payload.Secret != ""
@@ -1939,6 +1951,18 @@ func ensureIdentityForCommand(ctx context.Context, flagProfile, endpoint string)
 		return "", nil, err
 	}
 	return stateDir, identity, nil
+}
+
+func ensureDWNTenantRegistered(ctx context.Context, endpoint string, identity *did.DID) error {
+	if endpoint == "" || identity == nil || identity.URI == "" {
+		return nil
+	}
+	fmt.Printf("Registering DID with DWN...\n")
+	if err := dwn.RegisterTenant(ctx, endpoint, identity.URI); err != nil {
+		return fmt.Errorf("registering DID with DWN: %w", err)
+	}
+	fmt.Printf("  DWN tenant ready.\n")
+	return nil
 }
 
 // ensureNetwork handles network setup when the user is not yet in a network.

--- a/cmd/meshd/main_test.go
+++ b/cmd/meshd/main_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -159,6 +162,66 @@ func TestSudoOwnershipRootsRejectsOutsideHome(t *testing.T) {
 	}
 	if isSafeSudoOwnershipRoot(home, home) {
 		t.Fatal("home itself must not be accepted as an ownership root")
+	}
+}
+
+func TestEnsureDWNTenantRegistered(t *testing.T) {
+	var registeredDID string
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/info":
+			writeJSON(t, w, map[string]any{
+				"registrationRequirements": []string{"provider-auth-v0"},
+				"providerAuth": map[string]string{
+					"authorizeUrl": server.URL + "/authorize",
+					"tokenUrl":     server.URL + "/token",
+				},
+			})
+		case "/authorize":
+			writeJSON(t, w, map[string]string{
+				"code":  "test-code",
+				"state": r.URL.Query().Get("state"),
+			})
+		case "/token":
+			writeJSON(t, w, map[string]string{"registrationToken": "test-token"})
+		case "/registration":
+			var body struct {
+				RegistrationData struct {
+					DID string `json:"did"`
+				} `json:"registrationData"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decoding registration body: %v", err)
+			}
+			registeredDID = body.RegistrationData.DID
+			writeJSON(t, w, map[string]string{"status": "ok"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	identity := &did.DID{URI: "did:jwk:test"}
+	if err := ensureDWNTenantRegistered(context.Background(), server.URL, identity); err != nil {
+		t.Fatalf("ensureDWNTenantRegistered: %v", err)
+	}
+	if registeredDID != identity.URI {
+		t.Fatalf("registered DID = %q, want %q", registeredDID, identity.URI)
+	}
+}
+
+func TestEnsureDWNTenantRegisteredNoopWithoutEndpoint(t *testing.T) {
+	if err := ensureDWNTenantRegistered(context.Background(), "", &did.DID{URI: "did:jwk:test"}); err != nil {
+		t.Fatalf("ensureDWNTenantRegistered empty endpoint: %v", err)
+	}
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, value any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		t.Fatalf("encoding response: %v", err)
 	}
 }
 

--- a/internal/dwn/register.go
+++ b/internal/dwn/register.go
@@ -17,7 +17,7 @@ import (
 
 // serverInfo represents the response from GET /info.
 type serverInfo struct {
-	RegistrationRequirements []string         `json:"registrationRequirements"`
+	RegistrationRequirements []string          `json:"registrationRequirements"`
 	ProviderAuth             *providerAuthInfo `json:"providerAuth,omitempty"`
 }
 
@@ -205,6 +205,9 @@ func registerViaProviderAuth(ctx context.Context, client *http.Client, baseURL, 
 
 	if regResp.StatusCode != 200 {
 		body, _ := io.ReadAll(regResp.Body)
+		if registrationAlreadyExists(regResp.StatusCode, body) {
+			return nil
+		}
 		return fmt.Errorf("registration failed: %d %s", regResp.StatusCode, string(body))
 	}
 
@@ -301,10 +304,22 @@ func registerViaProofOfWork(ctx context.Context, client *http.Client, baseURL, d
 
 	if resp.StatusCode != 200 {
 		body, _ := io.ReadAll(resp.Body)
+		if registrationAlreadyExists(resp.StatusCode, body) {
+			return nil
+		}
 		return fmt.Errorf("registration failed: %d %s", resp.StatusCode, string(body))
 	}
 
 	return nil
+}
+
+func registrationAlreadyExists(statusCode int, body []byte) bool {
+	if statusCode == http.StatusConflict {
+		return true
+	}
+	msg := strings.ToLower(string(body))
+	return strings.Contains(msg, "already") &&
+		(strings.Contains(msg, "registered") || strings.Contains(msg, "exists"))
 }
 
 // hashHex computes SHA-256 of a string and returns it as lowercase hex.

--- a/internal/dwn/register_test.go
+++ b/internal/dwn/register_test.go
@@ -1,0 +1,27 @@
+package dwn
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestRegistrationAlreadyExists(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+	}{
+		{name: "conflict", status: http.StatusConflict, body: "anything", want: true},
+		{name: "already registered", status: http.StatusBadRequest, body: `{"error":"tenant already registered"}`, want: true},
+		{name: "already exists", status: http.StatusUnprocessableEntity, body: `{"error":"tenant already exists"}`, want: true},
+		{name: "bad request", status: http.StatusBadRequest, body: `{"error":"invalid did"}`, want: false},
+		{name: "rate limited", status: http.StatusTooManyRequests, body: `{"error":"rate limit exceeded"}`, want: false},
+	}
+
+	for _, tt := range tests {
+		if got := registrationAlreadyExists(tt.status, []byte(tt.body)); got != tt.want {
+			t.Fatalf("%s: registrationAlreadyExists() = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- register the local DID with the configured DWN before network create/join flows configure protocols or write join requests
- treat duplicate DWN tenant registration responses as success so repeated setup is idempotent
- update CLI integration coverage so registration happens through the real CLI path

Fixes #119

## Verification
- GOFLAGS=-mod=vendor go build ./...
- GOFLAGS=-mod=vendor go vet ./...
- GOFLAGS=-mod=vendor go test ./... -count=1 -race