### PR TITLE
Recover peer maps from encrypted node records

### DIFF
--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -1122,27 +1122,47 @@ func cmdPeerList(ctx context.Context, args []string, flagProfile string) error {
 	fmt.Println(strings.Repeat("-", 90))
 
 	for _, r := range records {
+		peerDID := r.Recipient
+		displayDID := peerDID
+		if displayDID == "" {
+			displayDID = "(unknown)"
+		}
+
 		var node struct {
 			MeshIP string `json:"meshIP"`
 			Label  string `json:"label"`
 		}
 		if err := r.Data().JSON(ctx, &node); err != nil {
 			// Data may not be inline (encrypted records need context key).
-			fmt.Printf("%-50s %-16s %-12s %s\n", truncate(r.Recipient, 50), "?", "(encrypted)", r.ProtocolPath)
+			fmt.Printf("%-50s %-16s %-12s %s\n",
+				truncate(displayDID, 50),
+				peerListMeshIP(ns.MeshCIDR, peerDID, ""),
+				"(encrypted)",
+				r.ProtocolPath)
 			continue
 		}
-		peerDID := r.Recipient
-		if peerDID == "" {
-			peerDID = "(unknown)"
-		}
 		fmt.Printf("%-50s %-16s %-12s %s\n",
-			truncate(peerDID, 50),
-			node.MeshIP,
+			truncate(displayDID, 50),
+			peerListMeshIP(ns.MeshCIDR, peerDID, node.MeshIP),
 			node.Label,
 			r.ProtocolPath)
 	}
 
 	return nil
+}
+
+func peerListMeshIP(meshCIDR string, peerDID string, recordMeshIP string) string {
+	if recordMeshIP != "" {
+		return recordMeshIP
+	}
+	if meshCIDR == "" || peerDID == "" {
+		return "?"
+	}
+	ip, err := mesh.AllocateMeshIP(meshCIDR, peerDID)
+	if err != nil {
+		return "?"
+	}
+	return ip.String()
 }
 
 // cmdPeerAdd adds a peer to the mesh network. This creates a node record
@@ -2452,6 +2472,7 @@ func fetchContextKey(ctx context.Context, identity *did.DID, ns *state.NetworkSt
 		AnchorEndpoint: ns.AnchorEndpoint,
 		AnchorDID:      ns.AnchorDID,
 		SelfDID:        identity.URI,
+		ContextID:      ns.NetworkRecordID,
 		Signer:         signer,
 	})
 }

--- a/cmd/meshd/main_test.go
+++ b/cmd/meshd/main_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/enboxorg/meshd/internal/did"
 	"github.com/enboxorg/meshd/internal/invite"
+	"github.com/enboxorg/meshd/internal/mesh"
 	"github.com/enboxorg/meshd/internal/profile"
 	"github.com/enboxorg/meshd/internal/state"
 )
@@ -39,6 +40,23 @@ func TestDefaultTUNName(t *testing.T) {
 	}
 	if got := defaultTUNName("linux"); got != "meshd0" {
 		t.Fatalf("defaultTUNName(linux) = %q, want meshd0", got)
+	}
+}
+
+func TestPeerListMeshIPFallsBackToDeterministicIP(t *testing.T) {
+	const peerDID = "did:jwk:test-peer"
+	want, err := mesh.AllocateMeshIP("10.200.0.0/16", peerDID)
+	if err != nil {
+		t.Fatalf("AllocateMeshIP: %v", err)
+	}
+	if got := peerListMeshIP("10.200.0.0/16", peerDID, ""); got != want.String() {
+		t.Fatalf("peerListMeshIP fallback = %q, want %q", got, want)
+	}
+	if got := peerListMeshIP("10.200.0.0/16", peerDID, "10.200.9.9"); got != "10.200.9.9" {
+		t.Fatalf("peerListMeshIP explicit = %q, want explicit record IP", got)
+	}
+	if got := peerListMeshIP("", peerDID, ""); got != "?" {
+		t.Fatalf("peerListMeshIP missing CIDR = %q, want ?", got)
 	}
 }
 

--- a/internal/control/control_test.go
+++ b/internal/control/control_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
+	"github.com/enboxorg/meshd/internal/meshaddr"
 	"github.com/enboxorg/meshd/pkg/dids/didjwk"
 )
 
@@ -126,6 +127,47 @@ func TestNewDWNClientProtocolRoleDefaults(t *testing.T) {
 			t.Fatalf("protocolRole = %q, want network/member", c.protocolRole)
 		}
 	})
+}
+
+func TestBuildMapResponseFallsBackToDeterministicMeshIP(t *testing.T) {
+	selfDID, _ := testDIDJWK(t)
+	peerDID, _ := testDIDJWK(t)
+	c := NewDWNClient("https://dwn.example", "did:example:anchor", "network-1", selfDID, nil)
+	c.network = &NetworkConfig{Name: "test", MeshCIDR: "10.200.0.0/16"}
+	c.nodes[selfDID] = &NodeRecord{DID: selfDID, RecordID: "self-record"}
+	c.nodes[peerDID] = &NodeRecord{DID: peerDID, RecordID: "peer-record"}
+
+	resp := c.buildMapResponse()
+	if resp == nil {
+		t.Fatal("buildMapResponse returned nil")
+	}
+	if resp.Node == nil {
+		t.Fatal("missing self node")
+	}
+	wantSelfIP, err := meshaddr.AllocateMeshIP("10.200.0.0/16", selfDID)
+	if err != nil {
+		t.Fatalf("AllocateMeshIP(self): %v", err)
+	}
+	if resp.Node.MeshIP != wantSelfIP {
+		t.Fatalf("self MeshIP = %s, want %s", resp.Node.MeshIP, wantSelfIP)
+	}
+	if len(resp.Node.AllowedIPs) != 1 || resp.Node.AllowedIPs[0].Addr() != wantSelfIP {
+		t.Fatalf("self AllowedIPs = %v, want %s/32", resp.Node.AllowedIPs, wantSelfIP)
+	}
+
+	if len(resp.Peers) != 1 {
+		t.Fatalf("peers = %d, want 1", len(resp.Peers))
+	}
+	wantPeerIP, err := meshaddr.AllocateMeshIP("10.200.0.0/16", peerDID)
+	if err != nil {
+		t.Fatalf("AllocateMeshIP(peer): %v", err)
+	}
+	if resp.Peers[0].MeshIP != wantPeerIP {
+		t.Fatalf("peer MeshIP = %s, want %s", resp.Peers[0].MeshIP, wantPeerIP)
+	}
+	if len(resp.Peers[0].AllowedIPs) != 1 || resp.Peers[0].AllowedIPs[0].Addr() != wantPeerIP {
+		t.Fatalf("peer AllowedIPs = %v, want %s/32", resp.Peers[0].AllowedIPs, wantPeerIP)
+	}
 }
 
 func TestNodeRecordToNode(t *testing.T) {
@@ -777,6 +819,50 @@ func TestBuildFilterRules_WithACLPolicy(t *testing.T) {
 	}
 	if rules[1].DstPorts[2].Ports != (PortRange{8000, 9000}) {
 		t.Errorf("port[2] = %+v", rules[1].DstPorts[2].Ports)
+	}
+}
+
+func TestBuildFilterRules_FallbackMeshIP(t *testing.T) {
+	did1, _ := testDIDJWK(t)
+	did2, _ := testDIDJWK(t)
+	wantSrc, err := meshaddr.AllocateMeshIP("10.200.0.0/16", did1)
+	if err != nil {
+		t.Fatalf("AllocateMeshIP source: %v", err)
+	}
+	wantDst, err := meshaddr.AllocateMeshIP("10.200.0.0/16", did2)
+	if err != nil {
+		t.Fatalf("AllocateMeshIP destination: %v", err)
+	}
+
+	c := &DWNClient{
+		network: &NetworkConfig{MeshCIDR: "10.200.0.0/16"},
+		nodes: map[string]*NodeRecord{
+			did1: {DID: did1, RecordID: "node-1"},
+			did2: {DID: did2, RecordID: "node-2"},
+		},
+		acl: &ACLPolicyData{
+			Version:       1,
+			DefaultAction: "drop",
+			Rules: []ACLRule{
+				{
+					Action:   "accept",
+					Src:      []string{did1},
+					Dst:      []string{did2},
+					DstPorts: []string{"22"},
+				},
+			},
+		},
+	}
+
+	rules := c.buildFilterRules()
+	if len(rules) != 1 {
+		t.Fatalf("want 1 rule, got %d", len(rules))
+	}
+	if len(rules[0].SrcIPs) != 1 || rules[0].SrcIPs[0] != wantSrc.String() {
+		t.Fatalf("SrcIPs = %v, want %s", rules[0].SrcIPs, wantSrc)
+	}
+	if len(rules[0].DstPorts) != 1 || rules[0].DstPorts[0].IP != wantDst.String() {
+		t.Fatalf("DstPorts = %v, want destination %s", rules[0].DstPorts, wantDst)
 	}
 }
 

--- a/internal/control/dwnclient.go
+++ b/internal/control/dwnclient.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/enboxorg/meshd/internal/dwn"
 	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
+	"github.com/enboxorg/meshd/internal/meshaddr"
 	"github.com/enboxorg/meshd/pkg/dids/didjwk"
 	"github.com/enboxorg/meshd/protocols"
 )
@@ -655,12 +656,11 @@ func (c *DWNClient) buildMapResponse() *MapResponse {
 		rec := c.nodes[did]
 		node := nodeRecordToNode(nodeID, did, rec)
 		nodeID++
+		c.applyFallbackMeshIP(node)
 
-		// Skip peers whose node records could not be decrypted. Without
-		// a mesh IP the peer has no addresses and WireGuard cannot route
-		// traffic to it. These "ghost" nodes are still tracked in c.nodes
-		// for auto key delivery purposes, but should not be injected
-		// into the network map.
+		// Skip peers whose mesh IP cannot be read or derived. These
+		// "ghost" nodes are still tracked in c.nodes for auto key delivery
+		// purposes, but should not be injected into the network map.
 		if did != c.selfDID && !node.MeshIP.IsValid() {
 			c.logger.Debug("skipping undecryptable peer in network map",
 				slog.String("did", did),
@@ -688,6 +688,29 @@ func (c *DWNClient) buildMapResponse() *MapResponse {
 	}
 
 	return resp
+}
+
+func (c *DWNClient) applyFallbackMeshIP(node *Node) {
+	if node == nil || node.MeshIP.IsValid() || c.network == nil || c.network.MeshCIDR == "" {
+		return
+	}
+	ip, err := meshaddr.AllocateMeshIP(c.network.MeshCIDR, node.DID)
+	if err != nil {
+		c.logger.Debug("fallback mesh IP allocation failed",
+			slog.String("did", node.DID),
+			slog.String("cidr", c.network.MeshCIDR),
+			slog.Any("error", err),
+		)
+		return
+	}
+	node.MeshIP = ip
+	if len(node.AllowedIPs) == 0 {
+		node.AllowedIPs = []netip.Prefix{netip.PrefixFrom(ip, ip.BitLen())}
+	}
+	c.logger.Debug("using deterministic fallback mesh IP",
+		slog.String("did", node.DID),
+		slog.String("ip", ip.String()),
+	)
 }
 
 func nodeRecordToNode(id int64, did string, rec *NodeRecord) *Node {
@@ -880,8 +903,14 @@ func (c *DWNClient) buildFilterRules() []FilterRule {
 	// Build DID → mesh IP lookup from the current node map.
 	didToIP := make(map[string]string, len(c.nodes))
 	for did, node := range c.nodes {
-		if node.MeshIP != "" {
-			didToIP[did] = node.MeshIP
+		ip := node.MeshIP
+		if ip == "" && c.network != nil && c.network.MeshCIDR != "" {
+			if fallbackIP, err := meshaddr.AllocateMeshIP(c.network.MeshCIDR, did); err == nil {
+				ip = fallbackIP.String()
+			}
+		}
+		if ip != "" {
+			didToIP[did] = ip
 		}
 	}
 

--- a/internal/engine/connectivity_test.go
+++ b/internal/engine/connectivity_test.go
@@ -301,6 +301,7 @@ func TestTwoNodeConnectivity(t *testing.T) {
 		AnchorEndpoint: endpoint,
 		AnchorDID:      nodeA.identity.URI,
 		SelfDID:        nodeB.identity.URI,
+		ContextID:      networkRecordID,
 		Signer:         nodeB.signer,
 	})
 	if err != nil {
@@ -777,6 +778,7 @@ func TestTwoNodeNetworkMapDiscovery(t *testing.T) {
 		AnchorEndpoint: endpoint,
 		AnchorDID:      nodeA.identity.URI,
 		SelfDID:        nodeB.identity.URI,
+		ContextID:      networkRecordID,
 		Signer:         nodeB.signer,
 	})
 	if err != nil {

--- a/internal/mesh/ipalloc.go
+++ b/internal/mesh/ipalloc.go
@@ -1,10 +1,9 @@
 package mesh
 
 import (
-	"crypto/sha256"
-	"encoding/binary"
-	"fmt"
 	"net/netip"
+
+	"github.com/enboxorg/meshd/internal/meshaddr"
 )
 
 // AllocateMeshIP deterministically allocates a mesh IP address from a CIDR
@@ -21,40 +20,5 @@ import (
 // 16-bit host space and SHA-256 distribution. For production use, the
 // network creator should maintain a registry.
 func AllocateMeshIP(cidr string, didURI string) (netip.Addr, error) {
-	prefix, err := netip.ParsePrefix(cidr)
-	if err != nil {
-		return netip.Addr{}, fmt.Errorf("parsing CIDR %q: %w", cidr, err)
-	}
-	prefix = prefix.Masked() // Canonicalize: zero host bits in the base address.
-
-	if !prefix.Addr().Is4() {
-		return netip.Addr{}, fmt.Errorf("only IPv4 CIDRs are supported, got %s", cidr)
-	}
-
-	// Calculate host space size.
-	bits := prefix.Bits()
-	hostBits := 32 - bits
-	if hostBits < 2 {
-		return netip.Addr{}, fmt.Errorf("CIDR %s has too few host bits (%d)", cidr, hostBits)
-	}
-
-	// Number of usable addresses: 2^hostBits - 3 (exclude network, broadcast, and service IP).
-	maxHosts := uint32(1<<hostBits) - 3
-
-	// Hash the DID to get a deterministic host offset.
-	hash := sha256.Sum256([]byte(didURI))
-	hostOffset := binary.BigEndian.Uint32(hash[:4]) % maxHosts
-
-	// Host offset is 0-based, but we start from .2 (skip network address and service IP).
-	hostNum := hostOffset + 2
-
-	// Add the host number to the network base address.
-	base := prefix.Addr().As4()
-	baseInt := binary.BigEndian.Uint32(base[:])
-	allocatedInt := baseInt + hostNum
-
-	var result [4]byte
-	binary.BigEndian.PutUint32(result[:], allocatedInt)
-
-	return netip.AddrFrom4(result), nil
+	return meshaddr.AllocateMeshIP(cidr, didURI)
 }

--- a/internal/mesh/keydelivery.go
+++ b/internal/mesh/keydelivery.go
@@ -14,8 +14,9 @@ import (
 // for the DWN Key Delivery Protocol.
 //
 // When a network owner creates a network or adds a node, they derive a
-// Protocol Context key for the network context and deliver it (encrypted)
-// to each participant. Participants can then decrypt records in that context.
+// Protocol Context key for the network context and deliver it to each
+// participant through an access-controlled contextKey record. Participants
+// can then decrypt records in that context.
 type KeyDeliveryManager struct {
 	// Endpoint is the DWN server URL.
 	Endpoint string
@@ -46,10 +47,11 @@ type DeliverContextKeyParams struct {
 }
 
 // DeliverContextKey derives the Protocol Context key for a context and
-// writes an encrypted contextKey record to the anchor's DWN.
+// writes a contextKey record to the anchor's DWN.
 //
-// The contextKey record is encrypted with the Protocol Path scheme for
-// the key-delivery protocol, so only the recipient can decrypt it.
+// The contextKey record payload is plaintext JSON, but protocol authorization
+// only allows the addressed recipient to read it. It is not Protocol Context
+// encrypted, because that would create a circular key exchange dependency.
 //
 // This MUST be called by the DWN owner (anchor) who has the root private key.
 func (m *KeyDeliveryManager) DeliverContextKey(ctx context.Context, params DeliverContextKeyParams) error {
@@ -120,9 +122,12 @@ type FetchContextKeyParams struct {
 	// SelfDID is this node's DID (the recipient).
 	SelfDID string
 
+	// ContextID is the network root context ID that the key must decrypt.
+	// When set, FetchContextKey ignores delivered keys for other contexts.
+	ContextID string
+
 	// Signer signs query/read messages.
 	Signer *dwn.Signer
-
 }
 
 // FetchContextKey queries the anchor DWN for a contextKey record addressed
@@ -158,34 +163,59 @@ func FetchContextKey(ctx context.Context, params FetchContextKeyParams) (*dwncry
 	if status.Code != 200 {
 		return nil, fmt.Errorf("querying contextKey: unexpected status %d %s", status.Code, status.Detail)
 	}
-	if len(records) == 0 {
-		return nil, nil // No matching record found.
+	for _, queryRecord := range records {
+		// Query results do not include data; read each candidate newest-first
+		// and return the first payload for the requested network context.
+		record, readStatus, err := api.Read(ctx, params.AnchorDID, dwn.RecordsFilter{
+			RecordID: queryRecord.ID,
+		}, "")
+		if err != nil {
+			return nil, fmt.Errorf("reading contextKey record: %w", err)
+		}
+		if readStatus.Code != 200 || record == nil {
+			return nil, fmt.Errorf("contextKey read failed: %d %s", readStatus.Code, readStatus.Detail)
+		}
+
+		// Get the record data. For RecordsRead, data comes from the HTTP body
+		// (stored as rawData) or from encodedData (for small inline payloads).
+		// contextKey records are written unencrypted (access controlled by $actions),
+		// so the data is plaintext JSON.
+		dataBytes, err := record.Data().Bytes(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("reading contextKey data: %w", err)
+		}
+
+		key, err := dwncrypto.ParseDerivedPrivateJwk(dataBytes)
+		if err != nil {
+			return nil, err
+		}
+		if !contextKeyMatchesContext(key, params.ContextID) {
+			continue
+		}
+		return key, nil
 	}
 
-	// Read the first (most recent) match to get the full data.
-	record, readStatus, err := api.Read(ctx, params.AnchorDID, dwn.RecordsFilter{
-		RecordID: records[0].ID,
-	}, "")
-	if err != nil {
-		return nil, fmt.Errorf("reading contextKey record: %w", err)
-	}
-	if readStatus.Code != 200 || record == nil {
-		return nil, fmt.Errorf("contextKey read failed: %d %s", readStatus.Code, readStatus.Detail)
-	}
-
-	// Get the record data. For RecordsRead, data comes from the HTTP body
-	// (stored as rawData) or from encodedData (for small inline payloads).
-	// contextKey records are written unencrypted (access controlled by $actions),
-	// so the data is plaintext JSON.
-	dataBytes, err := record.Data().Bytes(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("reading contextKey data: %w", err)
-	}
-
-	return dwncrypto.ParseDerivedPrivateJwk(dataBytes)
+	return nil, nil // No matching record found.
 }
 
-
+func contextKeyMatchesContext(key *dwncrypto.DerivedPrivateJwk, contextID string) bool {
+	if contextID == "" {
+		return true
+	}
+	if key == nil || key.DerivationScheme != dwncrypto.DerivationSchemeProtocolContext {
+		return false
+	}
+	expectedPath := dwncrypto.BuildProtocolContextDerivation(contextID)
+	if len(key.DerivationPath) != len(expectedPath) {
+		return false
+	}
+	for i := range expectedPath {
+		if key.DerivationPath[i] != expectedPath[i] {
+			return false
+		}
+	}
+	return true
+}
 
 // EnsureKeyDeliveryProtocol installs the key-delivery protocol on the
 // given DWN with $encryption directives injected.

--- a/internal/mesh/keydelivery_test.go
+++ b/internal/mesh/keydelivery_test.go
@@ -1,0 +1,63 @@
+package mesh
+
+import (
+	"testing"
+
+	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
+)
+
+func TestContextKeyMatchesContext(t *testing.T) {
+	keyForNetwork := &dwncrypto.DerivedPrivateJwk{
+		DerivationScheme: dwncrypto.DerivationSchemeProtocolContext,
+		DerivationPath:   dwncrypto.BuildProtocolContextDerivation("network-1"),
+	}
+
+	tests := []struct {
+		name      string
+		key       *dwncrypto.DerivedPrivateJwk
+		contextID string
+		want      bool
+	}{
+		{
+			name:      "empty expected context accepts key",
+			key:       keyForNetwork,
+			contextID: "",
+			want:      true,
+		},
+		{
+			name:      "matching protocol context",
+			key:       keyForNetwork,
+			contextID: "network-1",
+			want:      true,
+		},
+		{
+			name:      "different network context",
+			key:       keyForNetwork,
+			contextID: "network-2",
+			want:      false,
+		},
+		{
+			name: "wrong derivation scheme",
+			key: &dwncrypto.DerivedPrivateJwk{
+				DerivationScheme: dwncrypto.DerivationSchemeProtocolPath,
+				DerivationPath:   []string{dwncrypto.DerivationSchemeProtocolPath, "protocol", "contextKey"},
+			},
+			contextID: "network-1",
+			want:      false,
+		},
+		{
+			name:      "nil key",
+			key:       nil,
+			contextID: "network-1",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := contextKeyMatchesContext(tt.key, tt.contextID); got != tt.want {
+				t.Fatalf("contextKeyMatchesContext() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/meshaddr/ipalloc.go
+++ b/internal/meshaddr/ipalloc.go
@@ -1,0 +1,48 @@
+// Package meshaddr contains address allocation helpers shared by the mesh
+// orchestration and DWN control layers.
+package meshaddr
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"net/netip"
+)
+
+// AllocateMeshIP deterministically allocates a mesh IP address from a CIDR
+// based on the node's DID URI.
+//
+// The allocation uses SHA-256(DID) to pick a host address within the CIDR,
+// avoiding the network address (.0), broadcast address, and the meshnet
+// service IP (10.200.0.1) which is reserved by the networking engine.
+func AllocateMeshIP(cidr string, didURI string) (netip.Addr, error) {
+	prefix, err := netip.ParsePrefix(cidr)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("parsing CIDR %q: %w", cidr, err)
+	}
+	prefix = prefix.Masked()
+
+	if !prefix.Addr().Is4() {
+		return netip.Addr{}, fmt.Errorf("only IPv4 CIDRs are supported, got %s", cidr)
+	}
+
+	bits := prefix.Bits()
+	hostBits := 32 - bits
+	if hostBits < 2 {
+		return netip.Addr{}, fmt.Errorf("CIDR %s has too few host bits (%d)", cidr, hostBits)
+	}
+
+	maxHosts := uint32(1<<hostBits) - 3
+	hash := sha256.Sum256([]byte(didURI))
+	hostOffset := binary.BigEndian.Uint32(hash[:4]) % maxHosts
+	hostNum := hostOffset + 2
+
+	base := prefix.Addr().As4()
+	baseInt := binary.BigEndian.Uint32(base[:])
+	allocatedInt := baseInt + hostNum
+
+	var result [4]byte
+	binary.BigEndian.PutUint32(result[:], allocatedInt)
+
+	return netip.AddrFrom4(result), nil
+}

--- a/internal/meshaddr/ipalloc_test.go
+++ b/internal/meshaddr/ipalloc_test.go
@@ -1,0 +1,30 @@
+package meshaddr
+
+import "testing"
+
+func TestAllocateMeshIP(t *testing.T) {
+	ip, err := AllocateMeshIP("10.200.0.0/16", "did:jwk:test")
+	if err != nil {
+		t.Fatalf("AllocateMeshIP: %v", err)
+	}
+	if !ip.Is4() {
+		t.Fatalf("IP = %s, want IPv4", ip)
+	}
+	if ip.String() == "10.200.0.0" || ip.String() == "10.200.0.1" || ip.String() == "10.200.255.255" {
+		t.Fatalf("IP = %s, want usable host address", ip)
+	}
+}
+
+func TestAllocateMeshIPDeterministic(t *testing.T) {
+	a, err := AllocateMeshIP("10.200.0.0/16", "did:jwk:same")
+	if err != nil {
+		t.Fatalf("AllocateMeshIP first: %v", err)
+	}
+	b, err := AllocateMeshIP("10.200.0.0/16", "did:jwk:same")
+	if err != nil {
+		t.Fatalf("AllocateMeshIP second: %v", err)
+	}
+	if a != b {
+		t.Fatalf("AllocateMeshIP not deterministic: %s != %s", a, b)
+	}
+}


### PR DESCRIPTION
## Summary
- derive deterministic mesh IPs from DID/CIDR when encrypted node records cannot be decrypted
- use the same fallback for peer-list display and DID-based ACL expansion
- filter delivered context keys by network context before caching/using them

Fixes #122.

## Validation
- GOFLAGS=-mod=vendor go build ./...
- GOFLAGS=-mod=vendor go vet ./...
- GOFLAGS=-mod=vendor go test ./... -count=1 -race

## Notes
The web-wallet and dapp-demo patterns reinforce this direction: encrypted access is treated as scoped session/key state, while app surfaces remain explicit about missing grants or reapproval. This PR keeps the dataplane usable when encrypted metadata is temporarily unreadable, while making context-key selection stricter.