### PR TITLE
Fix TUN route reconciliation

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -52,8 +52,9 @@ type Engine struct {
 
 	// tunDev is the real TUN device when running in TUN mode.
 	// nil in userspace-only (netstack) mode.
-	tunDev  tun.Device
-	tunName string
+	tunDev   tun.Device
+	tunName  string
+	osRouter *synchronizedRouter
 
 	mu      sync.Mutex
 	running bool
@@ -253,7 +254,8 @@ func New(cfg Config) (*Engine, error) {
 	//      the netstack dialer can communicate through the mesh tunnel.
 	var tunDev tun.Device
 	var tunName string
-	var osRouter router.Router
+	var osRouter *synchronizedRouter
+	var wgRouter router.Router
 	userspaceOnly := true
 
 	if cfg.TUNName != "" {
@@ -273,14 +275,15 @@ func New(cfg Config) (*Engine, error) {
 			// TUN interface. Unsupported platforms return nil and fall back
 			// to the fake router (no OS routing).
 			if rtr := newOSRouter(logf, tunName); rtr != nil {
-				osRouter = rtr
+				osRouter = newSynchronizedRouter(rtr)
+				wgRouter = osRouter
 			}
 		}
 	}
 
 	wgConfig := wgengine.Config{
 		Tun:           tunDev, // nil = fake TUN (userspace only)
-		Router:        osRouter,
+		Router:        wgRouter,
 		EventBus:      sys.Bus.Get(),
 		ListenPort:    cfg.ListenPort,
 		NetMon:        nm,
@@ -424,6 +427,7 @@ func New(cfg Config) (*Engine, error) {
 		subWatcher: subWatcher,
 		tunDev:     tunDev,
 		tunName:    tunName,
+		osRouter:   osRouter,
 		logger:     l,
 	}, nil
 }
@@ -443,7 +447,7 @@ func (e *Engine) Start(ctx context.Context) error {
 		return fmt.Errorf("engine already running")
 	}
 
-	_, cancel := context.WithCancel(ctx)
+	runCtx, cancel := context.WithCancel(ctx)
 	e.cancel = cancel
 
 	e.logger.InfoContext(ctx, "starting meshd engine")
@@ -457,13 +461,15 @@ func (e *Engine) Start(ctx context.Context) error {
 		cancel()
 		return fmt.Errorf("starting backend: %w", err)
 	}
+	e.waitForInitialTUNRoutes(runCtx, 5*time.Second)
+	go e.runTUNRouteReconciler(runCtx)
 
 	// Start the subscription watcher for real-time updates.
 	// This is best-effort: if the DWN server doesn't support WebSocket
 	// subscriptions, we fall back to polling only. The watcher will
 	// auto-reconnect on transient failures.
 	if e.subWatcher != nil {
-		if err := e.subWatcher.Start(ctx); err != nil {
+		if err := e.subWatcher.Start(runCtx); err != nil {
 			e.logger.Warn("failed to start subscription watcher, falling back to polling",
 				slog.Any("error", err),
 			)

--- a/internal/engine/router_routes_test.go
+++ b/internal/engine/router_routes_test.go
@@ -5,6 +5,9 @@ import (
 	"net/netip"
 	"reflect"
 	"testing"
+
+	"github.com/enboxorg/meshnet/tailcfg"
+	"github.com/enboxorg/meshnet/types/netmap"
 )
 
 func TestTunnelRoutesExcludesLocalRoutes(t *testing.T) {
@@ -14,6 +17,52 @@ func TestTunnelRoutesExcludesLocalRoutes(t *testing.T) {
 	want := []netip.Prefix{peer}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("tunnelRoutes() = %v, want %v", got, want)
+	}
+}
+
+func TestRouterConfigFromNetMap(t *testing.T) {
+	self := &tailcfg.Node{
+		Addresses: []netip.Prefix{
+			netip.MustParsePrefix("10.200.26.192/32"),
+		},
+	}
+	peerA := &tailcfg.Node{
+		Addresses: []netip.Prefix{
+			netip.MustParsePrefix("10.200.43.197/32"),
+		},
+		AllowedIPs: []netip.Prefix{
+			netip.MustParsePrefix("10.200.43.197/32"),
+			netip.MustParsePrefix("0.0.0.0/0"),
+		},
+	}
+	peerB := &tailcfg.Node{
+		Addresses: []netip.Prefix{
+			netip.MustParsePrefix("10.200.99.7/32"),
+		},
+	}
+
+	cfg, ok := routerConfigFromNetMap(&netmap.NetworkMap{
+		SelfNode: self.View(),
+		Peers: []tailcfg.NodeView{
+			peerB.View(),
+			peerA.View(),
+		},
+	})
+	if !ok {
+		t.Fatal("routerConfigFromNetMap returned !ok")
+	}
+
+	wantAddrs := []netip.Prefix{netip.MustParsePrefix("10.200.26.192/32")}
+	if !reflect.DeepEqual(cfg.LocalAddrs, wantAddrs) {
+		t.Fatalf("LocalAddrs = %v, want %v", cfg.LocalAddrs, wantAddrs)
+	}
+
+	wantRoutes := []netip.Prefix{
+		netip.MustParsePrefix("10.200.43.197/32"),
+		netip.MustParsePrefix("10.200.99.7/32"),
+	}
+	if !reflect.DeepEqual(cfg.Routes, wantRoutes) {
+		t.Fatalf("Routes = %v, want %v", cfg.Routes, wantRoutes)
 	}
 }
 

--- a/internal/engine/router_sync.go
+++ b/internal/engine/router_sync.go
@@ -1,0 +1,37 @@
+package engine
+
+import (
+	"sync"
+
+	"github.com/enboxorg/meshnet/wgengine/router"
+)
+
+type synchronizedRouter struct {
+	mu sync.Mutex
+	r  router.Router
+}
+
+func newSynchronizedRouter(r router.Router) *synchronizedRouter {
+	if r == nil {
+		return nil
+	}
+	return &synchronizedRouter{r: r}
+}
+
+func (r *synchronizedRouter) Up() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.r.Up()
+}
+
+func (r *synchronizedRouter) Set(cfg *router.Config) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.r.Set(cfg)
+}
+
+func (r *synchronizedRouter) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.r.Close()
+}

--- a/internal/engine/tun_routes.go
+++ b/internal/engine/tun_routes.go
@@ -1,0 +1,141 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/netip"
+	"sort"
+	"time"
+
+	"github.com/enboxorg/meshnet/types/netmap"
+	"github.com/enboxorg/meshnet/wgengine/router"
+)
+
+const tunRouteReconcileInterval = 5 * time.Second
+
+func routerConfigFromNetMap(nm *netmap.NetworkMap) (*router.Config, bool) {
+	if nm == nil {
+		return nil, false
+	}
+
+	localAddrs := nm.GetAddresses().AsSlice()
+	if len(localAddrs) == 0 {
+		return nil, false
+	}
+
+	local := make(map[netip.Prefix]bool, len(localAddrs))
+	for _, p := range localAddrs {
+		local[p.Masked()] = true
+	}
+
+	routeSet := make(map[netip.Prefix]bool)
+	addRoute := func(p netip.Prefix) {
+		if !p.IsValid() || p.Bits() == 0 {
+			return
+		}
+		p = p.Masked()
+		if local[p] {
+			return
+		}
+		routeSet[p] = true
+	}
+
+	for _, peer := range nm.Peers {
+		allowed := peer.AllowedIPs()
+		if allowed.Len() > 0 {
+			for _, p := range allowed.All() {
+				addRoute(p)
+			}
+			continue
+		}
+		for _, p := range peer.Addresses().All() {
+			addRoute(p)
+		}
+	}
+
+	routes := make([]netip.Prefix, 0, len(routeSet))
+	for p := range routeSet {
+		routes = append(routes, p)
+	}
+	sort.Slice(routes, func(i, j int) bool {
+		return routes[i].String() < routes[j].String()
+	})
+
+	return &router.Config{
+		LocalAddrs: localAddrs,
+		Routes:     routes,
+	}, true
+}
+
+func (e *Engine) reconcileTUNRoutes(ctx context.Context) error {
+	if e.osRouter == nil {
+		return nil
+	}
+	nm := e.backend.NetMap()
+	cfg, ok := routerConfigFromNetMap(nm)
+	if !ok {
+		return fmt.Errorf("no usable network map addresses yet")
+	}
+	if err := e.osRouter.Set(cfg); err != nil {
+		return err
+	}
+	e.logger.DebugContext(ctx, "TUN routes reconciled",
+		slog.Int("localAddrs", len(cfg.LocalAddrs)),
+		slog.Int("routes", len(cfg.Routes)),
+	)
+	return nil
+}
+
+func (e *Engine) waitForInitialTUNRoutes(ctx context.Context, timeout time.Duration) {
+	if e.osRouter == nil {
+		return
+	}
+
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	var lastErr error
+	for {
+		if err := e.reconcileTUNRoutes(ctx); err == nil {
+			return
+		} else {
+			lastErr = err
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-deadline.C:
+			e.logger.WarnContext(ctx, "TUN routes not ready yet; will keep retrying in background",
+				slog.Any("error", lastErr),
+			)
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func (e *Engine) runTUNRouteReconciler(ctx context.Context) {
+	if e.osRouter == nil {
+		return
+	}
+
+	ticker := time.NewTicker(tunRouteReconcileInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := e.reconcileTUNRoutes(ctx); err != nil {
+				e.logger.DebugContext(ctx, "TUN route reconcile skipped",
+					slog.Any("error", err),
+				)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a synchronized OS router wrapper so meshnet and meshd route reconciliation cannot race
- derive TUN local addresses and per-peer routes from the live netmap and keep reconciling them while the daemon runs
- cover the two-peer /32 route case seen in Mac/Linux testing

## Why
Live Linux testing showed `meshd0` existed and the daemon was running, but the interface had no `10.200` address and no peer route, so pings were leaving via the LAN/default route instead of the mesh TUN.

## Tests
- `go test ./internal/engine`
- `go test ./cmd/meshd`
- `go test ./...`
- `go build ./cmd/meshd`