### PR TITLE
Label the local device in peer list

### DIFF
--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -1128,8 +1128,8 @@ func cmdPeerList(ctx context.Context, args []string, flagProfile string) error {
 	}
 
 	fmt.Printf("Peers in %q:\n", ns.NetworkName)
-	fmt.Printf("%-50s %-16s %-12s %s\n", "DID", "MESH IP", "LABEL", "PATH")
-	fmt.Println(strings.Repeat("-", 90))
+	fmt.Printf("%-50s %-16s %-12s %-12s %s\n", "DID", "MESH IP", "DEVICE", "LABEL", "PATH")
+	fmt.Println(strings.Repeat("-", 105))
 
 	for _, r := range records {
 		peerDID := r.Recipient
@@ -1137,6 +1137,7 @@ func cmdPeerList(ctx context.Context, args []string, flagProfile string) error {
 		if displayDID == "" {
 			displayDID = "(unknown)"
 		}
+		device := peerListDevice(peerDID, identity.URI)
 
 		var node struct {
 			MeshIP string `json:"meshIP"`
@@ -1144,21 +1145,30 @@ func cmdPeerList(ctx context.Context, args []string, flagProfile string) error {
 		}
 		if err := r.Data().JSON(ctx, &node); err != nil {
 			// Data may not be inline (encrypted records need context key).
-			fmt.Printf("%-50s %-16s %-12s %s\n",
+			fmt.Printf("%-50s %-16s %-12s %-12s %s\n",
 				truncate(displayDID, 50),
 				peerListMeshIP(ns.MeshCIDR, peerDID, ""),
+				device,
 				"(encrypted)",
 				r.ProtocolPath)
 			continue
 		}
-		fmt.Printf("%-50s %-16s %-12s %s\n",
+		fmt.Printf("%-50s %-16s %-12s %-12s %s\n",
 			truncate(displayDID, 50),
 			peerListMeshIP(ns.MeshCIDR, peerDID, node.MeshIP),
+			device,
 			node.Label,
 			r.ProtocolPath)
 	}
 
 	return nil
+}
+
+func peerListDevice(peerDID string, selfDID string) string {
+	if peerDID != "" && peerDID == selfDID {
+		return "this device"
+	}
+	return "peer"
 }
 
 func peerListMeshIP(meshCIDR string, peerDID string, recordMeshIP string) string {

--- a/cmd/meshd/main_test.go
+++ b/cmd/meshd/main_test.go
@@ -61,6 +61,19 @@ func TestPeerListMeshIPFallsBackToDeterministicIP(t *testing.T) {
 	}
 }
 
+func TestPeerListDeviceLabelsSelf(t *testing.T) {
+	const selfDID = "did:jwk:self"
+	if got := peerListDevice(selfDID, selfDID); got != "this device" {
+		t.Fatalf("peerListDevice(self) = %q, want this device", got)
+	}
+	if got := peerListDevice("did:jwk:peer", selfDID); got != "peer" {
+		t.Fatalf("peerListDevice(peer) = %q, want peer", got)
+	}
+	if got := peerListDevice("", selfDID); got != "peer" {
+		t.Fatalf("peerListDevice(empty) = %q, want peer", got)
+	}
+}
+
 func TestParseUpFlagsTunUsesPlatformDefault(t *testing.T) {
 	flags := parseUpFlags([]string{"--tun"})
 	want := defaultTUNName(runtime.GOOS)


### PR DESCRIPTION
## Summary
- add a DEVICE column to `meshd peer list`
- render the current node as `this device` and other rows as `peer`
- keep the self row visible so users can still see their assigned mesh IP

## Testing
- `go test ./cmd/meshd`
- `go test ./...`
