### PR TITLE
feat: add dashboard-owned admin flow

### DIFF
--- a/.github/workflows/admin-dapp.yml
+++ b/.github/workflows/admin-dapp.yml
@@ -1,0 +1,89 @@
+name: meshd Admin DApp
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "admin-dapp/**"
+      - "protocols/**"
+      - ".github/workflows/admin-dapp.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "admin-dapp/**"
+      - "protocols/**"
+      - ".github/workflows/admin-dapp.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: admin-dapp
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.19.0"
+          cache: npm
+          cache-dependency-path: admin-dapp/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      deployments: write
+    environment:
+      name: meshd-admin
+      url: https://meshd-admin.pages.dev
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.19.0"
+          cache: npm
+          cache-dependency-path: admin-dapp/package-lock.json
+
+      - name: Install dependencies
+        working-directory: admin-dapp
+        run: npm ci
+
+      - name: Test
+        working-directory: admin-dapp
+        run: npm test
+
+      - name: Build
+        working-directory: admin-dapp
+        run: npm run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4"
+          command: pages deploy admin-dapp/dist --project-name=meshd-admin --branch=main
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ Thumbs.db
 
 # Build
 /dist/
+admin-dapp/dist/
+admin-dapp/node_modules/
 
 # Config (may contain keys)
 *.key

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -214,15 +214,91 @@ You'd invite someone into your mesh when:
 
 ## Technical Design
 
+### Identity and Ownership Model
+
+meshd should keep wallet identity, delegated authority, and node identity as
+separate concepts.
+
+| Concept | What it is | Where the private key lives | What it controls |
+| ------- | ---------- | --------------------------- | ---------------- |
+| Owner DID | The user, wallet, or organization identity; represented by the DWN `network/member` role | Wallet or local vault | Mesh ownership, membership, revocation, policy |
+| Node DID | A specific installed device | Local meshd vault on that device | WireGuard identity, endpoint updates, node liveness |
+| Delegate DID | A local session/control identity associated with one node | Local meshd delegate vault on that device | DWN operations authorized by wallet grants; not WireGuard or node liveness |
+| Permission grant | Wallet-issued authority for a delegate DID, with legacy node-DID grant fallback | Stored as DWN permission records | What the local delegate may do on behalf of the member DID |
+
+The wallet should not generate the device's node DID for normal CLI use. The
+CLI creates and stores the node DID and a separate delegate DID locally, then
+asks the wallet to authorize the delegate for that node. This preserves a few
+important properties:
+
+- A server install can generate its identity without a browser.
+- A pasted wallet response does not need to contain private key material.
+- The wallet can revoke or rotate local authority without rotating the
+  wallet/member DID or the node DID.
+- Device records can be audited as node DID activity owned by a member DID.
+- A compromised node is scoped to grants and mesh records, not the wallet key.
+
+The connection flow is:
+
+1. `meshd auth connect` creates a local node DID and delegate DID if needed.
+2. The CLI signs a challenge with the node DID, binds the delegate DID into the
+   signed payload, and emits a `meshd://connect` request.
+3. The wallet verifies the node proof, lets the user pick the owning member
+   DID, then writes permission grants for the delegate DID.
+4. The CLI imports the wallet response and stores the member DID, node DID,
+   delegate DID, grant records, wallet origin, and any wallet-provided network
+   context keys in encrypted local state.
+5. Mesh commands target the member DID's DWN, sign grant-backed DWN operations
+   as the delegate DID, and continue using the node DID for WireGuard identity,
+   key delivery, and node membership proofs.
+
+Local-vault profiles are still valid. In that mode the member DID and node DID
+are the same value, so no permission grant is needed.
+
+For wallet-owned meshes, the CLI creates a signed `meshd://network-create`
+request and opens the wallet/admin surface to create the network root under
+the wallet DID. The wallet verifies the node proof, writes the network,
+wallet/member, and member-owned node records, derives and delivers the
+Protocol Context key, issues grants to the delegate DID, and returns the response
+to the CLI over either a short-lived localhost callback or a node DID
+wallet-response record on a DWN endpoint. The response endpoint and token are
+included in the signed node request so they cannot be redirected without
+invalidating the proof. JSON copy/import remains the final fallback. The node
+can hold a local delegate, grant references, and context keys after approval,
+but it cannot derive new
+wallet-owned Protocol Context keys without wallet participation.
+
+Wallet responses should name the wallet/member identity as `ownerDID` and CLI
+device material as node-owned material: `nodeContextKeys` and
+`nodeMultiPartyProtocols`. Older `connectedDid` and `delegateContextKeys`
+responses remain accepted as compatibility fallbacks. New responses should also
+echo the authorized `delegateDid` so the CLI can verify that the wallet granted
+the local delegate generated for this node.
+
+Wallet-created networks should place even the owner's first device under a
+member record:
+
+```
+network
+  member recipient = wallet/member DID
+    node recipient = local node DID
+```
+
+Top-level `network/node` records remain readable and removable for
+compatibility, but the beta wallet flow should prefer `network/member/node`
+so every device has an explicit owning member DID.
+
 ### DWN Primitive Mapping
 
 | Mesh Concept            | DWN Primitive                                                    |
 | ----------------------- | ---------------------------------------------------------------- |
-| Node identity           | DID (`did:dht`)                                                  |
+| Member identity         | Wallet/local DID (`did:jwk` today, `did:dht` when available)     |
+| Node identity           | Local device DID (`did:jwk` today, `did:dht` when available)     |
 | Mesh coordination       | Anchor DWN + per-node DWNs                                       |
 | Key exchange             | `RecordsWrite` (encrypted)                                       |
 | Key distribution        | Protocol `$actions` + Protocol Context key delivery              |
 | Membership              | Protocol roles (`$role: true`)                                   |
+| Wallet authorization    | DWN permission grants from member DID to node DID                |
 | ACL policies            | Protocol `$actions` rules + encrypted ACL records                |
 | Endpoint updates        | `RecordsWrite` updates (mutable, encrypted)                      |
 | Real-time peer discovery| `RecordsSubscribe` (live event streams via EventLog)             |
@@ -351,7 +427,7 @@ decrypt everything.
 
 Since all members need to read each other's encrypted data, the DWN owner
 distributes **context keys** to members using the key-delivery protocol
-(`https://enbox.id/protocols/key-delivery`):
+(`https://identity.foundation/protocols/key-delivery`):
 
 1. When a new member is added, the anchor DWN owner derives the context
    private key using the Protocol Context scheme for that network's context.
@@ -438,7 +514,8 @@ When a member is removed:
 2. All members receive this change via `RecordsSubscribe`
 3. Each member removes the revoked peer from their WireGuard configuration
 4. The revoked peer's `peerAuth` role on each node's DWN is deleted
-5. Context keys should be rotated for forward secrecy
+5. Delivered key-delivery `contextKey` records for the removed node are deleted
+6. Context keys should be rotated for forward secrecy against locally cached keys
 
 ### Threat Model
 
@@ -579,9 +656,9 @@ interactions. ACLs enforce who can reach what.
 ```
 1. Node runs `meshd init` (generates device DID + WireGuard keys)
 2. Node starts local DWN, installs wireguard-node protocol
-3. Admin runs `meshd peer add <node-did>` on anchor
-   a. Writes member role record (recipient = node DID)
-   b. Delivers context encryption key to the new member
+3. Admin runs `meshd peer add <node-did> --owner <owner-did>` on anchor
+   a. Writes node role record (recipient = node DID, owner/member = owner DID)
+   b. Delivers context encryption key to the new node
 4. Node runs `meshd network join <admin-did> <network-id>`
    a. Reads network config from anchor DWN (decrypts with context key)
    b. Reads member list, discovers peer DIDs

--- a/README.md
+++ b/README.md
@@ -36,6 +36,31 @@ meshd up
 # through encrypted WireGuard tunnels. NAT traversal is automatic.
 ```
 
+### Dashboard-owned enrollment
+
+For wallet-owned meshes, the CLI does not need to connect directly to the
+wallet. The wallet identity acts as the account/owner in the standalone meshd
+Admin dapp; each machine keeps a local encrypted node DID.
+
+```bash
+# Open the dashboard once as the owner so the wallet grants meshd Admin access.
+meshd admin --print
+
+# On a new device, request approval from that owner.
+meshd up --owner did:example:owner --endpoint https://dev.aws.dwn.enbox.id
+
+# Approve the pending device in the dashboard, then start it.
+meshd up
+```
+
+`meshd up` stores the pending owner request locally and exits cleanly while it
+waits. After approval, the dashboard writes the node membership record, delivers
+the network context key, and writes a node approval response that the CLI
+consumes on the next `meshd up`.
+
+For a full Mac/Linux validation pass, see
+[docs/smoke-test-mac-linux.md](docs/smoke-test-mac-linux.md).
+
 ## What is this?
 
 meshd is a WireGuard mesh network where there is no coordination server.
@@ -89,6 +114,7 @@ meshd <command> [arguments]
 Identity:
   init              Generate DID identity and store locally
   auth login        Create a named identity profile
+  auth connect      Connect a CLI profile to an Enbox Wallet
   auth list         List all profiles
   auth use <name>   Set the default profile
   auth logout       Remove a profile from config
@@ -102,18 +128,96 @@ Network:
   network leave     Leave the current mesh network
   invite create     Create an invite URL for joining this network
   join <url>        Join a network from a meshd://invite URL
-  peer add          Add a peer to the mesh (anchor only)
+  peer add          Add a peer node to the mesh (anchor only)
+  peer remove       Remove a peer node from the mesh (anchor only)
   peer list         List all peers in the mesh
   peer approve      Deliver encryption keys to a peer (anchor only)
   acl set <file>    Set ACL policy from a JSON file (anchor only)
   acl show          Show the current ACL policy
+  admin             Open the meshd admin dashboard
   status            Show mesh status and identity info
+  doctor            Diagnose identity, wallet, daemon, TUN, and routes
   up                Start the mesh agent daemon
   down              Stop the mesh agent daemon
 ```
 
 Run `meshd network create` or `meshd network join` without all arguments in
 an interactive terminal and meshd will prompt for the missing values.
+`meshd up` also acts as the first-run wizard: it can create a local node DID,
+request access from a wallet owner DID, create a local-vault network, or join
+with an invite URL.
+The join path asks for a `meshd://invite/...` URL first and only falls back to
+manual DWN endpoint, anchor DID, and network ID prompts if you leave it blank.
+For wallet-connected profiles, creating a network opens the wallet approval
+flow instead of asking for a DWN endpoint.
+
+## Identity modes
+
+meshd supports two identity modes:
+
+**Local vault.** The device DID is also the mesh member DID. This is the
+simplest no-wallet path and is what `meshd auth login` creates today.
+
+**Wallet-owned node.** The wallet DID is the mesh member/owner DID, while each
+machine keeps its own local node DID. The default beta path is dashboard-owned:
+`meshd up --owner <did>` writes a signed node request to the owner's DWN, and
+the meshd Admin dapp approves that node into a selected network. A separate
+delegate DID can still be used for wallet-issued grants, but it is not required
+for the normal enrollment path.
+
+The intended beta model is:
+
+```
+wallet/member DID  -- owns mesh membership and approves nodes
+       |
+       +-- node DID     -- local device identity, WireGuard identity, mesh IP
+       |
+       +-- delegate DID -- optional local session key for wallet-granted operations
+```
+
+The CLI records this split in profile and network state, imports legacy wallet
+permission grants when present, and caches wallet-provided network context keys
+in the encrypted local secrets vault. The dashboard-owned path avoids direct
+CLI-to-wallet approval pages for normal enrollment. The older wallet-connected
+network creation flow is still accepted for compatibility: the wallet owns the DWN
+encryption root, writes the network, member, and member-owned node records,
+derives the initial network context key, and sends the response back to the
+waiting CLI over a short-lived localhost callback or a node DID
+wallet-response record on a DWN endpoint. The DWN handoff lets an SSH/server
+install print a wallet URL that you can approve from another machine without
+relying on that other browser reaching the server's `127.0.0.1`. If both
+delivery channels fail, the wallet still shows a JSON response that can be
+imported with `meshd network create --response <response.json>`. Local-vault
+profiles can continue to create networks directly from the CLI. Set
+`MESHD_WALLET_RESPONSE_ENDPOINT` to choose the node DID mailbox DWN; otherwise
+meshd uses `DWN_ENDPOINT` or the beta default.
+
+New wallet responses use `ownerDID` for the wallet/member identity,
+`delegateDid` for the local grant recipient, and `nodeContextKeys` for keys
+delivered to the local CLI node. The older `connectedDid` and
+`delegateContextKeys` fields are still accepted for compatibility.
+New wallet-connected imports require `delegateDid` to be present and distinct
+from `nodeDid`; direct node-DID grants are only a legacy fallback for older
+sessions that do not have a delegate key.
+
+Run `meshd doctor` when setup or connectivity does not look right. It checks
+the active profile, vault, wallet owner/delegate session, network state,
+daemon socket, TUN device, and the route to a discovered peer, then prints the
+next command or admin action to try.
+
+Run `meshd admin` to open the standalone meshd Admin dapp for the active owner and
+network. From there you can create, copy, and revoke invite URLs, approve
+pending nodes, and remove devices without copying record IDs by hand. Use
+`meshd admin --print` on SSH servers when you only want the URL.
+
+For manual admin onboarding, use `meshd peer add <node-did> --owner
+<wallet-or-owner-did>` when the device DID and owning wallet/member DID are
+different. Omitting `--owner` keeps the local-vault behavior where the node
+owns itself. `--member` is still accepted as a compatibility alias. Use
+`meshd peer remove <node-did>` to remove a device from peer discovery and
+delete delivered context-key records for that node. Rotate network context
+keys before re-adding that node if you need strong cryptographic revocation of
+locally cached keys.
 
 ## If you already have a DID and DWN
 
@@ -181,6 +285,9 @@ on the anchor's DWN:
 
 ```
 network
+  +-- nodeRequest                              -- device asks wallet owner for approval
+  +-- nodeApproval                             -- owner tells device which network it joined
+  |
   +-- node ($role, recipient = device DID)    -- owner-provisioned devices
   |     +-- nodeInfo                          -- device writes: hostname, OS
   |     +-- endpoint                          -- device writes: IPs, NAT type

--- a/admin-dapp/README.md
+++ b/admin-dapp/README.md
@@ -1,0 +1,81 @@
+# meshd Admin dapp
+
+Standalone dashboard for wallet-owned meshd networks.
+
+The CLI creates and runs local node DIDs. The owner wallet acts as the mesh
+account. This dapp connects to that wallet, receives delegated DWN grants, and
+then manages networks, invites, pending node approvals, and removals on behalf
+of the owner.
+
+## Local development
+
+```bash
+npm ci
+npm run dev
+```
+
+Use Node.js 20.19.0 or newer Node 20, or Node.js 22.12.0+.
+
+Open the printed Vite URL, connect an Enbox Wallet, and approve the requested
+meshd permissions.
+
+The default local Vite URL is usually:
+
+```text
+http://127.0.0.1:5173/
+```
+
+## Wallet connect model
+
+The dapp requests access with:
+
+- `https://enbox.id/protocols/wireguard-mesh`
+- `https://identity.foundation/protocols/key-delivery`
+
+For each protocol it asks for read, write, and delete record permissions. The
+wallet installs/configures the protocols during approval and grants this dapp a
+local delegate session. The dapp does not ask for delegated
+`Protocols.Configure` access and does not need the wallet's private keys.
+
+On startup, the dapp runs the SDK readiness/import path for both protocols and
+verifies that the installed wallet-owned definitions contain the expected meshd
+types and paths before enabling dashboard actions.
+
+## Environment
+
+All variables are optional.
+
+```bash
+VITE_ENBOX_DAPP_NAME="meshd Admin"
+VITE_ENBOX_WALLET_URL="https://enbox-wallet.pages.dev"
+VITE_ENBOX_BLUE_WALLET_URL="https://blue-enbox-wallet.pages.dev"
+VITE_ENBOX_DWN_ENDPOINTS="https://dev.aws.dwn.enbox.id,https://enbox-dwn.fly.dev"
+```
+
+## Checks
+
+```bash
+npm test
+npm run build
+```
+
+`npm test` covers the wallet-connect permission request shape and the delegated
+protocol readiness checks. `npm run build` typechecks and builds the static app.
+
+## Cloudflare Pages
+
+The repository workflow `.github/workflows/admin-dapp.yml` builds this app on
+PRs and deploys it on pushes to `main`.
+
+Required GitHub secrets:
+
+```text
+CLOUDFLARE_API_TOKEN
+CLOUDFLARE_ACCOUNT_ID
+```
+
+The workflow deploys `admin-dapp/dist` to the Cloudflare Pages project:
+
+```text
+meshd-admin
+```

--- a/admin-dapp/index.html
+++ b/admin-dapp/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#101820" />
+    <title>meshd Admin</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/admin-dapp/package-lock.json
+++ b/admin-dapp/package-lock.json
@@ -1,0 +1,5432 @@
+{
+  "name": "@enbox/meshd-admin-dapp",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@enbox/meshd-admin-dapp",
+      "version": "0.0.1",
+      "dependencies": {
+        "@enbox/agent": "0.8.6",
+        "@enbox/api": "0.6.44",
+        "@enbox/auth": "0.6.52",
+        "@enbox/browser": "0.3.30",
+        "@enbox/common": "0.1.1",
+        "@enbox/crypto": "0.1.1",
+        "@enbox/dids": "0.1.1",
+        "@enbox/dwn-sdk-js": "0.4.4",
+        "@enbox/protocols": "0.2.71",
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.407.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "sonner": "^1.5.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.19.43",
+        "@types/react": "^18.3.1",
+        "@types/react-dom": "^18.3.0",
+        "@vitejs/plugin-react": "^5.2.0",
+        "typescript": "^5.2.2",
+        "vite": "^7.3.5",
+        "vite-plugin-node-polyfills": "^0.28.0",
+        "vitest": "^3.2.6"
+      }
+    },
+    "node_modules/@assemblyscript/loader": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.9.4.tgz",
+      "integrity": "sha512-HazVq9zwTVwGmqdwYzu7WyQ6FQVZ7SwET0KKQuKm55jD0IfUpZgN0OPIiZG3zV1iSrVYcN0bdwLRXI/VNCYsUA=="
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@decentralized-identity/ion-sdk": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@decentralized-identity/ion-sdk/-/ion-sdk-1.0.4.tgz",
+      "integrity": "sha512-pOWrlTH5ChxUKRHOgfG2ZeTioWEFJXADyErCQOJ0BqYNDKfP+CM09Vss+9ei6PNOABQlcDn0mEDFZtpO+DXl8A==",
+      "dependencies": {
+        "@noble/ed25519": "^2.0.0",
+        "@noble/secp256k1": "^2.0.0",
+        "canonicalize": "^2.0.0",
+        "multiformats": "^12.1.3",
+        "uri-js": "^4.4.1"
+      }
+    },
+    "node_modules/@decentralized-identity/ion-sdk/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@dnsquery/dns-packet": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@dnsquery/dns-packet/-/dns-packet-6.1.1.tgz",
+      "integrity": "sha512-WXTuFvL3G+74SchFAtz3FgIYVOe196ycvGsMgvSH/8Goptb1qpIQtIuM4SOK9G9lhMWYpHxnXyy544ZhluFOew==",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.4",
+        "utf8-codec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@enbox/agent": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@enbox/agent/-/agent-0.8.6.tgz",
+      "integrity": "sha512-UotC4WRkukPWWBBu21KvThCuxIoKzfVrnbt44EF83MIllxLU3zjd8IF+5UaXet6dP0sC53Sl0WCYe9ZQK57sRw==",
+      "dependencies": {
+        "@enbox/common": "0.1.1",
+        "@enbox/crypto": "0.1.1",
+        "@enbox/dids": "0.1.1",
+        "@enbox/dwn-clients": "0.4.9",
+        "@enbox/dwn-sdk-js": "0.4.4",
+        "@scure/bip39": "1.2.2",
+        "abstract-level": "1.0.4",
+        "ed25519-keygen": "0.4.11",
+        "level": "8.0.1",
+        "ms": "2.1.3",
+        "ulidx": "2.1.0"
+      },
+      "engines": {
+        "bun": ">=1.3.14"
+      }
+    },
+    "node_modules/@enbox/api": {
+      "version": "0.6.44",
+      "resolved": "https://registry.npmjs.org/@enbox/api/-/api-0.6.44.tgz",
+      "integrity": "sha512-PJQJuW/qrBVqnkqYOXFPzukr4FBmYJp1XPoyUCtUdZbpZ52+Gcb7F4WxGtGVSpVrZCQulJUK09N0YZi8YKGUAg==",
+      "dependencies": {
+        "@enbox/agent": "0.8.6",
+        "@enbox/auth": "0.6.52",
+        "@enbox/common": "0.1.1",
+        "@enbox/dwn-clients": "0.4.9"
+      },
+      "engines": {
+        "bun": ">=1.3.14"
+      }
+    },
+    "node_modules/@enbox/auth": {
+      "version": "0.6.52",
+      "resolved": "https://registry.npmjs.org/@enbox/auth/-/auth-0.6.52.tgz",
+      "integrity": "sha512-ZkysASxx5w9ZBH3nQMspjEHF9rhMRVZP2gx5jvb7l1idKKC1P65iYDUDIkjM8IQw5y4QaBywBlBZwz8UbUOD6A==",
+      "dependencies": {
+        "@enbox/agent": "0.8.6",
+        "@enbox/common": "0.1.1",
+        "@enbox/crypto": "0.1.1",
+        "@enbox/dids": "0.1.1",
+        "@enbox/dwn-clients": "0.4.9",
+        "@enbox/dwn-sdk-js": "0.4.4",
+        "level": "8.0.1"
+      },
+      "engines": {
+        "bun": ">=1.0.0"
+      }
+    },
+    "node_modules/@enbox/browser": {
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/@enbox/browser/-/browser-0.3.30.tgz",
+      "integrity": "sha512-ICKdtrRiGFV7u73+qi/Vm/AuWi5FB+asEIwCVSGarReGy5PftF1YnzV7DT3w+JdHwNvjydchCHhocolRe9G5Hw==",
+      "dependencies": {
+        "@enbox/agent": "0.8.6",
+        "@enbox/api": "0.6.44",
+        "@enbox/auth": "0.6.52",
+        "@enbox/dids": "0.1.1"
+      }
+    },
+    "node_modules/@enbox/common": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@enbox/common/-/common-0.1.1.tgz",
+      "integrity": "sha512-QsrjbYklh05nvCmn6a33iqCei1PGyNDOhnbB6bNgdnLyzsf0TKwzZgnx1qlpoiCwO6GJI4I2qXIfK4aP/ngeug==",
+      "dependencies": {
+        "@isaacs/ttlcache": "1.4.1",
+        "level": "8.0.1",
+        "multiformats": "11.0.2"
+      },
+      "engines": {
+        "bun": ">=1.0.0"
+      }
+    },
+    "node_modules/@enbox/crypto": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@enbox/crypto/-/crypto-0.1.1.tgz",
+      "integrity": "sha512-Jd4pYGYG7SmmEQ7Gy2rFb0dfb9hEIsNM7AGptTI1KM+Lp8bMgPF93H+x3s8dPuThfjGh2285i5I5+Aott6xZ2w==",
+      "dependencies": {
+        "@enbox/common": "0.1.1",
+        "@noble/ciphers": "0.5.3",
+        "@noble/curves": "1.3.0",
+        "@noble/hashes": "1.4.0",
+        "cborg": "4.5.8"
+      },
+      "engines": {
+        "bun": ">=1.0.0"
+      }
+    },
+    "node_modules/@enbox/dids": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@enbox/dids/-/dids-0.1.1.tgz",
+      "integrity": "sha512-t2mNm8IKkZ2c2ouKnVvbPUNFD+n1Neu+gt+RYncovH1ARkIv6Azf1zTezubU8snXefeEPQBfS/sia/65paXoCA==",
+      "dependencies": {
+        "@decentralized-identity/ion-sdk": "1.0.4",
+        "@dnsquery/dns-packet": "6.1.1",
+        "@enbox/common": "0.1.1",
+        "@enbox/crypto": "0.1.1",
+        "abstract-level": "1.0.4",
+        "bencode": "4.0.0",
+        "level": "8.0.1",
+        "ms": "2.1.3"
+      },
+      "engines": {
+        "bun": ">=1.0.0"
+      }
+    },
+    "node_modules/@enbox/dwn-clients": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@enbox/dwn-clients/-/dwn-clients-0.4.9.tgz",
+      "integrity": "sha512-NJgIdfvi+k8tw3PrNhZd4Ea8ltwWmf6rYxxsDSxd7v50Sp4hpnjbkPtBykOz7TF2Wz8QIHipGDyI6cPN+2b68Q==",
+      "dependencies": {
+        "@enbox/common": "0.1.1",
+        "@enbox/crypto": "0.1.1",
+        "@enbox/dwn-sdk-js": "0.4.4",
+        "ms": "2.1.3"
+      },
+      "engines": {
+        "bun": ">=1.3.14"
+      }
+    },
+    "node_modules/@enbox/dwn-sdk-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@enbox/dwn-sdk-js/-/dwn-sdk-js-0.4.4.tgz",
+      "integrity": "sha512-ifPHmoP7fPLdGlMIFduS25AcYAeXhDv8yb8X+RZDcp/M0YozV4HGDJEa6nWBj37v6VB7h/zzi1qhP16UUMgyjA==",
+      "dependencies": {
+        "@enbox/common": "0.1.1",
+        "@enbox/crypto": "0.1.1",
+        "@enbox/dids": "0.1.1",
+        "@ipld/dag-cbor": "9.0.5",
+        "@js-temporal/polyfill": "0.4.4",
+        "@noble/ciphers": "0.5.3",
+        "@noble/curves": "1.3.0",
+        "@noble/ed25519": "2.0.0",
+        "@noble/secp256k1": "2.0.0",
+        "abstract-level": "1.0.4",
+        "ajv": "8.18.0",
+        "interface-blockstore": "5.2.3",
+        "interface-store": "5.1.2",
+        "ipfs-unixfs-exporter": "13.1.5",
+        "ipfs-unixfs-importer": "15.1.5",
+        "level": "8.0.1",
+        "lodash": "4.17.21",
+        "lru-cache": "9.1.2",
+        "mitt": "3.0.1",
+        "multiformats": "11.0.2",
+        "uint8arrays": "5.1.0",
+        "ulidx": "2.1.0"
+      },
+      "engines": {
+        "bun": ">= 1.0"
+      }
+    },
+    "node_modules/@enbox/dwn-sdk-js/node_modules/@noble/ed25519": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.0.0.tgz",
+      "integrity": "sha512-/extjhkwFupyopDrt80OMWKdLgP429qLZj+z6sYJz90rF2Iz0gjZh2ArMKPImUl13Kx+0EXI2hN9T/KJV0/Zng==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@enbox/dwn-sdk-js/node_modules/@noble/secp256k1": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-2.0.0.tgz",
+      "integrity": "sha512-rUGBd95e2a45rlmFTqQJYEFA4/gdIARFfuTuTqLglz0PZ6AKyzyXsEZZq7UZn8hZsvaBgpCzKKBJizT2cJERXw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@enbox/protocols": {
+      "version": "0.2.71",
+      "resolved": "https://registry.npmjs.org/@enbox/protocols/-/protocols-0.2.71.tgz",
+      "integrity": "sha512-zoKvZv1Vi9aGGCacH3uwI4pdoWBORouzZCuFEKSb9Cw8eptetuLeFihUR7zpMK90EMotAz47P6HOSdwaku9n0Q==",
+      "dependencies": {
+        "@enbox/api": "0.6.44",
+        "@enbox/dwn-sdk-js": "0.4.4"
+      },
+      "engines": {
+        "bun": ">=1.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ipld/dag-cbor": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.5.tgz",
+      "integrity": "sha512-TyqgtxEojc98rvxg4NGM+73JzQeM4+tK2VQes/in2mdyhO+1wbGuBijh1tvi9BErQ/dEblxs9v4vEQSX8mFCIw==",
+      "dependencies": {
+        "cborg": "^4.0.0",
+        "multiformats": "^12.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/dag-cbor/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/dag-pb": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.1.7.tgz",
+      "integrity": "sha512-/i/13trFihjWfDyXlylRwhuYjtzYjvOFw0vlRjYGnZuv7d7MOgA2lV/vRuL5RfeUajM03aZfFLdq4S7cTbbTRg==",
+      "dependencies": {
+        "multiformats": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/dag-pb/node_modules/multiformats": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
+      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg=="
+    },
+    "node_modules/@isaacs/ttlcache": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz",
+      "integrity": "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.4.4.tgz",
+      "integrity": "sha512-2X6bvghJ/JAoZO52lbgyAPFj8uCflhTo2g7nkFzEQdXd/D8rEeD4HtmTEpmtGCva260fcd66YNXBOYdnmHqSOg==",
+      "dependencies": {
+        "jsbi": "^4.3.0",
+        "tslib": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
+    },
+    "node_modules/@multiformats/murmur3": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.2.5.tgz",
+      "integrity": "sha512-M+VwV8hEx5qB8i7b8fljMwZETJsqyLo8RAXA+JAn+QF9NnH46ZWvGErNukJVlxXSR2KQpuOtHIYIzZlbhhdFvw==",
+      "dependencies": {
+        "multiformats": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/murmur3/node_modules/multiformats": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
+      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg=="
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.5.3.tgz",
+      "integrity": "sha512-B0+6IIHiqEs3BPMT0hcRmHvEj2QHOLu+uwt+tqDDeVd0oyVzh7BPrDcPjRnV1PV/5LaknXJJQvOuRGR0zQJz+w==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
+      "integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
+      "dependencies": {
+        "@noble/hashes": "1.3.3"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/ed25519": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.3.0.tgz",
+      "integrity": "sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/secp256k1": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-2.3.0.tgz",
+      "integrity": "sha512-0TQed2gcBbIrh7Ccyw+y/uZQvbJwm7Ao4scBUxqpBCcsOlZG0O4KGfjtNAy/li4W8n1xt3dxrwJ0beZ2h2G6Kw==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true
+    },
+    "node_modules/@rollup/plugin-inject": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz",
+      "integrity": "sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.2.tgz",
+      "integrity": "sha512-HYf9TUXG80beW+hGAt3TRM8wU6pQoYur9iNypTROm42dorCGmLnFe3eWjz3gOq6G62H2WRh0FCzAR1PI+29zIA==",
+      "dependencies": {
+        "@noble/hashes": "~1.3.2",
+        "@scure/base": "~1.1.4"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/abort-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/abort-error/-/abort-error-1.0.2.tgz",
+      "integrity": "sha512-lVgvB2NyPLqbXXhVmXcYFTC1x5K7CiVdPgdY7LGgFQWC8506oN01sPN3i9cl9ynuwF4iJ0TS9exnR7cZ9FuX4w=="
+    },
+    "node_modules/abstract-level": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.4.tgz",
+      "integrity": "sha512-eUP/6pbXBkMbXFdx4IH2fVgvB7M0JvR7/lIL33zcs0IBcwjdzSSl31TOJsaCzmKSSDF9h8QYSOJux4Nd4YJqFg==",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "catering": "^2.1.0",
+        "is-buffer": "^2.0.5",
+        "level-supports": "^4.0.0",
+        "level-transcoder": "^1.0.1",
+        "module-error": "^1.0.1",
+        "queue-microtask": "^1.2.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/asn1.js": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/asn1.js/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "dev": true
+    },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.38",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "dev": true,
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bencode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bencode/-/bencode-4.0.0.tgz",
+      "integrity": "sha512-AERXw18df0pF3ziGOCyUjqKZBVNH8HV3lBxnx5w0qtgMIk4a1wb9BkcCQbkp9Zstfrn/dzRwl7MmUHHocX3sRQ==",
+      "dependencies": {
+        "uint8-util": "^2.2.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
+      "dev": true
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "dev": true
+    },
+    "node_modules/browser-level": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browser-level/-/browser-level-1.0.1.tgz",
+      "integrity": "sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==",
+      "dependencies": {
+        "abstract-level": "^1.0.2",
+        "catering": "^2.1.1",
+        "module-error": "^1.0.2",
+        "run-parallel-limit": "^1.1.0"
+      }
+    },
+    "node_modules/browser-resolve": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz",
+      "integrity": "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.17.0"
+      }
+    },
+    "node_modules/browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dev": true,
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "dev": true,
+      "dependencies": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "node_modules/browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "dev": true,
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/browserify-rsa": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
+      "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/browserify-sign": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.6.tgz",
+      "integrity": "sha512-sd+Q65fjlWCYWtZKXiKfrUc8d+4jtp/8f0W2NkwzLtoW4bI6UDnWusLWIurHnmurW0XShIRxpwiOX4EoPtXUAg==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^5.2.3",
+        "browserify-rsa": "^4.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.6.1",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.9",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
+    },
+    "node_modules/browserify-sign/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/browserify-sign/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "dev": true,
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "dev": true
+    },
+    "node_modules/builtin-status-codes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
+      "dev": true
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
+    },
+    "node_modules/canonicalize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
+      "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      }
+    },
+    "node_modules/catering": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
+      "integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cborg": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.5.8.tgz",
+      "integrity": "sha512-6/viltD51JklRhq4L7jC3zgy6gryuG5xfZ3kzpE+PravtyeQLeQmCYLREhQH7pWENg5pY4Yu/XCd6a7dKScVlw==",
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/cipher-base": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
+      "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/classic-level": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.4.1.tgz",
+      "integrity": "sha512-qGx/KJl3bvtOHrGau2WklEZuXhS3zme+jf+fsu6Ej7W7IP/C49v7KNlWIsT1jZu0YnfzSIYDGcEWpCa1wKGWXQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "abstract-level": "^1.0.2",
+        "catering": "^2.1.0",
+        "module-error": "^1.0.1",
+        "napi-macros": "^2.2.2",
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/console-browserify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+      "dev": true
+    },
+    "node_modules/constants-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==",
+      "dev": true
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
+    },
+    "node_modules/create-ecdh": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      }
+    },
+    "node_modules/create-ecdh/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "dev": true
+    },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dev": true,
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dev": true,
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "node_modules/crypto-browserify": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
+      "integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
+      "dev": true,
+      "dependencies": {
+        "browserify-cipher": "^1.0.1",
+        "browserify-sign": "^4.2.3",
+        "create-ecdh": "^4.0.4",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "diffie-hellman": "^5.0.3",
+        "hash-base": "~3.0.4",
+        "inherits": "^2.0.4",
+        "pbkdf2": "^3.1.2",
+        "public-encrypt": "^4.0.3",
+        "randombytes": "^2.1.0",
+        "randomfill": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      }
+    },
+    "node_modules/diffie-hellman/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "dev": true
+    },
+    "node_modules/domain-browser": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.22.0.tgz",
+      "integrity": "sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ed25519-keygen": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/ed25519-keygen/-/ed25519-keygen-0.4.11.tgz",
+      "integrity": "sha512-UKxebk/eoW/0yy6BcyCkgAvN2/VzwVXiMVHgKNYBMX6T0fJRAE3WWvH2inyuBvMIJaOqlkc3utylUvL8yW6SOg==",
+      "deprecated": "Switch to \"micro-key-producer\" for security updates",
+      "dependencies": {
+        "@noble/curves": "~1.3.0",
+        "@noble/hashes": "~1.3.3",
+        "@scure/base": "~1.1.5",
+        "micro-packed": "~0.5.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ed25519-keygen/node_modules/@noble/hashes": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.378",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.378.tgz",
+      "integrity": "sha512-VinvOAuuPmdD1guEgGv5f2Qp7/vlfqOrUOMYNnOD4wj3pit8kRsQHzfIf6teyUGWo15Tg5+bOJaRunvyltpVWQ==",
+      "dev": true
+    },
+    "node_modules/elliptic": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "dev": true
+    },
+    "node_modules/err-code": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dev": true,
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hamt-sharding": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-3.0.8.tgz",
+      "integrity": "sha512-pEh4hYa4ZyDJ2jWBTz7MVqTTGC3va3iEIMDJfbCKskR9rzHRd8HVwUyH5nLiLxK6VCFWIJ4vnlAEn4Hwx49Rbg==",
+      "dependencies": {
+        "sparse-array": "^1.3.1",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/hamt-sharding/node_modules/multiformats": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
+      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg=="
+    },
+    "node_modules/hamt-sharding/node_modules/uint8arrays": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-6.1.1.tgz",
+      "integrity": "sha512-iz7JN0XCSZYA111lhFG2Ui9EhFvTNekqSRHw3lvMHq+dzwWy1OQftxFQREEh4rffU0oSoXdQHsk2TiHKVm4fsA==",
+      "dependencies": {
+        "multiformats": "^14.0.0"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hash-base": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
+      "integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "dev": true,
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/https-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
+      "dev": true
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/interface-blockstore": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-5.2.3.tgz",
+      "integrity": "sha512-15cN+ZFdcVXdXo6I/SrSzFDsuJyDTyEI52XuvXQlR/G5fe3cK8p0tvVjfu5diRQH1XqNgmJEdMPixyt0xgjtvQ==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "multiformats": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/interface-store": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.2.tgz",
+      "integrity": "sha512-q2sLoqC+UdaWnjwGyghsH0jwqqVk226lsG207e3QwPB8sAZYmYIWUnJwJH3JjFNNRV9e6CUTmm+gDO0Xg4KRiw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-unixfs": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.2.5.tgz",
+      "integrity": "sha512-uasYJ0GLPbViaTFsOLnL9YPjX5VmhnqtWRriogAHOe4ApmIi9VAOFBzgDHsUW2ub4pEa/EysbtWk126g2vkU/g==",
+      "dependencies": {
+        "protons-runtime": "^5.5.0",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/ipfs-unixfs-exporter": {
+      "version": "13.1.5",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-13.1.5.tgz",
+      "integrity": "sha512-O5aMawsHoe4DaYk5FFil2EPrNOaU3pkHC6qUR5JMnW7es93W3b/RjJoO7AyDL1rpb+M3K0oRu86Yc5wLNQQ8jg==",
+      "dependencies": {
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-pb": "^4.0.0",
+        "@multiformats/murmur3": "^2.0.0",
+        "err-code": "^3.0.1",
+        "hamt-sharding": "^3.0.0",
+        "interface-blockstore": "^5.0.0",
+        "ipfs-unixfs": "^11.0.0",
+        "it-filter": "^3.0.2",
+        "it-last": "^3.0.2",
+        "it-map": "^3.0.3",
+        "it-parallel": "^3.0.0",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.1.0",
+        "multiformats": "^11.0.0",
+        "p-queue": "^7.3.0",
+        "progress-events": "^1.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-unixfs-exporter/node_modules/uint8arrays": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.10.tgz",
+      "integrity": "sha512-AnJNUGGDJAgFw/eWu/Xb9zrVKEGlwJJCaeInlf3BkecE/zcTobk5YXYIPNQJO1q5Hh1QZrQQHf0JvcHqz2hqoA==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/ipfs-unixfs-exporter/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-unixfs-importer": {
+      "version": "15.1.5",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-15.1.5.tgz",
+      "integrity": "sha512-TXaOI0M5KNpq2+qLw8AIYd0Lnc0gWTKCBqUd9eErBUwaP3Fna4qauF+JX9Rj2UrwaOvG/1xbF8Vm+92eOcKWMA==",
+      "dependencies": {
+        "@ipld/dag-pb": "^4.0.0",
+        "@multiformats/murmur3": "^2.0.0",
+        "err-code": "^3.0.1",
+        "hamt-sharding": "^3.0.0",
+        "interface-blockstore": "^5.0.0",
+        "interface-store": "^5.0.1",
+        "ipfs-unixfs": "^11.0.0",
+        "it-all": "^3.0.2",
+        "it-batch": "^3.0.2",
+        "it-first": "^3.0.2",
+        "it-parallel-batch": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "progress-events": "^1.0.0",
+        "rabin-wasm": "^0.1.4",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-unixfs-importer/node_modules/uint8arrays": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.10.tgz",
+      "integrity": "sha512-AnJNUGGDJAgFw/eWu/Xb9zrVKEGlwJJCaeInlf3BkecE/zcTobk5YXYIPNQJO1q5Hh1QZrQQHf0JvcHqz2hqoA==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/ipfs-unixfs-importer/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
+    },
+    "node_modules/isomorphic-timers-promises": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-timers-promises/-/isomorphic-timers-promises-1.0.1.tgz",
+      "integrity": "sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/it-all": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.11.tgz",
+      "integrity": "sha512-Gvqj6MO4GMLnFdtE68HZRpGBskNC+9+GQ+JevTGNYLyhjUuPhjDLU3jN1LpBemXJDW1bRSkczqA/qGyKlPKrcQ=="
+    },
+    "node_modules/it-batch": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-3.0.11.tgz",
+      "integrity": "sha512-2bvKErkXhtwKYDLKAGdEgveOs8wB0i3RItbaroP/6cC/QlrM7j+HAq/yJq6ci4J7KnzdRi76GyipKlafdOTBgw=="
+    },
+    "node_modules/it-filter": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-3.1.6.tgz",
+      "integrity": "sha512-yXiGPAvJn/exXjVFSCMQc3+J/7RLpOMwKoY2DH1yMhF4lYkdRoAdOwU0vnDACAlRAexf7AZvESZIc9mzhEoi/A==",
+      "dependencies": {
+        "it-peekable": "^3.0.0"
+      }
+    },
+    "node_modules/it-first": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.11.tgz",
+      "integrity": "sha512-0ig8DKpg09V1o7JBagm3oPx3VY7WYfU5w3lpbLbqzijnfMPSvMGoMZuLm17h/RgOJXKP+9mt7vsCNiU2TW8TkQ=="
+    },
+    "node_modules/it-last": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-3.0.11.tgz",
+      "integrity": "sha512-Fg571l81nPzhZsiYjkw4dkhRqAK4oqIamTPEfAOnXI/5pYXz+dIfMVYmh9ncZs58oFNMkdF3bYFuCBTw/xJK0w=="
+    },
+    "node_modules/it-map": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.1.6.tgz",
+      "integrity": "sha512-wCix0FXImtIPIxhCnbz35RqWs00e/CReSZX9nZq1j46JcAzBBp57ob9/2l1WnDYEaUURIR8xCyg2NsWbOwBJFQ==",
+      "dependencies": {
+        "it-peekable": "^3.0.0"
+      }
+    },
+    "node_modules/it-merge": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.14.tgz",
+      "integrity": "sha512-D3t1Go2G2SQMkTujaA6EVojJPJKA9pFksxlSPDRBfrHKhWl6O40vEP7Itr5eCAjyCQH5p9+BFFVIy9bhLM4ZuQ==",
+      "dependencies": {
+        "it-queueless-pushable": "^2.0.0"
+      }
+    },
+    "node_modules/it-parallel": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.15.tgz",
+      "integrity": "sha512-1iUV4wg7cDy40N32/XosK7mcwKM+oeSGq0r7czxNaUGGSQvbdSmkIoK4Vu/XPsXZIqBLt9tO+LDPi8RJBJ/Qwg==",
+      "dependencies": {
+        "p-defer": "^4.0.1"
+      }
+    },
+    "node_modules/it-parallel-batch": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-3.0.11.tgz",
+      "integrity": "sha512-n2gvHRVx14COn25jkio+fOHuKWaA5EVf9f0GbdWgVe8gXRIMYCai+CbmQACIv7o2Jn3ZAUOXD9Ob1Ftod0qtJQ==",
+      "dependencies": {
+        "it-batch": "^3.0.0"
+      }
+    },
+    "node_modules/it-peekable": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.10.tgz",
+      "integrity": "sha512-2E6+p1pelZOhzp69aaiiBuEybWzAl10uYbIdCR3Pxy8bFNnS/kgpbLtGbNbIZ6RVdU7yHHkmATYwjy52GfFEKA=="
+    },
+    "node_modules/it-pipe": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-3.0.1.tgz",
+      "integrity": "sha512-sIoNrQl1qSRg2seYSBH/3QxWhJFn9PKYvOf/bHdtCBF0bnghey44VyASsWzn5dAx0DCDDABq1hZIuzKmtBZmKA==",
+      "dependencies": {
+        "it-merge": "^3.0.0",
+        "it-pushable": "^3.1.2",
+        "it-stream-types": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-pushable": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.4.tgz",
+      "integrity": "sha512-WSD7Ss4oCRfDZJT4ldLWr0Bom/muY90xxoJ5PQnU3uSKf0kxCOeehqZtiJX1ARqn+ymXGh1bxpDW9bDNHp2ivQ==",
+      "dependencies": {
+        "p-defer": "^4.0.0"
+      }
+    },
+    "node_modules/it-queueless-pushable": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/it-queueless-pushable/-/it-queueless-pushable-2.0.5.tgz",
+      "integrity": "sha512-BaKqGLL1AQMR1AEaxiM09vzJQVXHHhfhh9UV0qPqORw/8Rm8igDQqT1qHregfHIb1NIW9jxQ/aXBibHJyuivuQ==",
+      "dependencies": {
+        "abort-error": "^1.0.2",
+        "p-defer": "^4.0.1",
+        "race-signal": "^2.0.0"
+      }
+    },
+    "node_modules/it-stream-types": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.4.tgz",
+      "integrity": "sha512-tsX+klvMQ53J4Jm2B52vCIs7WD609ck+VS9X2TKMEv7VPY9VwaYKmSWyHek5QS0wHBtP0bWj9KMqCtAHgVKiXw=="
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/jsbi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
+      "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew=="
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/layerr": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/layerr/-/layerr-2.1.0.tgz",
+      "integrity": "sha512-xDD9suWxfBYeXgqffRVH/Wqh+mqZrQcqPRn0I0ijl7iJQ7vu8gMGPt1Qop59pEW/jaIDNUN7+PX1Qk40+vuflg=="
+    },
+    "node_modules/level": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/level/-/level-8.0.1.tgz",
+      "integrity": "sha512-oPBGkheysuw7DmzFQYyFe8NAia5jFLAgEnkgWnK3OXAuJr8qFT+xBQIwokAZPME2bhPFzS8hlYcL16m8UZrtwQ==",
+      "dependencies": {
+        "abstract-level": "^1.0.4",
+        "browser-level": "^1.0.1",
+        "classic-level": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/level"
+      }
+    },
+    "node_modules/level-supports": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
+      "integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/level-transcoder": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
+      "integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "module-error": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
+      "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.407.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.407.0.tgz",
+      "integrity": "sha512-+dRIu9Sry+E8wPF9+sY5eKld2omrU4X5IKXxrgqBt+o11IIHVU0QOfNoVWFuj0ZRDrxr4Wci26o2mKZqLGE0lA==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dev": true,
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/micro-packed": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/micro-packed/-/micro-packed-0.5.3.tgz",
+      "integrity": "sha512-zWRoH+qUb/ZMp9gVZhexvRGCENDM5HEQF4sflqpdilUHWK2/zKR7/MT8GBctnTwbhNJwy1iuk5q6+TYP7/twYA==",
+      "dependencies": {
+        "@scure/base": "~1.1.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      }
+    },
+    "node_modules/miller-rabin/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "dev": true
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "dev": true
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
+    },
+    "node_modules/module-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
+      "integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-macros": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
+      "integrity": "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g=="
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.48",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
+      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/node-stdlib-browser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-stdlib-browser/-/node-stdlib-browser-1.3.1.tgz",
+      "integrity": "sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==",
+      "dev": true,
+      "dependencies": {
+        "assert": "^2.0.0",
+        "browser-resolve": "^2.0.0",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^5.7.1",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "create-require": "^1.1.1",
+        "crypto-browserify": "^3.12.1",
+        "domain-browser": "4.22.0",
+        "events": "^3.0.0",
+        "https-browserify": "^1.0.0",
+        "isomorphic-timers-promises": "^1.0.1",
+        "os-browserify": "^0.3.0",
+        "path-browserify": "^1.0.1",
+        "pkg-dir": "^5.0.0",
+        "process": "^0.11.10",
+        "punycode": "^1.4.1",
+        "querystring-es3": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "stream-browserify": "^3.0.0",
+        "stream-http": "^3.2.0",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
+        "tty-browserify": "0.0.1",
+        "url": "^0.11.4",
+        "util": "^0.12.4",
+        "vm-browserify": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-stdlib-browser/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/os-browserify": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
+      "dev": true
+    },
+    "node_modules/p-defer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.1.tgz",
+      "integrity": "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+      "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
+    },
+    "node_modules/parse-asn1": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
+      "integrity": "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==",
+      "dev": true,
+      "dependencies": {
+        "asn1.js": "^4.10.1",
+        "browserify-aes": "^1.2.0",
+        "evp_bytestokey": "^1.0.3",
+        "pbkdf2": "^3.1.5",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/pbkdf2": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.6.tgz",
+      "integrity": "sha512-BT6eelPB1EyGHo8pC0o9Bl6k6SYVhKO1jEbd3lcTrtr7XHdjP8BW1YpfCV3G9Kwkxgattk+S5q2/RvuttCsS1g==",
+      "dev": true,
+      "dependencies": {
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "ripemd160": "^2.0.3",
+        "safe-buffer": "^5.2.1",
+        "sha.js": "^2.4.12",
+        "to-buffer": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+      "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "node_modules/progress-events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.1.0.tgz",
+      "integrity": "sha512-82DVc5tI36neVB3IjdXR11ztwGuoBc98em9ijzubeZKxI47OlV2Znq6mlPqE5xPDzO2Uw98GHiQSjj2favBCRQ=="
+    },
+    "node_modules/protons-runtime": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.6.0.tgz",
+      "integrity": "sha512-/Kde+sB9DsMFrddJT/UZWe6XqvL7SL5dbag/DBCElFKhkwDj7XKt53S+mzLyaDP5OqS0wXjV5SA572uWDaT0Hg==",
+      "dependencies": {
+        "uint8-varint": "^2.0.2",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/public-encrypt/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "dev": true
+    },
+    "node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "dev": true
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "dev": true,
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/querystring-es3": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/rabin-wasm": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/rabin-wasm/-/rabin-wasm-0.1.5.tgz",
+      "integrity": "sha512-uWgQTo7pim1Rnj5TuWcCewRDTf0PEFTSlaUjWP4eY9EbLV9em08v89oCz/WO+wRxpYuO36XEHp4wgYQnAgOHzA==",
+      "dependencies": {
+        "@assemblyscript/loader": "^0.9.4",
+        "bl": "^5.0.0",
+        "debug": "^4.3.1",
+        "minimist": "^1.2.5",
+        "node-fetch": "^2.6.1",
+        "readable-stream": "^3.6.0"
+      },
+      "bin": {
+        "rabin-wasm": "cli/bin.js"
+      }
+    },
+    "node_modules/race-signal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-2.0.0.tgz",
+      "integrity": "sha512-P31bLhE4ByBX/70QDXMutxnqgwrF1WUXea1O8DXuviAgkdbQ1iQMQotNgzJIBC9yUSn08u/acZrMUhgw7w6GpA=="
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ripemd160": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
+      "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
+      "dev": true,
+      "dependencies": {
+        "hash-base": "^3.1.2",
+        "inherits": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ripemd160/node_modules/hash-base": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
+      "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ripemd160/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
+    },
+    "node_modules/ripemd160/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/ripemd160/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/ripemd160/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/ripemd160/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
+      "integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/sonner": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.4.tgz",
+      "integrity": "sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sparse-array": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/sparse-array/-/sparse-array-1.3.2.tgz",
+      "integrity": "sha512-ZT711fePGn3+kQyLuv1fpd3rNSkNF8vd5Kv2D+qnOANeyKs3fx6bUMGWRPvgTTcYV64QMqZKZwcuaQSP3AZ0tg=="
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/stream-http": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz",
+      "integrity": "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==",
+      "dev": true,
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "xtend": "^4.0.2"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/timers-browserify": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
+      "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
+      "dev": true,
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/tty-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+      "dev": true
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uint8-util": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/uint8-util/-/uint8-util-2.2.6.tgz",
+      "integrity": "sha512-r+ZjS8CzPhtPF771ROOadUoqC40OVdiMKBI8lTfJQWb4W7+73sMBwMYmai/uvNcmZ7tBJJyZSad03yMWIt3RQg==",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
+    },
+    "node_modules/uint8-varint": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.5.tgz",
+      "integrity": "sha512-jeFLbL/x30wBRnWjKE1qVBXeumG46r7XmYkpis955lTQ+blccGKFrOsSMHlxePwYB1pI7L8YPHz1t4jLxEs3nA==",
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/uint8arraylist": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.9.tgz",
+      "integrity": "sha512-KxWjyEFzchzik3aoQlK66oaoxIReoMo5bQRm1fcjBUZvE8xv/tyR3CTKhjh6K/faV8VaF6hd5pjr45CzbwuwkA==",
+      "dependencies": {
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ=="
+    },
+    "node_modules/ulidx": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ulidx/-/ulidx-2.1.0.tgz",
+      "integrity": "sha512-DlMi97oP9HASI3kLCjBlOhAG1SoisUrEqC2PJ7itiFbq9q5Zo0JejupXeu2Gke99W62epNzA4MFNToNiq8A5LA==",
+      "dependencies": {
+        "layerr": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uri-js/node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/url": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/utf8-codec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utf8-codec/-/utf8-codec-1.0.0.tgz",
+      "integrity": "sha512-S/QSLezp3qvG4ld5PUfXiH7mCFxLKjSVZRFkB3DOjgwHuJPFDkInAXc/anf7BAbHt/D38ozDzL+QMZ6/7gsI6w=="
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/vite": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-plugin-node-polyfills": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.28.0.tgz",
+      "integrity": "sha512-NXct/ci2ef4fRyCfTb8fk2HmR80Rv7icLd+cRH41TnUugDzdKMFKqFPpZYCFUInZMMem9bkLv5pkq02+7Xu7+w==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/plugin-inject": "^5.0.5",
+        "node-stdlib-browser": "^1.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/davidmyersdev"
+      },
+      "peerDependencies": {
+        "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vm-browserify": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+      "dev": true
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/admin-dapp/package.json
+++ b/admin-dapp/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@enbox/meshd-admin-dapp",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "test": "vitest run",
+    "preview": "vite preview"
+  },
+  "overrides": {
+    "esbuild": "0.28.1",
+    "lodash": "4.18.1"
+  },
+  "dependencies": {
+    "@enbox/agent": "0.8.6",
+    "@enbox/api": "0.6.44",
+    "@enbox/auth": "0.6.52",
+    "@enbox/browser": "0.3.30",
+    "@enbox/common": "0.1.1",
+    "@enbox/crypto": "0.1.1",
+    "@enbox/dids": "0.1.1",
+    "@enbox/dwn-sdk-js": "0.4.4",
+    "@enbox/protocols": "0.2.71",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.407.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "sonner": "^1.5.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.19.43",
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^5.2.0",
+    "typescript": "^5.2.2",
+    "vite": "^7.3.5",
+    "vite-plugin-node-polyfills": "^0.28.0",
+    "vitest": "^3.2.6"
+  }
+}

--- a/admin-dapp/public/favicon.svg
+++ b/admin-dapp/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="meshd">
+  <rect width="64" height="64" rx="14" fill="#17201d"/>
+  <circle cx="20" cy="22" r="7" fill="#8fd7c5"/>
+  <circle cx="44" cy="22" r="7" fill="#f1c46b"/>
+  <circle cx="32" cy="44" r="7" fill="#d46a6a"/>
+  <path d="M26 23h12M23 28l6 10M41 28l-6 10" fill="none" stroke="#f7faf5" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/admin-dapp/src/App.tsx
+++ b/admin-dapp/src/App.tsx
@@ -1,0 +1,614 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  CheckIcon,
+  ClipboardIcon,
+  KeyRoundIcon,
+  Loader2Icon,
+  LogOutIcon,
+  NetworkIcon,
+  PlusIcon,
+  RefreshCwIcon,
+  ServerIcon,
+  ShieldCheckIcon,
+  Trash2Icon,
+  UserPlusIcon,
+  XIcon
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { useEnbox } from "./enbox/use-enbox";
+import {
+  approveMeshdNodeRequest,
+  buildMeshdInviteURL,
+  createMeshdInvite,
+  createMeshdNetwork,
+  fetchMeshdNetworkTopology,
+  fetchMeshdNetworks,
+  rejectMeshdNodeRequest,
+  removeMeshdNode,
+  revokeMeshdInvite,
+  type CreateMeshdInviteResult,
+  type MeshdAdminSession,
+  type MeshdNetworkSummary,
+  type MeshdNetworkTopology,
+  type MeshdNodeRequestSummary,
+  type MeshdNodeSummary,
+  type MeshdPreAuthKeySummary
+} from "./meshd/admin";
+
+type LoadState = "idle" | "loading" | "ready" | "error";
+type InviteExpiryValue = "1h" | "24h" | "7d" | "30d" | "never";
+
+const INVITE_EXPIRY_OPTIONS: Array<{ value: InviteExpiryValue; label: string; durationMs?: number }> = [
+  { value: "1h", label: "1 hour", durationMs: 60 * 60 * 1000 },
+  { value: "24h", label: "24 hours", durationMs: 24 * 60 * 60 * 1000 },
+  { value: "7d", label: "7 days", durationMs: 7 * 24 * 60 * 60 * 1000 },
+  { value: "30d", label: "30 days", durationMs: 30 * 24 * 60 * 60 * 1000 },
+  { value: "never", label: "Never" }
+];
+
+function truncateDid(did: string, head = 18, tail = 10) {
+  if (did.length <= head + tail + 3) return did;
+  return `${did.slice(0, head)}...${did.slice(-tail)}`;
+}
+
+function formatTime(value?: string) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return value;
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit"
+  }).format(date);
+}
+
+async function copyToClipboard(value: string) {
+  await navigator.clipboard.writeText(value);
+  toast.success("Copied");
+}
+
+function inviteExpiryTimestamp(value: InviteExpiryValue) {
+  const option = INVITE_EXPIRY_OPTIONS.find((item) => item.value === value);
+  if (!option?.durationMs) {
+    return undefined;
+  }
+  return new Date(Date.now() + option.durationMs).toISOString();
+}
+
+export function App() {
+  const enboxState = useEnbox();
+
+  return (
+    <div className="app-shell">
+      <header className="topbar">
+        <button className="brand" type="button" aria-label="meshd Admin">
+          <span className="brand-mark"><NetworkIcon size={20} /></span>
+          <span className="brand-copy">
+            <span>meshd</span>
+            <small>Admin</small>
+          </span>
+        </button>
+        <div className="topbar-actions">
+          {enboxState.did ? (
+            <>
+              <span className="identity-pill" title={enboxState.did}>
+                <ShieldCheckIcon size={15} />
+                {truncateDid(enboxState.did, 14, 8)}
+              </span>
+              <button
+                className="icon-button"
+                type="button"
+                aria-label="Disconnect"
+                title="Disconnect"
+                onClick={() => void enboxState.disconnect({ clearStorage: true })}
+              >
+                <LogOutIcon size={17} />
+              </button>
+            </>
+          ) : null}
+        </div>
+      </header>
+
+      <main className="workspace">
+        {!enboxState.isConnected ? <ConnectPanel /> : <Dashboard />}
+      </main>
+    </div>
+  );
+}
+
+function ConnectPanel() {
+  const { connectWallet, isConnecting } = useEnbox();
+  const [error, setError] = useState<string>();
+
+  async function connect() {
+    setError(undefined);
+    try {
+      await connectWallet();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Wallet connection failed.";
+      if (!message.toLowerCase().includes("cancel")) {
+        setError(message);
+      }
+    }
+  }
+
+  return (
+    <section className="connect-panel">
+      <div className="connect-title">
+        <span className="panel-icon"><KeyRoundIcon size={22} /></span>
+        <div>
+          <h1>meshd Admin</h1>
+          <p>Connect an owner wallet to manage networks and node approvals.</p>
+        </div>
+      </div>
+      {error ? <div className="error-banner">{error}</div> : null}
+      <button className="primary-button" type="button" disabled={isConnecting} onClick={() => void connect()}>
+        {isConnecting ? <Loader2Icon className="spin" size={17} /> : <ShieldCheckIcon size={17} />}
+        Connect Wallet
+      </button>
+    </section>
+  );
+}
+
+function Dashboard() {
+  const { did, delegateDid, enbox, protocolsInitialized, protocolSetupError } = useEnbox();
+  const session = useMemo<MeshdAdminSession | undefined>(() => {
+    if (!did || !enbox) return undefined;
+    return {
+      ownerDid: did,
+      delegateDid,
+      agent: enbox.agent as never
+    };
+  }, [delegateDid, did, enbox]);
+
+  const [networks, setNetworks] = useState<MeshdNetworkSummary[]>([]);
+  const [selectedNetworkId, setSelectedNetworkId] = useState(() => new URLSearchParams(window.location.search).get("network") ?? "");
+  const [topology, setTopology] = useState<MeshdNetworkTopology>();
+  const [loadState, setLoadState] = useState<LoadState>("idle");
+  const [error, setError] = useState<string>();
+  const [inviteResult, setInviteResult] = useState<CreateMeshdInviteResult>();
+  const [inviteLabel, setInviteLabel] = useState("");
+  const [inviteExpiry, setInviteExpiry] = useState<InviteExpiryValue>("24h");
+  const [inviteReusable, setInviteReusable] = useState(false);
+  const [networkName, setNetworkName] = useState("");
+  const [networkCIDR, setNetworkCIDR] = useState("10.200.0.0/16");
+  const [busyAction, setBusyAction] = useState<string>();
+
+  const selectedNetwork = useMemo(() => {
+    if (networks.length === 0) return undefined;
+    return networks.find((network) => network.recordId === selectedNetworkId) ?? networks[0];
+  }, [networks, selectedNetworkId]);
+
+  const refreshNetworks = useCallback(async () => {
+    if (!session || !protocolsInitialized) return;
+    setLoadState("loading");
+    setError(undefined);
+    try {
+      const nextNetworks = await fetchMeshdNetworks(session);
+      setNetworks(nextNetworks);
+      if (!selectedNetworkId && nextNetworks[0]) {
+        setSelectedNetworkId(nextNetworks[0].recordId);
+      }
+      setLoadState("ready");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not load networks.");
+      setLoadState("error");
+    }
+  }, [protocolsInitialized, selectedNetworkId, session]);
+
+  const refreshTopology = useCallback(async () => {
+    if (!session || !protocolsInitialized || !selectedNetwork) return;
+    setError(undefined);
+    try {
+      const nextTopology = await fetchMeshdNetworkTopology(session, selectedNetwork);
+      setTopology(nextTopology);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not load network topology.");
+    }
+  }, [protocolsInitialized, selectedNetwork, session]);
+
+  useEffect(() => {
+    void refreshNetworks();
+  }, [refreshNetworks]);
+
+  useEffect(() => {
+    void refreshTopology();
+  }, [refreshTopology]);
+
+  useEffect(() => {
+    if (!selectedNetwork) return;
+    const params = new URLSearchParams(window.location.search);
+    params.set("network", selectedNetwork.recordId);
+    if (did) params.set("owner", did);
+    window.history.replaceState(null, "", `?${params.toString()}`);
+  }, [did, selectedNetwork]);
+
+  async function runAction(label: string, action: () => Promise<void>) {
+    setBusyAction(label);
+    setError(undefined);
+    try {
+      await action();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Action failed.");
+    } finally {
+      setBusyAction(undefined);
+    }
+  }
+
+  async function handleCreateNetwork() {
+    if (!session) return;
+    await runAction("create-network", async () => {
+      const network = await createMeshdNetwork(session, { name: networkName, meshCIDR: networkCIDR });
+      setNetworkName("");
+      setNetworks((current) => [network, ...current]);
+      setSelectedNetworkId(network.recordId);
+      toast.success("Network created");
+    });
+  }
+
+  async function handleCreateInvite() {
+    if (!session || !selectedNetwork) return;
+    await runAction("create-invite", async () => {
+      const result = await createMeshdInvite(session, selectedNetwork, {
+        label: inviteLabel.trim() || selectedNetwork.name,
+        expiresAt: inviteExpiryTimestamp(inviteExpiry),
+        reusable: inviteReusable
+      });
+      setInviteLabel("");
+      setInviteResult(result);
+      toast.success("Invite created");
+      await refreshTopology();
+    });
+  }
+
+  async function handleApprove(request: MeshdNodeRequestSummary) {
+    if (!session || !selectedNetwork) return;
+    await runAction(`approve-${request.recordId}`, async () => {
+      const result = await approveMeshdNodeRequest(session, selectedNetwork, request);
+      toast.success(`Node approved at ${result.meshIP}`);
+      await refreshTopology();
+    });
+  }
+
+  async function handleReject(request: MeshdNodeRequestSummary) {
+    if (!session) return;
+    await runAction(`reject-${request.recordId}`, async () => {
+      await rejectMeshdNodeRequest(session, request);
+      toast.success("Request rejected");
+      await refreshTopology();
+    });
+  }
+
+  async function handleRevokeInvite(key: MeshdPreAuthKeySummary) {
+    if (!session) return;
+    await runAction(`revoke-${key.recordId}`, async () => {
+      await revokeMeshdInvite(session, key);
+      toast.success("Invite revoked");
+      await refreshTopology();
+    });
+  }
+
+  async function handleCopyExistingInvite(key: MeshdPreAuthKeySummary) {
+    if (!session || !selectedNetwork) return;
+    const url = await buildMeshdInviteURL(session, selectedNetwork, key);
+    await copyToClipboard(url);
+  }
+
+  async function handleRemoveNode(node: MeshdNodeSummary) {
+    if (!session || !selectedNetwork) return;
+    await runAction(`remove-${node.recordId}`, async () => {
+      const result = await removeMeshdNode(session, selectedNetwork, node);
+      if (result.contextKeyCleanupError) {
+        toast.warning(result.contextKeyCleanupError);
+      }
+      toast.success("Node removed");
+      await refreshTopology();
+    });
+  }
+
+  if (protocolSetupError) {
+    return <StatePanel title="Protocol setup failed" detail={protocolSetupError} />;
+  }
+
+  if (!protocolsInitialized) {
+    return <StatePanel title="Initializing" detail="Preparing meshd protocols for this wallet session." loading />;
+  }
+
+  const allNodes = [
+    ...(topology?.members.flatMap((member) => member.nodes.map((node) => ({ node, member }))) ?? []),
+    ...(topology?.legacyNodes.map((node) => ({ node, member: undefined })) ?? [])
+  ];
+
+  return (
+    <div className="dashboard-grid">
+      <aside className="sidebar">
+        <div className="section-heading">
+          <span>Networks</span>
+          <button className="icon-button small" type="button" aria-label="Refresh networks" title="Refresh" onClick={() => void refreshNetworks()}>
+            <RefreshCwIcon size={15} />
+          </button>
+        </div>
+        {loadState === "loading" ? <div className="muted-row"><Loader2Icon className="spin" size={15} /> Loading</div> : null}
+        <div className="network-list">
+          {networks.map((network) => (
+            <button
+              key={network.recordId}
+              type="button"
+              className={`network-row ${network.recordId === selectedNetwork?.recordId ? "active" : ""}`}
+              onClick={() => setSelectedNetworkId(network.recordId)}
+            >
+              <NetworkIcon size={16} />
+              <span>
+                <strong>{network.name}</strong>
+                <small>{network.meshCIDR}</small>
+              </span>
+            </button>
+          ))}
+        </div>
+
+        <div className="create-box">
+          <div className="section-heading">
+            <span>Create</span>
+          </div>
+          <label>
+            Name
+            <input value={networkName} onChange={(event) => setNetworkName(event.target.value)} placeholder="home" />
+          </label>
+          <label>
+            CIDR
+            <input value={networkCIDR} onChange={(event) => setNetworkCIDR(event.target.value)} />
+          </label>
+          <button
+            className="secondary-button"
+            type="button"
+            disabled={busyAction === "create-network" || networkName.trim() === ""}
+            onClick={() => void handleCreateNetwork()}
+          >
+            {busyAction === "create-network" ? <Loader2Icon className="spin" size={16} /> : <PlusIcon size={16} />}
+            Create Network
+          </button>
+        </div>
+      </aside>
+
+      <section className="main-panel">
+        {error ? <div className="error-banner">{error}</div> : null}
+        {!selectedNetwork ? (
+          <StatePanel title="No networks" detail="Create a mesh network to start approving nodes." />
+        ) : (
+          <>
+            <div className="network-header">
+              <div>
+                <h1>{selectedNetwork.name}</h1>
+                <p>{selectedNetwork.meshCIDR}</p>
+              </div>
+              <div className="header-buttons">
+                <button className="secondary-button" type="button" onClick={() => void refreshTopology()}>
+                  <RefreshCwIcon size={16} />
+                  Refresh
+                </button>
+              </div>
+            </div>
+
+            <section className="invite-composer">
+              <div className="section-heading">
+                <span>New Invite</span>
+              </div>
+              <div className="invite-fields">
+                <label>
+                  Label
+                  <input value={inviteLabel} onChange={(event) => setInviteLabel(event.target.value)} placeholder={selectedNetwork.name} />
+                </label>
+                <label>
+                  Expires
+                  <select value={inviteExpiry} onChange={(event) => setInviteExpiry(event.target.value as InviteExpiryValue)}>
+                    {INVITE_EXPIRY_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>{option.label}</option>
+                    ))}
+                  </select>
+                </label>
+                <label className="toggle-field">
+                  <input
+                    type="checkbox"
+                    checked={inviteReusable}
+                    onChange={(event) => setInviteReusable(event.target.checked)}
+                  />
+                  Reusable
+                </label>
+                <button
+                  className="primary-button"
+                  type="button"
+                  disabled={busyAction === "create-invite"}
+                  onClick={() => void handleCreateInvite()}
+                >
+                  {busyAction === "create-invite" ? <Loader2Icon className="spin" size={16} /> : <UserPlusIcon size={16} />}
+                  Create Invite
+                </button>
+              </div>
+            </section>
+
+            {inviteResult ? (
+              <div className="invite-result">
+                <div>
+                  <strong>Invite URL</strong>
+                  <code>{inviteResult.url}</code>
+                </div>
+                <button className="icon-button" type="button" aria-label="Copy invite URL" title="Copy" onClick={() => void copyToClipboard(inviteResult.url)}>
+                  <ClipboardIcon size={16} />
+                </button>
+              </div>
+            ) : null}
+
+            <section className="content-section">
+              <div className="section-heading">
+                <span>Pending</span>
+                <small>{topology?.pendingRequests.length ?? 0}</small>
+              </div>
+              <div className="stack">
+                {topology?.pendingRequests.length ? topology.pendingRequests.map((request) => (
+                  <PendingRequestRow
+                    key={request.recordId}
+                    request={request}
+                    busyAction={busyAction}
+                    onApprove={handleApprove}
+                    onReject={handleReject}
+                  />
+                )) : <EmptyRow icon={<ShieldCheckIcon size={18} />} text="No pending approvals" />}
+              </div>
+            </section>
+
+            <section className="content-section">
+              <div className="section-heading">
+                <span>Nodes</span>
+                <small>{allNodes.length}</small>
+              </div>
+              <div className="node-grid">
+                {allNodes.length ? allNodes.map(({ node, member }) => (
+                  <NodeCard key={node.recordId} node={node} owner={member?.did} busyAction={busyAction} onRemove={handleRemoveNode} />
+                )) : <EmptyRow icon={<ServerIcon size={18} />} text="No nodes" />}
+              </div>
+            </section>
+
+            <section className="content-section">
+              <div className="section-heading">
+                <span>Invites</span>
+                <small>{topology?.preAuthKeys.length ?? 0}</small>
+              </div>
+              <div className="stack">
+                {topology?.preAuthKeys.length ? topology.preAuthKeys.map((key) => (
+                  <InviteRow
+                    key={key.recordId}
+                    invite={key}
+                    busyAction={busyAction}
+                    onCopy={handleCopyExistingInvite}
+                    onRevoke={handleRevokeInvite}
+                  />
+                )) : <EmptyRow icon={<UserPlusIcon size={18} />} text="No active invites" />}
+              </div>
+            </section>
+          </>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function PendingRequestRow({
+  request,
+  busyAction,
+  onApprove,
+  onReject
+}: {
+  request: MeshdNodeRequestSummary;
+  busyAction?: string;
+  onApprove: (request: MeshdNodeRequestSummary) => Promise<void>;
+  onReject: (request: MeshdNodeRequestSummary) => Promise<void>;
+}) {
+  const approving = busyAction === `approve-${request.recordId}`;
+  const rejecting = busyAction === `reject-${request.recordId}`;
+  return (
+    <article className="data-row">
+      <div className="row-main">
+        <span className="row-icon"><ServerIcon size={17} /></span>
+        <span>
+          <strong>{request.label || truncateDid(request.nodeDID)}</strong>
+          <small>{request.requestKind === "owner-node" || request.protocolPath === "nodeRequest" ? "Owner request" : "Invite request"}</small>
+        </span>
+      </div>
+      <code title={request.nodeDID}>{truncateDid(request.nodeDID)}</code>
+      <div className="row-actions">
+        <button className="icon-button success" type="button" aria-label="Approve" title="Approve" disabled={approving || rejecting} onClick={() => void onApprove(request)}>
+          {approving ? <Loader2Icon className="spin" size={16} /> : <CheckIcon size={16} />}
+        </button>
+        <button className="icon-button danger" type="button" aria-label="Reject" title="Reject" disabled={approving || rejecting} onClick={() => void onReject(request)}>
+          {rejecting ? <Loader2Icon className="spin" size={16} /> : <XIcon size={16} />}
+        </button>
+      </div>
+    </article>
+  );
+}
+
+function NodeCard({
+  node,
+  owner,
+  busyAction,
+  onRemove
+}: {
+  node: MeshdNodeSummary;
+  owner?: string;
+  busyAction?: string;
+  onRemove: (node: MeshdNodeSummary) => Promise<void>;
+}) {
+  const removing = busyAction === `remove-${node.recordId}`;
+  return (
+    <article className="node-card">
+      <div className="node-card-header">
+        <span className="row-icon"><ServerIcon size={17} /></span>
+        <strong>{node.label || node.meshIP || truncateDid(node.did, 12, 6)}</strong>
+        <button className="icon-button danger small" type="button" aria-label="Remove node" title="Remove" disabled={removing} onClick={() => void onRemove(node)}>
+          {removing ? <Loader2Icon className="spin" size={15} /> : <Trash2Icon size={15} />}
+        </button>
+      </div>
+      <dl>
+        <div><dt>Mesh IP</dt><dd>{node.meshIP || "unknown"}</dd></div>
+        <div><dt>Node</dt><dd title={node.did}>{truncateDid(node.did)}</dd></div>
+        {owner ? <div><dt>Owner</dt><dd title={owner}>{truncateDid(owner)}</dd></div> : null}
+        {node.expiresAt ? <div><dt>Expires</dt><dd>{formatTime(node.expiresAt)}</dd></div> : null}
+      </dl>
+    </article>
+  );
+}
+
+function InviteRow({
+  invite,
+  busyAction,
+  onCopy,
+  onRevoke
+}: {
+  invite: MeshdPreAuthKeySummary;
+  busyAction?: string;
+  onCopy: (invite: MeshdPreAuthKeySummary) => Promise<void>;
+  onRevoke: (invite: MeshdPreAuthKeySummary) => Promise<void>;
+}) {
+  const revoking = busyAction === `revoke-${invite.recordId}`;
+  return (
+    <article className="data-row">
+      <div className="row-main">
+        <span className="row-icon"><UserPlusIcon size={17} /></span>
+        <span>
+          <strong>{invite.label || truncateDid(invite.recordId, 12, 6)}</strong>
+          <small>{invite.expiresAt ? `Expires ${formatTime(invite.expiresAt)}` : "No expiry"}</small>
+        </span>
+      </div>
+      <code>{invite.usedBy.length} used</code>
+      <div className="row-actions">
+        <button className="icon-button" type="button" aria-label="Copy invite" title="Copy" onClick={() => void onCopy(invite)}>
+          <ClipboardIcon size={16} />
+        </button>
+        <button className="icon-button danger" type="button" aria-label="Revoke invite" title="Revoke" disabled={revoking} onClick={() => void onRevoke(invite)}>
+          {revoking ? <Loader2Icon className="spin" size={16} /> : <Trash2Icon size={16} />}
+        </button>
+      </div>
+    </article>
+  );
+}
+
+function StatePanel({ title, detail, loading }: { title: string; detail: string; loading?: boolean }) {
+  return (
+    <section className="state-panel">
+      {loading ? <Loader2Icon className="spin" size={24} /> : <NetworkIcon size={24} />}
+      <h1>{title}</h1>
+      <p>{detail}</p>
+    </section>
+  );
+}
+
+function EmptyRow({ icon, text }: { icon: React.ReactNode; text: string }) {
+  return (
+    <div className="empty-row">
+      {icon}
+      <span>{text}</span>
+    </div>
+  );
+}

--- a/admin-dapp/src/enbox/EnboxProvider.tsx
+++ b/admin-dapp/src/enbox/EnboxProvider.tsx
@@ -1,0 +1,273 @@
+import React, { createContext, useCallback, useEffect, useRef, useState } from "react";
+
+import { AuthManager, BrowserConnectHandler, Enbox } from "@enbox/browser";
+import type { AuthManagerOptions, AuthSession } from "@enbox/browser";
+import { BrowserStorage } from "@enbox/auth";
+import type { ProviderAuthParams, ProviderAuthResult } from "@enbox/auth";
+
+import {
+  AUTH_DATA_PATH,
+  AUTH_STORAGE_PREFIX,
+  DAPP_NAME,
+  DAPP_PROTOCOLS,
+  DWN_ENDPOINTS,
+  IDENTITY_SYNC_PROTOCOLS,
+  VAULT_PASSWORD_STORAGE_KEY,
+  WALLET_OPTIONS
+} from "./config";
+import { ensureProtocolsReady } from "./protocols";
+
+type EnboxContextProps = {
+  auth: AuthManager | null;
+  enbox?: Enbox;
+  did?: string;
+  delegateDid?: string;
+  isConnecting: boolean;
+  isConnected: boolean;
+  isDelegateSession: boolean;
+  protocolsInitialized: boolean;
+  protocolSetupError?: string;
+  connectWallet: () => Promise<void>;
+  disconnect: (options?: { clearStorage?: boolean }) => Promise<void>;
+};
+
+export const EnboxContext = createContext<EnboxContextProps>({
+  auth: null,
+  isConnecting: false,
+  isConnected: false,
+  isDelegateSession: false,
+  protocolsInitialized: false,
+  connectWallet: () => Promise.reject(new Error("EnboxProvider not mounted")),
+  disconnect: () => Promise.reject(new Error("EnboxProvider not mounted"))
+});
+
+function randomHex(byteLength: number) {
+  const bytes = new Uint8Array(byteLength);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function getOrCreateVaultPassword() {
+  const existing = localStorage.getItem(VAULT_PASSWORD_STORAGE_KEY);
+  if (existing) {
+    return existing;
+  }
+  const created = randomHex(32);
+  localStorage.setItem(VAULT_PASSWORD_STORAGE_KEY, created);
+  return created;
+}
+
+async function resolveProviderAuth(request: ProviderAuthParams): Promise<ProviderAuthResult> {
+  const response = await fetch(request.authorizeUrl, { signal: AbortSignal.timeout(30_000) });
+  if (!response.ok) {
+    throw new Error(`Provider auth failed (${response.status}): ${await response.text()}`);
+  }
+  const data = await response.json() as ProviderAuthResult;
+  if (data.state !== request.state) {
+    throw new Error("Provider auth state mismatch");
+  }
+  return data;
+}
+
+async function createAuthManager(password: string) {
+  return AuthManager.create({
+    dataPath: AUTH_DATA_PATH,
+    password,
+    storage: new BrowserStorage(AUTH_STORAGE_PREFIX),
+    dwnEndpoints: DWN_ENDPOINTS,
+    identitySyncProtocols: IDENTITY_SYNC_PROTOCOLS,
+    connectHandler: BrowserConnectHandler({
+      wallets: WALLET_OPTIONS,
+      appName: DAPP_NAME,
+      appIcon: `${window.location.origin}/favicon.svg`
+    }),
+    registration: {
+      onSuccess: () => console.info("[meshd-admin] DWN registration complete"),
+      onFailure: (error: unknown) => console.warn("[meshd-admin] DWN registration failed:", error),
+      persistTokens: true,
+      onProviderAuthRequired: resolveProviderAuth
+    }
+  } satisfies AuthManagerOptions);
+}
+
+function isIncorrectVaultPasswordError(error: unknown) {
+  return error instanceof Error
+    && error.message.includes("Unable to unlock the vault due to an incorrect password");
+}
+
+async function deleteIndexedDbByNamePart(namePart: string) {
+  const indexedDb = globalThis.indexedDB as (IDBFactory & {
+    databases?: () => Promise<Array<{ name?: string | null }>>;
+  }) | undefined;
+  if (!indexedDb?.databases) {
+    return;
+  }
+
+  const databases = await indexedDb.databases();
+  await Promise.all(databases.map((database) => {
+    if (!database.name || !database.name.includes(namePart)) {
+      return Promise.resolve();
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      const request = indexedDb.deleteDatabase(database.name as string);
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error ?? new Error(`Could not delete ${database.name}`));
+      request.onblocked = () => resolve();
+    });
+  }));
+}
+
+async function resetScopedAuthStorage() {
+  localStorage.removeItem(VAULT_PASSWORD_STORAGE_KEY);
+  for (const key of Object.keys(localStorage)) {
+    if (key.startsWith(AUTH_STORAGE_PREFIX)) {
+      localStorage.removeItem(key);
+    }
+  }
+  await deleteIndexedDbByNamePart(AUTH_DATA_PATH);
+}
+
+export const EnboxProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const authRef = useRef<AuthManager | null>(null);
+
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [enbox, setEnbox] = useState<Enbox | undefined>();
+  const [did, setDid] = useState<string | undefined>();
+  const [delegateDid, setDelegateDid] = useState<string | undefined>();
+  const [isDelegateSession, setIsDelegateSession] = useState(false);
+  const [protocolsInitialized, setProtocolsInitialized] = useState(false);
+  const [protocolSetupError, setProtocolSetupError] = useState<string | undefined>();
+
+  const applySession = useCallback((session: AuthSession) => {
+    const api = Enbox.fromSession(session);
+    setEnbox(api);
+    setDid(session.did);
+    setDelegateDid(session.delegateDid);
+    setIsDelegateSession(Boolean(session.delegateDid));
+    setProtocolsInitialized(false);
+    setProtocolSetupError(undefined);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function init() {
+      setIsConnecting(true);
+      try {
+        const password = getOrCreateVaultPassword();
+        const auth = await createAuthManager(password);
+        if (cancelled) {
+          return;
+        }
+        authRef.current = auth;
+        const session = await auth.restoreSession({ password });
+        if (!cancelled && session) {
+          applySession(session);
+        }
+      } catch (error) {
+        console.warn("[meshd-admin] Auth restore failed:", error);
+      } finally {
+        if (!cancelled) {
+          setIsConnecting(false);
+        }
+      }
+    }
+
+    void init();
+    return () => {
+      cancelled = true;
+    };
+  }, [applySession]);
+
+  useEffect(() => {
+    if (!enbox || protocolsInitialized) {
+      return;
+    }
+
+    let cancelled = false;
+    setProtocolSetupError(undefined);
+
+    ensureProtocolsReady(enbox)
+      .then(() => {
+        if (!cancelled) {
+          setProtocolsInitialized(true);
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setProtocolSetupError(error instanceof Error ? error.message : "Protocol setup failed.");
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enbox, protocolsInitialized]);
+
+  const connectWallet = useCallback(async () => {
+    let auth = authRef.current;
+    if (!auth) {
+      throw new Error("AuthManager not ready");
+    }
+
+    setIsConnecting(true);
+    try {
+      try {
+        const session = await auth.connect({ protocols: DAPP_PROTOCOLS });
+        applySession(session);
+      } catch (error) {
+        if (!isIncorrectVaultPasswordError(error)) {
+          throw error;
+        }
+        await resetScopedAuthStorage();
+        const password = getOrCreateVaultPassword();
+        auth = await createAuthManager(password);
+        authRef.current = auth;
+        const session = await auth.connect({ protocols: DAPP_PROTOCOLS });
+        applySession(session);
+      }
+    } finally {
+      setIsConnecting(false);
+    }
+  }, [applySession]);
+
+  const disconnect = useCallback(async (options?: { clearStorage?: boolean }) => {
+    const auth = authRef.current;
+    try {
+      await enbox?.disconnect();
+      await auth?.disconnect({ clearStorage: options?.clearStorage });
+    } finally {
+      setEnbox(undefined);
+      setDid(undefined);
+      setDelegateDid(undefined);
+      setIsDelegateSession(false);
+      setProtocolsInitialized(false);
+      setProtocolSetupError(undefined);
+      if (options?.clearStorage) {
+        await resetScopedAuthStorage();
+        window.location.reload();
+      }
+    }
+  }, [enbox]);
+
+  return (
+    <EnboxContext.Provider
+      value={{
+        auth: authRef.current,
+        enbox,
+        did,
+        delegateDid,
+        isConnecting,
+        isConnected: Boolean(enbox),
+        isDelegateSession,
+        protocolsInitialized,
+        protocolSetupError,
+        connectWallet,
+        disconnect
+      }}
+    >
+      {children}
+    </EnboxContext.Provider>
+  );
+};

--- a/admin-dapp/src/enbox/config.ts
+++ b/admin-dapp/src/enbox/config.ts
@@ -1,0 +1,49 @@
+import type { AuthManagerOptions, Permission, ProtocolRequest, WalletOption } from "@enbox/browser";
+
+import meshProtocolDefinition from "../../../protocols/wireguard-mesh.json";
+import keyDeliveryProtocolDefinition from "../../../protocols/key-delivery.json";
+
+export const MESHD_PROTOCOL_URI = "https://enbox.id/protocols/wireguard-mesh";
+export const MESHD_KEY_DELIVERY_PROTOCOL_URI = "https://identity.foundation/protocols/key-delivery";
+
+type IdentitySyncProtocols = NonNullable<AuthManagerOptions["identitySyncProtocols"]>;
+
+const ADMIN_PERMISSIONS = ["read", "write", "delete"] satisfies Permission[];
+
+export const DAPP_NAME = import.meta.env.VITE_ENBOX_DAPP_NAME || "meshd Admin";
+
+export const WALLET_OPTIONS = [
+  {
+    name: "Enbox Wallet",
+    url: import.meta.env.VITE_ENBOX_WALLET_URL || "https://enbox-wallet.pages.dev",
+    icon: `${import.meta.env.VITE_ENBOX_WALLET_URL || "https://enbox-wallet.pages.dev"}/favicon.ico`,
+    description: "Your Enbox identity wallet"
+  },
+  {
+    name: "Blue Enbox Wallet",
+    url: import.meta.env.VITE_ENBOX_BLUE_WALLET_URL || "https://blue-enbox-wallet.pages.dev",
+    icon: `${import.meta.env.VITE_ENBOX_BLUE_WALLET_URL || "https://blue-enbox-wallet.pages.dev"}/favicon.ico`,
+    description: "Your Enbox identity wallet"
+  }
+] satisfies WalletOption[];
+
+export const DWN_ENDPOINTS = (
+  import.meta.env.VITE_ENBOX_DWN_ENDPOINTS || "https://dev.aws.dwn.enbox.id,https://enbox-dwn.fly.dev"
+).split(",").map((endpoint: string) => endpoint.trim()).filter(Boolean);
+
+export const MeshProtocolDefinition = meshProtocolDefinition;
+export const KeyDeliveryProtocolDefinition = keyDeliveryProtocolDefinition;
+
+export const DAPP_PROTOCOLS = [
+  { definition: MeshProtocolDefinition, permissions: ADMIN_PERMISSIONS },
+  { definition: KeyDeliveryProtocolDefinition, permissions: ADMIN_PERMISSIONS }
+] as unknown as ProtocolRequest[];
+
+export const IDENTITY_SYNC_PROTOCOLS: IdentitySyncProtocols = [
+  MESHD_PROTOCOL_URI,
+  MESHD_KEY_DELIVERY_PROTOCOL_URI
+];
+
+export const AUTH_DATA_PATH = "DATA/ENBOX_MESHD_ADMIN_DAPP";
+export const AUTH_STORAGE_PREFIX = "enbox:meshd-admin:";
+export const VAULT_PASSWORD_STORAGE_KEY = `${AUTH_STORAGE_PREFIX}vault-password`;

--- a/admin-dapp/src/enbox/protocols.test.ts
+++ b/admin-dapp/src/enbox/protocols.test.ts
@@ -1,0 +1,112 @@
+import { normalizeProtocolRequests } from "@enbox/auth";
+import type { Enbox } from "@enbox/browser";
+import { DwnInterfaceName, DwnMethodName } from "@enbox/dwn-sdk-js";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  DAPP_PROTOCOLS,
+  KeyDeliveryProtocolDefinition,
+  MESHD_KEY_DELIVERY_PROTOCOL_URI,
+  MESHD_PROTOCOL_URI,
+  MeshProtocolDefinition
+} from "./config";
+import { ensureProtocolsReady, KeyDeliveryProtocol, MeshProtocol } from "./protocols";
+
+type ConfigurableProtocol = {
+  protocol: string;
+  configure: ReturnType<typeof vi.fn>;
+};
+
+function configurableProtocol(protocol: string, definition: unknown, status = { code: 200, detail: "OK" }) {
+  return {
+    protocol,
+    configure: vi.fn().mockResolvedValue({
+      status,
+      protocol: { definition }
+    })
+  } satisfies ConfigurableProtocol;
+}
+
+function fakeEnbox(mesh: ConfigurableProtocol, keyDelivery: ConfigurableProtocol) {
+  return {
+    using: vi.fn((protocol: unknown) => {
+      if (protocol === MeshProtocol) return mesh;
+      if (protocol === KeyDeliveryProtocol) return keyDelivery;
+      throw new Error("unexpected protocol");
+    })
+  } as unknown as Enbox;
+}
+
+describe("meshd admin protocol requests", () => {
+  it("asks wallet connect for protocol install plus record grants, not delegated protocol configure", () => {
+    const requests = normalizeProtocolRequests(DAPP_PROTOCOLS);
+
+    for (const protocol of [MESHD_PROTOCOL_URI, MESHD_KEY_DELIVERY_PROTOCOL_URI]) {
+      const request = requests.find((item) => item.protocolDefinition.protocol === protocol);
+      expect(request).toBeDefined();
+      expect(request?.permissionScopes).toEqual(expect.arrayContaining([
+        { protocol, interface: DwnInterfaceName.Protocols, method: DwnMethodName.Query },
+        { protocol, interface: DwnInterfaceName.Messages, method: DwnMethodName.Read },
+        { protocol, interface: DwnInterfaceName.Records, method: DwnMethodName.Read },
+        { protocol, interface: DwnInterfaceName.Records, method: DwnMethodName.Write },
+        { protocol, interface: DwnInterfaceName.Records, method: DwnMethodName.Delete }
+      ]));
+      expect(request?.permissionScopes).not.toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          protocol,
+          interface: DwnInterfaceName.Protocols,
+          method: DwnMethodName.Configure
+        })
+      ]));
+    }
+  });
+});
+
+describe("ensureProtocolsReady", () => {
+  it("runs the SDK readiness/import step for mesh and key-delivery protocols", async () => {
+    const mesh = configurableProtocol(MESHD_PROTOCOL_URI, MeshProtocolDefinition);
+    const keyDelivery = configurableProtocol(MESHD_KEY_DELIVERY_PROTOCOL_URI, KeyDeliveryProtocolDefinition);
+
+    await expect(ensureProtocolsReady(fakeEnbox(mesh, keyDelivery))).resolves.toBeUndefined();
+
+    expect(mesh.configure).toHaveBeenCalledOnce();
+    expect(keyDelivery.configure).toHaveBeenCalledOnce();
+  });
+
+  it("fails when the wallet-installed mesh protocol is missing expected types", async () => {
+    const staleDefinition = structuredClone(MeshProtocolDefinition) as typeof MeshProtocolDefinition;
+    delete (staleDefinition.types as Record<string, unknown>).preAuthKey;
+
+    const mesh = configurableProtocol(MESHD_PROTOCOL_URI, staleDefinition);
+    const keyDelivery = configurableProtocol(MESHD_KEY_DELIVERY_PROTOCOL_URI, KeyDeliveryProtocolDefinition);
+
+    await expect(ensureProtocolsReady(fakeEnbox(mesh, keyDelivery))).rejects.toThrow(
+      "meshd mesh protocol: wallet protocol is missing types: preAuthKey."
+    );
+  });
+
+  it("fails when the wallet-installed mesh protocol is missing expected paths", async () => {
+    const staleDefinition = structuredClone(MeshProtocolDefinition) as typeof MeshProtocolDefinition;
+    delete (staleDefinition.structure.network.member.node as Record<string, unknown>).endpoint;
+
+    const mesh = configurableProtocol(MESHD_PROTOCOL_URI, staleDefinition);
+    const keyDelivery = configurableProtocol(MESHD_KEY_DELIVERY_PROTOCOL_URI, KeyDeliveryProtocolDefinition);
+
+    await expect(ensureProtocolsReady(fakeEnbox(mesh, keyDelivery))).rejects.toThrow(
+      "meshd mesh protocol: wallet protocol is missing paths: network/member/node/endpoint."
+    );
+  });
+
+  it("surfaces protocol readiness status failures", async () => {
+    const mesh = configurableProtocol(
+      MESHD_PROTOCOL_URI,
+      MeshProtocolDefinition,
+      { code: 401, detail: "missing delegated grant" }
+    );
+    const keyDelivery = configurableProtocol(MESHD_KEY_DELIVERY_PROTOCOL_URI, KeyDeliveryProtocolDefinition);
+
+    await expect(ensureProtocolsReady(fakeEnbox(mesh, keyDelivery))).rejects.toThrow(
+      `${MESHD_PROTOCOL_URI}: 401 missing delegated grant`
+    );
+  });
+});

--- a/admin-dapp/src/enbox/protocols.ts
+++ b/admin-dapp/src/enbox/protocols.ts
@@ -1,0 +1,162 @@
+import { defineProtocol } from "@enbox/browser";
+import type { Enbox } from "@enbox/browser";
+import type { ConnectPermissionRequest } from "@enbox/agent";
+
+import {
+  KeyDeliveryProtocolDefinition,
+  MESHD_KEY_DELIVERY_PROTOCOL_URI,
+  MESHD_PROTOCOL_URI,
+  MeshProtocolDefinition
+} from "./config";
+
+type MeshProtocolSchemaMap = {
+  network: Record<string, unknown>;
+  member: Record<string, unknown>;
+  nodeRequest: Record<string, unknown>;
+  nodeApproval: Record<string, unknown>;
+  node: Record<string, unknown>;
+  nodeInfo: Record<string, unknown>;
+  endpoint: Record<string, unknown>;
+  aclPolicy: Record<string, unknown>;
+  relay: Record<string, unknown>;
+  preAuthKey: Record<string, unknown>;
+};
+
+type KeyDeliverySchemaMap = {
+  contextKey: Record<string, unknown>;
+};
+
+type ProtocolDefinition = {
+  protocol?: unknown;
+  types?: unknown;
+  structure?: unknown;
+};
+
+type InstalledProtocol = {
+  definition?: unknown;
+};
+
+export const MeshProtocol = defineProtocol(
+  MeshProtocolDefinition as never,
+  {} as MeshProtocolSchemaMap
+);
+
+export const KeyDeliveryProtocol = defineProtocol(
+  KeyDeliveryProtocolDefinition as never,
+  {} as KeyDeliverySchemaMap
+);
+
+export const MeshNodePermissionRequest: ConnectPermissionRequest = {
+  protocolDefinition: MeshProtocolDefinition as never,
+  permissionScopes: [
+    { interface: "Records", method: "Read", protocol: MESHD_PROTOCOL_URI },
+    { interface: "Records", method: "Write", protocol: MESHD_PROTOCOL_URI, protocolPath: "network/node/nodeInfo" },
+    { interface: "Records", method: "Write", protocol: MESHD_PROTOCOL_URI, protocolPath: "network/node/endpoint" },
+    { interface: "Records", method: "Write", protocol: MESHD_PROTOCOL_URI, protocolPath: "network/member/node/nodeInfo" },
+    { interface: "Records", method: "Write", protocol: MESHD_PROTOCOL_URI, protocolPath: "network/member/node/endpoint" }
+  ] as never
+};
+
+export const MeshAdminPermissionRequest: ConnectPermissionRequest = {
+  protocolDefinition: MeshProtocolDefinition as never,
+  permissionScopes: [
+    { interface: "Records", method: "Read", protocol: MESHD_PROTOCOL_URI },
+    { interface: "Records", method: "Write", protocol: MESHD_PROTOCOL_URI },
+    { interface: "Records", method: "Delete", protocol: MESHD_PROTOCOL_URI }
+  ] as never
+};
+
+export const KeyDeliveryAdminPermissionRequest: ConnectPermissionRequest = {
+  protocolDefinition: KeyDeliveryProtocolDefinition as never,
+  permissionScopes: [
+    { interface: "Records", method: "Read", protocol: MESHD_KEY_DELIVERY_PROTOCOL_URI },
+    { interface: "Records", method: "Write", protocol: MESHD_KEY_DELIVERY_PROTOCOL_URI },
+    { interface: "Records", method: "Delete", protocol: MESHD_KEY_DELIVERY_PROTOCOL_URI }
+  ] as never
+};
+
+type ConfigurableProtocol = {
+  protocol: string;
+  configure: () => Promise<{ status: { code: number; detail: string }; protocol?: InstalledProtocol }>;
+};
+
+function ensureConfigureStatus(protocol: string, status: { code: number; detail: string }) {
+  if ((status.code >= 200 && status.code < 300) || status.code === 409) {
+    return;
+  }
+  throw new Error(`${protocol}: ${status.code} ${status.detail}`);
+}
+
+async function configure(protocol: ConfigurableProtocol) {
+  const { status, protocol: installed } = await protocol.configure();
+  ensureConfigureStatus(protocol.protocol, status);
+  return installed;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function protocolDefinition(value: unknown): ProtocolDefinition | undefined {
+  return isRecord(value) ? value : undefined;
+}
+
+function collectProtocolPaths(structure: unknown, prefix = ""): string[] {
+  if (!isRecord(structure)) {
+    return [];
+  }
+
+  const paths: string[] = [];
+  for (const [key, value] of Object.entries(structure)) {
+    if (key.startsWith("$") || !isRecord(value)) {
+      continue;
+    }
+
+    const path = prefix ? `${prefix}/${key}` : key;
+    paths.push(path, ...collectProtocolPaths(value, path));
+  }
+  return paths;
+}
+
+function assertExpectedProtocolDefinition(
+  label: string,
+  expectedDefinition: ProtocolDefinition,
+  installedDefinition: unknown
+) {
+  const installed = protocolDefinition(installedDefinition);
+  if (!installed) {
+    return;
+  }
+
+  if (installed.protocol !== expectedDefinition.protocol) {
+    throw new Error(`${label}: wallet installed an unexpected protocol definition.`);
+  }
+
+  const expectedTypes = isRecord(expectedDefinition.types) ? Object.keys(expectedDefinition.types) : [];
+  const installedTypes = isRecord(installed.types) ? Object.keys(installed.types) : [];
+  const missingTypes = expectedTypes.filter((type) => !installedTypes.includes(type));
+  if (missingTypes.length > 0) {
+    throw new Error(`${label}: wallet protocol is missing types: ${missingTypes.join(", ")}.`);
+  }
+
+  const expectedPaths = collectProtocolPaths(expectedDefinition.structure);
+  const installedPaths = collectProtocolPaths(installed.structure);
+  const missingPaths = expectedPaths.filter((path) => !installedPaths.includes(path));
+  if (missingPaths.length > 0) {
+    throw new Error(`${label}: wallet protocol is missing paths: ${missingPaths.join(", ")}.`);
+  }
+}
+
+export async function ensureProtocolsReady(enbox: Enbox) {
+  const [mesh, keyDelivery] = await Promise.all([
+    configure(enbox.using(MeshProtocol) as ConfigurableProtocol),
+    configure(enbox.using(KeyDeliveryProtocol) as ConfigurableProtocol)
+  ]);
+
+  assertExpectedProtocolDefinition("meshd mesh protocol", MeshProtocolDefinition as ProtocolDefinition, mesh?.definition);
+  assertExpectedProtocolDefinition(
+    "meshd key-delivery protocol",
+    KeyDeliveryProtocolDefinition as ProtocolDefinition,
+    keyDelivery?.definition
+  );
+}

--- a/admin-dapp/src/enbox/use-enbox.ts
+++ b/admin-dapp/src/enbox/use-enbox.ts
@@ -1,0 +1,11 @@
+import { useContext } from "react";
+
+import { EnboxContext } from "./EnboxProvider";
+
+export function useEnbox() {
+  const context = useContext(EnboxContext);
+  if (!context) {
+    throw new Error("useEnbox must be used within EnboxProvider");
+  }
+  return context;
+}

--- a/admin-dapp/src/main.tsx
+++ b/admin-dapp/src/main.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { Toaster } from "sonner";
+
+import { App } from "./App";
+import { EnboxProvider } from "./enbox/EnboxProvider";
+import "./styles.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <EnboxProvider>
+      <App />
+      <Toaster position="bottom-right" richColors />
+    </EnboxProvider>
+  </React.StrictMode>
+);

--- a/admin-dapp/src/meshd/admin.test.ts
+++ b/admin-dapp/src/meshd/admin.test.ts
@@ -1,0 +1,317 @@
+import { DwnInterface } from "@enbox/agent";
+import { describe, expect, it, vi } from "vitest";
+
+import { MESHD_PROTOCOL_URI } from "@/enbox/config";
+
+import {
+  buildMeshdInviteURL,
+  createMeshdInvite,
+  createMeshdNetwork,
+  fetchMeshdNetworks,
+  type MeshdAdminAgent,
+  type MeshdAdminSession,
+  type MeshdNetworkSummary
+} from "./admin";
+
+type CapturedRequest = Record<string, any>;
+
+function decodeBase64UrlJson(value: string) {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(normalized.length + ((4 - normalized.length % 4) % 4), "=");
+  return JSON.parse(atob(padded));
+}
+
+async function blobJson(blob: Blob) {
+  return JSON.parse(await blob.text());
+}
+
+function recordEntry(recordId: string, protocolPath: string, data: Record<string, unknown>, dateCreated = "2026-06-24T00:00:00Z") {
+  return {
+    recordsWrite: {
+      recordId,
+      descriptor: {
+        protocol: MESHD_PROTOCOL_URI,
+        protocolPath,
+        dateCreated
+      },
+      encodedData: btoa(JSON.stringify(data)).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+    }
+  };
+}
+
+function createFakeSession(options: {
+  delegate?: boolean;
+  endpoints?: string[];
+  queryEntries?: unknown[];
+  recordIds?: string[];
+} = {}) {
+  const requests: CapturedRequest[] = [];
+  const pushes: CapturedRequest[] = [];
+  const recordIds = [...(options.recordIds ?? ["record-1", "record-2", "record-3"])];
+  let cid = 0;
+
+  const agent: MeshdAdminAgent = {
+    permissions: {
+      getPermissionForRequest: vi.fn(async (request) => ({
+        message: {
+          grant: `${request.protocol}:${String(request.messageType)}`
+        }
+      }))
+    },
+    dwn: {
+      getDwnEndpointUrlsForTarget: vi.fn(async () => options.endpoints ?? ["https://dev.aws.dwn.enbox.id"])
+    },
+    processDwnRequest: vi.fn(async (request: CapturedRequest) => {
+      requests.push(request);
+      if (request.messageType === DwnInterface.RecordsQuery) {
+        return {
+          reply: {
+            status: { code: 200, detail: "OK" },
+            entries: options.queryEntries ?? []
+          }
+        };
+      }
+
+      const recordId = recordIds.shift() ?? `record-${requests.length}`;
+      return {
+        reply: { status: { code: 202, detail: "Accepted" } },
+        message: {
+          recordId,
+          descriptor: { dateCreated: "2026-06-24T00:00:00Z" }
+        },
+        messageCid: `cid-${++cid}`
+      };
+    }),
+    sendDwnRequest: vi.fn(async (request: CapturedRequest) => {
+      pushes.push(request);
+      return { reply: { status: { code: 202, detail: "Accepted" } } };
+    })
+  };
+
+  return {
+    session: {
+      agent,
+      ownerDid: "did:example:owner",
+      ...(options.delegate ? { delegateDid: "did:example:delegate" } : {})
+    } satisfies MeshdAdminSession,
+    agent,
+    requests,
+    pushes
+  };
+}
+
+describe("meshd admin DWN operations", () => {
+  it("creates owner-scoped networks with delegated grants and remote push", async () => {
+    const { session, agent, requests, pushes } = createFakeSession({
+      delegate: true,
+      endpoints: ["", "https://dev.aws.dwn.enbox.id"],
+      recordIds: ["network-record"]
+    });
+
+    const network = await createMeshdNetwork(session, {
+      name: "  Home mesh  ",
+      meshCIDR: "10.201.0.0/16"
+    });
+
+    expect(network).toMatchObject({
+      recordId: "network-record",
+      name: "Home mesh",
+      meshCIDR: "10.201.0.0/16",
+      anchorEndpoint: "https://dev.aws.dwn.enbox.id"
+    });
+
+    expect(agent.permissions?.getPermissionForRequest).toHaveBeenCalledWith(expect.objectContaining({
+      connectedDid: "did:example:owner",
+      delegateDid: "did:example:delegate",
+      protocol: MESHD_PROTOCOL_URI,
+      delegate: true,
+      cached: true,
+      messageType: DwnInterface.RecordsWrite
+    }));
+    expect(requests[0]).toMatchObject({
+      author: "did:example:owner",
+      target: "did:example:owner",
+      granteeDid: "did:example:delegate",
+      messageType: DwnInterface.RecordsWrite,
+      messageParams: {
+        protocol: MESHD_PROTOCOL_URI,
+        protocolPath: "network",
+        schema: "https://enbox.id/schemas/wireguard-mesh/network",
+        dataFormat: "application/json",
+        delegatedGrant: {
+          grant: `${MESHD_PROTOCOL_URI}:${DwnInterface.RecordsWrite}`
+        }
+      }
+    });
+    await expect(blobJson(requests[0].dataStream)).resolves.toEqual({
+      name: "Home mesh",
+      meshCIDR: "10.201.0.0/16",
+      anchorEndpoint: "https://dev.aws.dwn.enbox.id"
+    });
+    expect(pushes).toEqual([
+      {
+        author: "did:example:owner",
+        target: "did:example:owner",
+        messageType: DwnInterface.RecordsWrite,
+        messageCid: "cid-1"
+      }
+    ]);
+  });
+
+  it("normalizes and validates network CIDR before writing network records", async () => {
+    const valid = createFakeSession({ recordIds: ["network-record"] });
+
+    const network = await createMeshdNetwork(valid.session, {
+      name: "Home mesh",
+      meshCIDR: "10.201.42.9/16"
+    });
+
+    expect(network.meshCIDR).toBe("10.201.0.0/16");
+    await expect(blobJson(valid.requests[0].dataStream)).resolves.toMatchObject({
+      meshCIDR: "10.201.0.0/16"
+    });
+
+    const invalid = createFakeSession();
+    await expect(createMeshdNetwork(invalid.session, {
+      name: "Bad mesh",
+      meshCIDR: "fd00::/64"
+    })).rejects.toThrow("Invalid IPv4 address");
+    expect(invalid.requests).toHaveLength(0);
+
+    await expect(createMeshdNetwork(invalid.session, {
+      name: "Tiny mesh",
+      meshCIDR: "10.200.0.0/31"
+    })).rejects.toThrow("must be an IPv4 CIDR with at least 2 host bits");
+    expect(invalid.requests).toHaveLength(0);
+  });
+
+  it("creates invite records and returns CLI-compatible meshd invite URLs", async () => {
+    const { session, requests } = createFakeSession({ delegate: true, recordIds: ["invite-record"] });
+    const network: MeshdNetworkSummary = {
+      recordId: "network-record",
+      name: "Home mesh",
+      meshCIDR: "10.200.0.0/16",
+      anchorEndpoint: "https://owner.dwn.example"
+    };
+
+    const result = await createMeshdInvite(session, network, {
+      label: "server",
+      expiresAt: "2026-06-25T00:00:00Z",
+      reusable: false
+    });
+
+    expect(result.tokenId).toBe("invite-record");
+    expect(result.url.startsWith("meshd://invite/")).toBe(true);
+    const payload = decodeBase64UrlJson(result.url.slice("meshd://invite/".length));
+    expect(payload).toEqual({
+      version: 1,
+      endpoint: "https://owner.dwn.example",
+      anchorDid: "did:example:owner",
+      networkId: "network-record",
+      networkName: "Home mesh",
+      tokenId: "invite-record",
+      secret: result.secret,
+      expiresAt: "2026-06-25T00:00:00Z"
+    });
+
+    expect(requests[0]).toMatchObject({
+      encryption: true,
+      messageType: DwnInterface.RecordsWrite,
+      messageParams: {
+        protocol: MESHD_PROTOCOL_URI,
+        protocolPath: "network/preAuthKey",
+        schema: "https://enbox.id/schemas/wireguard-mesh/pre-auth-key",
+        parentContextId: "network-record"
+      }
+    });
+    await expect(blobJson(requests[0].dataStream)).resolves.toMatchObject({
+      key: result.secret,
+      expiresAt: "2026-06-25T00:00:00Z",
+      reusable: false,
+      label: "server",
+      usedBy: []
+    });
+  });
+
+  it("creates reusable invites without expiry when requested", async () => {
+    const { session, requests } = createFakeSession({ recordIds: ["invite-record"] });
+    const network: MeshdNetworkSummary = {
+      recordId: "network-record",
+      name: "Home mesh",
+      meshCIDR: "10.200.0.0/16",
+      anchorEndpoint: "https://owner.dwn.example"
+    };
+
+    const result = await createMeshdInvite(session, network, {
+      label: "team",
+      reusable: true
+    });
+
+    const payload = decodeBase64UrlJson(result.url.slice("meshd://invite/".length));
+    expect(payload).not.toHaveProperty("expiresAt");
+    expect(result).not.toHaveProperty("expiresAt");
+    await expect(blobJson(requests[0].dataStream)).resolves.toMatchObject({
+      key: result.secret,
+      reusable: true,
+      label: "team",
+      usedBy: []
+    });
+    await expect(blobJson(requests[0].dataStream)).resolves.not.toHaveProperty("expiresAt");
+  });
+
+  it("rebuilds invite URLs from existing preauth records", async () => {
+    const { session } = createFakeSession();
+    const network: MeshdNetworkSummary = {
+      recordId: "network-record",
+      name: "Home mesh",
+      meshCIDR: "10.200.0.0/16",
+      anchorEndpoint: "https://owner.dwn.example"
+    };
+
+    const url = await buildMeshdInviteURL(session, network, {
+      recordId: "invite-record",
+      key: "secret-value",
+      expiresAt: "2026-06-25T00:00:00Z",
+      usedBy: []
+    });
+
+    expect(decodeBase64UrlJson(url.slice("meshd://invite/".length))).toEqual({
+      version: 1,
+      endpoint: "https://owner.dwn.example",
+      anchorDid: "did:example:owner",
+      networkId: "network-record",
+      networkName: "Home mesh",
+      tokenId: "invite-record",
+      secret: "secret-value",
+      expiresAt: "2026-06-25T00:00:00Z"
+    });
+  });
+
+  it("fetches and sorts network records through delegated records queries", async () => {
+    const { session, requests } = createFakeSession({
+      delegate: true,
+      queryEntries: [
+        recordEntry("older", "network", { name: "Older", meshCIDR: "10.200.0.0/16" }, "2026-06-23T00:00:00Z"),
+        recordEntry("newer", "network", { name: "Newer", meshCIDR: "10.201.0.0/16" }, "2026-06-24T00:00:00Z"),
+        recordEntry("ignored", "network/member", { name: "Member", meshCIDR: "10.202.0.0/16" }, "2026-06-25T00:00:00Z")
+      ]
+    });
+
+    const networks = await fetchMeshdNetworks(session);
+
+    expect(networks.map((network) => network.recordId)).toEqual(["newer", "older"]);
+    expect(requests[0]).toMatchObject({
+      granteeDid: "did:example:delegate",
+      messageType: DwnInterface.RecordsQuery,
+      messageParams: {
+        filter: {
+          protocol: MESHD_PROTOCOL_URI,
+          protocolPath: "network"
+        },
+        delegatedGrant: {
+          grant: `${MESHD_PROTOCOL_URI}:${DwnInterface.RecordsQuery}`
+        }
+      }
+    });
+  });
+});

--- a/admin-dapp/src/meshd/admin.ts
+++ b/admin-dapp/src/meshd/admin.ts
@@ -1,0 +1,1286 @@
+import {
+  DwnInterface,
+  EnboxConnectProtocol,
+  writeContextKeyRecord as writeContextKeyRecordWithAgent
+} from "@enbox/agent";
+import type { DwnMessage } from "@enbox/agent";
+import { Ed25519 } from "@enbox/crypto";
+import { DidJwk } from "@enbox/dids";
+import { Message } from "@enbox/dwn-sdk-js";
+
+import {
+  MESHD_KEY_DELIVERY_PROTOCOL_URI,
+  MESHD_PROTOCOL_URI
+} from "@/enbox/config";
+import { MeshNodePermissionRequest } from "@/enbox/protocols";
+
+export type MeshdAdminAgent = {
+  permissions?: {
+    getPermissionForRequest?: (request: {
+      connectedDid: string;
+      delegateDid: string;
+      protocol?: string;
+      delegate?: boolean;
+      cached?: boolean;
+      messageType: unknown;
+    }) => Promise<{ message: unknown; grant?: { id?: string } }>;
+  };
+  processDwnRequest: (request: Record<string, unknown>) => Promise<{
+    reply: {
+      status: { code: number; detail?: string };
+      entries?: unknown[];
+    };
+    message?: {
+      recordId?: string;
+      descriptor?: {
+        dateCreated?: string;
+      };
+    };
+    messageCid?: string;
+  }>;
+  sendDwnRequest?: (request: Record<string, unknown>) => Promise<{
+    reply: {
+      status: { code: number; detail?: string };
+    };
+  }>;
+  dwn?: {
+    getDwnEndpointUrlsForTarget?: (targetDid: string) => Promise<string[]>;
+    getProtocolDefinition?: (tenantDid: string, protocolUri: string, granteeDid?: string) => Promise<unknown>;
+    exportDelegateContextKeys?: (delegateDid: string) => unknown[];
+  };
+};
+
+export type MeshdAdminSession = {
+  agent: MeshdAdminAgent;
+  ownerDid: string;
+  delegateDid?: string;
+};
+
+export type MeshdNetworkSummary = {
+  recordId: string;
+  name: string;
+  meshCIDR: string;
+  anchorEndpoint?: string;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export type MeshdMemberSummary = {
+  recordId: string;
+  did: string;
+  label?: string;
+  addedAt?: string;
+  createdAt?: string;
+  nodes: MeshdNodeSummary[];
+};
+
+export type MeshdNodeSummary = {
+  recordId: string;
+  did: string;
+  meshIP?: string;
+  label?: string;
+  ownerDID?: string;
+  memberDID?: string;
+  delegateDID?: string;
+  memberRecordId?: string;
+  addedAt?: string;
+  expiresAt?: string;
+  createdAt?: string;
+};
+
+export type MeshdNodeRequestSummary = {
+  recordId: string;
+  protocolPath?: string;
+  nodeDID: string;
+  ownerDID?: string;
+  memberDID?: string;
+  delegateDID?: string;
+  requestedBy?: string;
+  nodeProof?: string;
+  requestKind?: string;
+  networkRecordId?: string;
+  networkName?: string;
+  label?: string;
+  sourceDWN?: string;
+  nodeKeyDelivery?: MeshdNodeKeyDelivery;
+  preAuthKeyId?: string;
+  preAuthProof?: string;
+  requestedAt?: string;
+  expiresAt?: string;
+  createdAt?: string;
+};
+
+export type MeshdPreAuthKeySummary = {
+  recordId: string;
+  key: string;
+  createdAt?: string;
+  expiresAt?: string;
+  reusable?: boolean;
+  ephemeral?: boolean;
+  label?: string;
+  usedBy: string[];
+  recordCreatedAt?: string;
+};
+
+export type MeshdNetworkTopology = {
+  network: MeshdNetworkSummary;
+  members: MeshdMemberSummary[];
+  legacyNodes: MeshdNodeSummary[];
+  pendingRequests: MeshdNodeRequestSummary[];
+  preAuthKeys: MeshdPreAuthKeySummary[];
+};
+
+export type MeshdNodeKeyDelivery = {
+  rootKeyId?: string;
+  publicKeyJwk?: {
+    kid?: string;
+    kty?: string;
+    crv?: string;
+    x?: string;
+    [key: string]: unknown;
+  };
+};
+
+export type CreateMeshdInviteResult = {
+  url: string;
+  tokenId: string;
+  secret: string;
+  expiresAt?: string;
+};
+
+export type ApproveMeshdNodeRequestResult = {
+  memberRecordId: string;
+  nodeRecordId: string;
+  meshIP: string;
+  deliveredContextKey: boolean;
+};
+
+type AuthoredRecord = {
+  recordId: string;
+  dateCreated?: string;
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value.trim() : undefined;
+}
+
+function base64UrlDecode(value: string): string {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(normalized.length + ((4 - normalized.length % 4) % 4), "=");
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+function base64UrlDecodeBytes(value: string): Uint8Array {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(normalized.length + ((4 - normalized.length % 4) % 4), "=");
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function base64UrlEncodeBytes(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64UrlEncodeJson(value: unknown): string {
+  return base64UrlEncodeBytes(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+function generateInviteSecret(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return base64UrlEncodeBytes(bytes);
+}
+
+function getRecordWrite(rawEntry: unknown): Record<string, unknown> | undefined {
+  if (!isObject(rawEntry)) return undefined;
+  if (isObject(rawEntry.recordsWrite)) return rawEntry.recordsWrite;
+  if (isObject(rawEntry.record)) return rawEntry.record;
+  return rawEntry;
+}
+
+function getRecordId(
+  entry: Record<string, unknown>,
+  wrapper: Record<string, unknown>,
+  descriptor: Record<string, unknown>
+): string | undefined {
+  return getString(entry.recordId)
+    ?? getString(wrapper.recordId)
+    ?? getString(descriptor.recordId)
+    ?? getString(wrapper.id);
+}
+
+function getRecipient(
+  entry: Record<string, unknown>,
+  wrapper: Record<string, unknown>,
+  descriptor: Record<string, unknown>
+): string | undefined {
+  return getString(entry.recipient)
+    ?? getString(descriptor.recipient)
+    ?? getString(wrapper.recipient);
+}
+
+function decodeRecordPayload(entry: Record<string, unknown>, wrapper: Record<string, unknown>): unknown {
+  if (isObject(wrapper.data)) return wrapper.data;
+  if (isObject(entry.data)) return entry.data;
+  if (typeof wrapper.encodedData === "string") return JSON.parse(base64UrlDecode(wrapper.encodedData));
+  if (typeof entry.encodedData === "string") return JSON.parse(base64UrlDecode(entry.encodedData));
+  return undefined;
+}
+
+async function processDwnRequest(
+  session: MeshdAdminSession,
+  request: Record<string, unknown>,
+  protocol?: string
+) {
+  const next: Record<string, any> = {
+    ...request,
+    messageParams: {
+      ...(isObject(request.messageParams) ? request.messageParams : {})
+    }
+  };
+
+  if (session.delegateDid && protocol) {
+    const permission = await session.agent.permissions?.getPermissionForRequest?.({
+      connectedDid: session.ownerDid,
+      delegateDid: session.delegateDid,
+      protocol,
+      delegate: true,
+      cached: true,
+      messageType: next.messageType
+    });
+    if (!permission?.message) {
+      throw new Error(`The wallet session did not grant ${protocol} access to this dashboard.`);
+    }
+    next.messageParams = {
+      ...next.messageParams,
+      delegatedGrant: permission.message
+    };
+    next.granteeDid = session.delegateDid;
+  }
+
+  return session.agent.processDwnRequest(next);
+}
+
+async function sendDwnMessage(
+  session: MeshdAdminSession,
+  messageType: unknown,
+  messageCid: string
+) {
+  if (!session.agent.sendDwnRequest) {
+    return;
+  }
+  const pushed = await session.agent.sendDwnRequest({
+    author: session.ownerDid,
+    target: session.ownerDid,
+    messageType,
+    messageCid
+  });
+  if (pushed.reply.status.code >= 300 && pushed.reply.status.code !== 409) {
+    throw new Error(`Remote DWN send failed: ${pushed.reply.status.code} ${pushed.reply.status.detail ?? ""}`.trim());
+  }
+}
+
+function recordIdFromMessage(message?: { recordId?: string; descriptor?: { dateCreated?: string } }): string {
+  const recordId = message?.recordId;
+  if (!recordId) {
+    throw new Error("DWN write did not return a record ID.");
+  }
+  return recordId;
+}
+
+async function writeRecord(
+  session: MeshdAdminSession,
+  protocol: string,
+  messageParams: Record<string, unknown>,
+  payload: Record<string, unknown>,
+  encryption?: true
+): Promise<AuthoredRecord> {
+  const data = new TextEncoder().encode(JSON.stringify(payload));
+  const { reply, message, messageCid } = await processDwnRequest(
+    session,
+    {
+      author: session.ownerDid,
+      target: session.ownerDid,
+      messageType: DwnInterface.RecordsWrite,
+      messageParams,
+      dataStream: new Blob([data], { type: "application/json" }),
+      ...(encryption ? { encryption } : {})
+    },
+    protocol
+  );
+
+  if (reply.status.code >= 300 || !message || !messageCid) {
+    throw new Error(`DWN write failed: ${reply.status.code} ${reply.status.detail ?? ""}`.trim());
+  }
+
+  await sendDwnMessage(session, DwnInterface.RecordsWrite, messageCid);
+  return {
+    recordId: recordIdFromMessage(message),
+    dateCreated: message.descriptor?.dateCreated
+  };
+}
+
+async function deleteRecord(
+  session: MeshdAdminSession,
+  protocol: string,
+  recordId: string,
+  prune: boolean
+): Promise<void> {
+  const { reply, messageCid } = await processDwnRequest(
+    session,
+    {
+      author: session.ownerDid,
+      target: session.ownerDid,
+      messageType: DwnInterface.RecordsDelete,
+      messageParams: { recordId, prune }
+    },
+    protocol
+  );
+
+  if (reply.status.code >= 300) {
+    throw new Error(`Could not delete record ${recordId}: ${reply.status.detail ?? reply.status.code}`);
+  }
+  if (messageCid) {
+    await sendDwnMessage(session, DwnInterface.RecordsDelete, messageCid);
+  }
+}
+
+async function queryRecords(
+  session: MeshdAdminSession,
+  protocol: string,
+  protocolPath: string,
+  contextId?: string,
+  extraFilter: Record<string, unknown> = {}
+): Promise<unknown[]> {
+  const result = await processDwnRequest(
+    session,
+    {
+      author: session.ownerDid,
+      target: session.ownerDid,
+      messageType: DwnInterface.RecordsQuery,
+      messageParams: {
+        filter: {
+          protocol,
+          protocolPath,
+          ...(contextId ? { contextId } : {}),
+          ...extraFilter
+        },
+        dateSort: "createdAscending"
+      }
+    },
+    protocol
+  );
+
+  if (result.reply.status.code !== 200) {
+    throw new Error(`Could not fetch ${protocolPath} records: ${result.reply.status.detail ?? result.reply.status.code}`);
+  }
+  return result.reply.entries ?? [];
+}
+
+export function parseMeshdNetworkRecord(rawEntry: unknown): MeshdNetworkSummary | undefined {
+  const wrapper = isObject(rawEntry) ? rawEntry : undefined;
+  const entry = getRecordWrite(rawEntry);
+  if (!entry || !wrapper) return undefined;
+  const descriptor = isObject(entry.descriptor) ? entry.descriptor : {};
+  const protocolPath = getString(descriptor.protocolPath);
+  if (protocolPath && protocolPath !== "network") return undefined;
+  const recordId = getRecordId(entry, wrapper, descriptor);
+  if (!recordId) return undefined;
+
+  let payload: unknown;
+  try {
+    payload = decodeRecordPayload(entry, wrapper);
+  } catch {
+    return undefined;
+  }
+  if (!isObject(payload)) return undefined;
+  const meshCIDR = getString(payload.meshCIDR) ?? getString(payload.meshCidr);
+  if (!meshCIDR) return undefined;
+  return {
+    recordId,
+    name: getString(payload.name) ?? "Unnamed mesh",
+    meshCIDR,
+    anchorEndpoint: getString(payload.anchorEndpoint) ?? getString(payload.endpoint),
+    createdAt: getString(descriptor.dateCreated) ?? getString(wrapper.dateCreated),
+    updatedAt: getString(descriptor.dateModified) ?? getString(wrapper.dateModified)
+  };
+}
+
+export function parseMeshdMemberRecord(rawEntry: unknown): Omit<MeshdMemberSummary, "nodes"> | undefined {
+  const wrapper = isObject(rawEntry) ? rawEntry : undefined;
+  const entry = getRecordWrite(rawEntry);
+  if (!entry || !wrapper) return undefined;
+  const descriptor = isObject(entry.descriptor) ? entry.descriptor : {};
+  const protocolPath = getString(descriptor.protocolPath);
+  if (protocolPath && protocolPath !== "network/member") return undefined;
+  const recordId = getRecordId(entry, wrapper, descriptor);
+  const did = getRecipient(entry, wrapper, descriptor);
+  if (!recordId || !did) return undefined;
+
+  let payload: unknown;
+  try {
+    payload = decodeRecordPayload(entry, wrapper);
+  } catch {
+    payload = undefined;
+  }
+  const data = isObject(payload) ? payload : {};
+  return {
+    recordId,
+    did,
+    label: getString(data.label),
+    addedAt: getString(data.addedAt),
+    createdAt: getString(descriptor.dateCreated) ?? getString(wrapper.dateCreated)
+  };
+}
+
+export function parseMeshdNodeRecord(rawEntry: unknown, memberRecordId?: string): MeshdNodeSummary | undefined {
+  const wrapper = isObject(rawEntry) ? rawEntry : undefined;
+  const entry = getRecordWrite(rawEntry);
+  if (!entry || !wrapper) return undefined;
+  const descriptor = isObject(entry.descriptor) ? entry.descriptor : {};
+  const protocolPath = getString(descriptor.protocolPath);
+  if (protocolPath && protocolPath !== "network/member/node" && protocolPath !== "network/node") return undefined;
+  const recordId = getRecordId(entry, wrapper, descriptor);
+  const did = getRecipient(entry, wrapper, descriptor);
+  if (!recordId || !did) return undefined;
+
+  let payload: unknown;
+  try {
+    payload = decodeRecordPayload(entry, wrapper);
+  } catch {
+    payload = undefined;
+  }
+  const data = isObject(payload) ? payload : {};
+  return {
+    recordId,
+    did,
+    meshIP: getString(data.meshIP),
+    label: getString(data.label),
+    ownerDID: getString(data.ownerDID) ?? getString(data.memberDID),
+    memberDID: getString(data.memberDID) ?? getString(data.ownerDID),
+    delegateDID: getString(data.delegateDID),
+    memberRecordId,
+    addedAt: getString(data.addedAt),
+    expiresAt: getString(data.expiresAt),
+    createdAt: getString(descriptor.dateCreated) ?? getString(wrapper.dateCreated)
+  };
+}
+
+export function parseMeshdNodeRequestRecord(rawEntry: unknown): MeshdNodeRequestSummary | undefined {
+  const wrapper = isObject(rawEntry) ? rawEntry : undefined;
+  const entry = getRecordWrite(rawEntry);
+  if (!entry || !wrapper) return undefined;
+  const descriptor = isObject(entry.descriptor) ? entry.descriptor : {};
+  const protocolPath = getString(descriptor.protocolPath);
+  if (protocolPath && protocolPath !== "network/nodeRequest" && protocolPath !== "nodeRequest") return undefined;
+  const recordId = getRecordId(entry, wrapper, descriptor);
+  if (!recordId) return undefined;
+
+  let payload: unknown;
+  try {
+    payload = decodeRecordPayload(entry, wrapper);
+  } catch {
+    return undefined;
+  }
+  if (!isObject(payload)) return undefined;
+  const nodeDID = getString(payload.nodeDID);
+  if (!nodeDID) return undefined;
+  return {
+    recordId,
+    protocolPath,
+    nodeDID,
+    ownerDID: getString(payload.ownerDID) ?? getString(payload.memberDID),
+    memberDID: getString(payload.memberDID) ?? getString(payload.ownerDID),
+    delegateDID: getString(payload.delegateDID),
+    requestedBy: getString(payload.requestedBy),
+    nodeProof: getString(payload.nodeProof),
+    requestKind: getString(payload.requestKind),
+    networkRecordId: getString(payload.networkRecordId),
+    networkName: getString(payload.networkName),
+    label: getString(payload.label),
+    sourceDWN: getString(payload.sourceDWN),
+    nodeKeyDelivery: isObject(payload.nodeKeyDelivery) ? payload.nodeKeyDelivery as MeshdNodeKeyDelivery : undefined,
+    preAuthKeyId: getString(payload.preAuthKeyId),
+    preAuthProof: getString(payload.preAuthProof),
+    requestedAt: getString(payload.requestedAt),
+    expiresAt: getString(payload.expiresAt),
+    createdAt: getString(descriptor.dateCreated) ?? getString(wrapper.dateCreated)
+  };
+}
+
+export function parseMeshdPreAuthKeyRecord(rawEntry: unknown): MeshdPreAuthKeySummary | undefined {
+  const wrapper = isObject(rawEntry) ? rawEntry : undefined;
+  const entry = getRecordWrite(rawEntry);
+  if (!entry || !wrapper) return undefined;
+  const descriptor = isObject(entry.descriptor) ? entry.descriptor : {};
+  const protocolPath = getString(descriptor.protocolPath);
+  if (protocolPath && protocolPath !== "network/preAuthKey") return undefined;
+  const recordId = getRecordId(entry, wrapper, descriptor);
+  if (!recordId) return undefined;
+
+  let payload: unknown;
+  try {
+    payload = decodeRecordPayload(entry, wrapper);
+  } catch {
+    return undefined;
+  }
+  if (!isObject(payload)) return undefined;
+  const key = getString(payload.key);
+  if (!key) return undefined;
+  return {
+    recordId,
+    key,
+    createdAt: getString(payload.createdAt),
+    expiresAt: getString(payload.expiresAt),
+    reusable: typeof payload.reusable === "boolean" ? payload.reusable : undefined,
+    ephemeral: typeof payload.ephemeral === "boolean" ? payload.ephemeral : undefined,
+    label: getString(payload.label),
+    usedBy: Array.isArray(payload.usedBy)
+      ? payload.usedBy.filter((item): item is string => typeof item === "string" && item.trim() !== "")
+      : [],
+    recordCreatedAt: getString(descriptor.dateCreated) ?? getString(wrapper.dateCreated)
+  };
+}
+
+export async function fetchMeshdNetworks(session: MeshdAdminSession): Promise<MeshdNetworkSummary[]> {
+  const entries = await queryRecords(session, MESHD_PROTOCOL_URI, "network");
+  return entries
+    .map(parseMeshdNetworkRecord)
+    .filter((network): network is MeshdNetworkSummary => Boolean(network))
+    .sort((a, b) => (b.createdAt ?? "").localeCompare(a.createdAt ?? ""));
+}
+
+export async function fetchMeshdNetworkTopology(
+  session: MeshdAdminSession,
+  network: MeshdNetworkSummary
+): Promise<MeshdNetworkTopology> {
+  const memberEntries = await queryRecords(session, MESHD_PROTOCOL_URI, "network/member", network.recordId);
+  const memberRecords = memberEntries
+    .map(parseMeshdMemberRecord)
+    .filter((member): member is Omit<MeshdMemberSummary, "nodes"> => Boolean(member));
+
+  const members = await Promise.all(memberRecords.map(async (member) => {
+    const nodeEntries = await queryRecords(
+      session,
+      MESHD_PROTOCOL_URI,
+      "network/member/node",
+      `${network.recordId}/${member.recordId}`
+    );
+    return {
+      ...member,
+      nodes: nodeEntries
+        .map((entry) => parseMeshdNodeRecord(entry, member.recordId))
+        .filter((node): node is MeshdNodeSummary => Boolean(node))
+    };
+  }));
+
+  const legacyNodeEntries = await queryRecords(session, MESHD_PROTOCOL_URI, "network/node", network.recordId);
+  const legacyNodes = legacyNodeEntries
+    .map((entry) => parseMeshdNodeRecord(entry))
+    .filter((node): node is MeshdNodeSummary => Boolean(node));
+
+  const pendingInviteEntries = await queryRecords(session, MESHD_PROTOCOL_URI, "network/nodeRequest", network.recordId);
+  const pendingInviteRequests = pendingInviteEntries
+    .map(parseMeshdNodeRequestRecord)
+    .filter((request): request is MeshdNodeRequestSummary => Boolean(request));
+
+  const ownerRequestEntries = await queryRecords(session, MESHD_PROTOCOL_URI, "nodeRequest");
+  const ownerPendingRequests = ownerRequestEntries
+    .map(parseMeshdNodeRequestRecord)
+    .filter((request): request is MeshdNodeRequestSummary => {
+      if (!request) return false;
+      return !request.networkRecordId || request.networkRecordId === network.recordId;
+    });
+
+  const preAuthEntries = await queryRecords(session, MESHD_PROTOCOL_URI, "network/preAuthKey", network.recordId);
+  const preAuthKeys = preAuthEntries
+    .map(parseMeshdPreAuthKeyRecord)
+    .filter((key): key is MeshdPreAuthKeySummary => Boolean(key));
+
+  return {
+    network,
+    members,
+    legacyNodes,
+    pendingRequests: [...ownerPendingRequests, ...pendingInviteRequests],
+    preAuthKeys
+  };
+}
+
+async function ownerDefaultDwnEndpoint(session: MeshdAdminSession): Promise<string> {
+  const endpoints = await session.agent.dwn?.getDwnEndpointUrlsForTarget?.(session.ownerDid);
+  const endpoint = endpoints?.find((candidate) => candidate.trim() !== "");
+  if (!endpoint) {
+    throw new Error("The owner identity does not publish a DWN endpoint.");
+  }
+  return endpoint;
+}
+
+export async function createMeshdNetwork(
+  session: MeshdAdminSession,
+  options: { name: string; meshCIDR?: string }
+): Promise<MeshdNetworkSummary> {
+  const name = options.name.trim();
+  if (!name) {
+    throw new Error("Network name is required.");
+  }
+  const meshCIDR = normalizeMeshCIDR(options.meshCIDR?.trim() || "10.200.0.0/16");
+  const anchorEndpoint = await ownerDefaultDwnEndpoint(session);
+  const record = await writeRecord(
+    session,
+    MESHD_PROTOCOL_URI,
+    {
+      protocol: MESHD_PROTOCOL_URI,
+      protocolPath: "network",
+      schema: "https://enbox.id/schemas/wireguard-mesh/network",
+      dataFormat: "application/json"
+    },
+    { name, meshCIDR, anchorEndpoint }
+  );
+  return {
+    recordId: record.recordId,
+    name,
+    meshCIDR,
+    anchorEndpoint,
+    createdAt: record.dateCreated
+  };
+}
+
+function encodeMeshdInviteURL(
+  endpoint: string,
+  ownerDid: string,
+  network: MeshdNetworkSummary,
+  tokenId: string,
+  secret: string,
+  expiresAt?: string
+): string {
+  return `meshd://invite/${base64UrlEncodeJson({
+    version: 1,
+    endpoint,
+    anchorDid: ownerDid,
+    networkId: network.recordId,
+    networkName: network.name,
+    tokenId,
+    secret,
+    ...(expiresAt ? { expiresAt } : {})
+  })}`;
+}
+
+async function networkAnchorEndpoint(
+  session: MeshdAdminSession,
+  network: MeshdNetworkSummary
+): Promise<string> {
+  if (network.anchorEndpoint) {
+    return network.anchorEndpoint;
+  }
+  return ownerDefaultDwnEndpoint(session);
+}
+
+export async function buildMeshdInviteURL(
+  session: MeshdAdminSession,
+  network: MeshdNetworkSummary,
+  key: MeshdPreAuthKeySummary
+) {
+  const endpoint = await networkAnchorEndpoint(session, network);
+  return encodeMeshdInviteURL(endpoint, session.ownerDid, network, key.recordId, key.key, key.expiresAt);
+}
+
+export async function createMeshdInvite(
+  session: MeshdAdminSession,
+  network: MeshdNetworkSummary,
+  options: { label?: string; expiresAt?: string; reusable?: boolean; ephemeral?: boolean } = {}
+): Promise<CreateMeshdInviteResult> {
+  const secret = generateInviteSecret();
+  const expiresAt = options.expiresAt?.trim();
+  const endpoint = await networkAnchorEndpoint(session, network);
+  const record = await writeRecord(
+    session,
+    MESHD_PROTOCOL_URI,
+    {
+      protocol: MESHD_PROTOCOL_URI,
+      protocolPath: "network/preAuthKey",
+      schema: "https://enbox.id/schemas/wireguard-mesh/pre-auth-key",
+      dataFormat: "application/json",
+      parentContextId: network.recordId
+    },
+    {
+      key: secret,
+      createdAt: new Date().toISOString(),
+      ...(expiresAt ? { expiresAt } : {}),
+      ...(options.reusable !== undefined ? { reusable: options.reusable } : {}),
+      ...(options.ephemeral !== undefined ? { ephemeral: options.ephemeral } : {}),
+      ...(options.label ? { label: options.label } : {}),
+      usedBy: []
+    },
+    true
+  );
+  return {
+    url: encodeMeshdInviteURL(endpoint, session.ownerDid, network, record.recordId, secret, expiresAt),
+    tokenId: record.recordId,
+    secret,
+    ...(expiresAt ? { expiresAt } : {})
+  };
+}
+
+export async function revokeMeshdInvite(
+  session: MeshdAdminSession,
+  key: Pick<MeshdPreAuthKeySummary, "recordId">
+): Promise<void> {
+  await deleteRecord(session, MESHD_PROTOCOL_URI, key.recordId, false);
+}
+
+function nodeJoinProofMessage(
+  networkId: string,
+  nodeDID: string,
+  ownerDID = nodeDID,
+  preAuthKeyId = ""
+): Uint8Array {
+  return new TextEncoder().encode(
+    "meshd node join v1\n"
+    + `network=${networkId}\n`
+    + `node=${nodeDID}\n`
+    + `member=${ownerDID || nodeDID}\n`
+    + `preauth=${preAuthKeyId}\n`
+  );
+}
+
+function ownerNodeRequestProofMessage(
+  ownerDID: string,
+  nodeDID: string,
+  sourceDWN = "",
+  requestedAt = ""
+): Uint8Array {
+  return new TextEncoder().encode(
+    "meshd owner node request v1\n"
+    + `owner=${ownerDID}\n`
+    + `node=${nodeDID}\n`
+    + `sourceDWN=${sourceDWN}\n`
+    + `requestedAt=${requestedAt}\n`
+  );
+}
+
+function nodeOwnerDID(request: Pick<MeshdNodeRequestSummary, "nodeDID" | "ownerDID" | "memberDID">): string {
+  return request.ownerDID || request.memberDID || request.nodeDID;
+}
+
+async function verifyNodeSignature(nodeDid: string, proof: string, data: Uint8Array): Promise<boolean> {
+  if (!nodeDid.startsWith("did:jwk:")) {
+    return false;
+  }
+  const resolved = await DidJwk.resolve(nodeDid);
+  const key = resolved.didDocument?.verificationMethod?.[0]?.publicKeyJwk;
+  if (!key) {
+    return false;
+  }
+  return Ed25519.verify({
+    key,
+    data,
+    signature: base64UrlDecodeBytes(proof)
+  });
+}
+
+async function verifyNodeJoinProof(request: MeshdNodeRequestSummary, networkId: string): Promise<boolean> {
+  if (!request.nodeProof) {
+    return false;
+  }
+  return verifyNodeSignature(
+    request.nodeDID,
+    request.nodeProof,
+    nodeJoinProofMessage(networkId, request.nodeDID, nodeOwnerDID(request), request.preAuthKeyId || "")
+  );
+}
+
+async function verifyOwnerNodeRequestProof(request: MeshdNodeRequestSummary): Promise<boolean> {
+  if (!request.nodeProof || !request.ownerDID || !request.requestedAt) {
+    return false;
+  }
+  return verifyNodeSignature(
+    request.nodeDID,
+    request.nodeProof,
+    ownerNodeRequestProofMessage(request.ownerDID, request.nodeDID, request.sourceDWN || "", request.requestedAt)
+  );
+}
+
+function isOwnerNodeRequest(request: MeshdNodeRequestSummary): boolean {
+  return request.protocolPath === "nodeRequest" || request.requestKind === "owner-node";
+}
+
+async function inviteProof(secret: string, networkId: string, nodeDID: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const signature = new Uint8Array(await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(`${networkId}\n${nodeDID}`)
+  ));
+  return `hmac-sha256:${base64UrlEncodeBytes(signature)}`;
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  let mismatch = a.length ^ b.length;
+  const maxLength = Math.max(a.length, b.length);
+  for (let i = 0; i < maxLength; i++) {
+    mismatch |= (a.charCodeAt(i) || 0) ^ (b.charCodeAt(i) || 0);
+  }
+  return mismatch === 0;
+}
+
+function preAuthKeyAllows(key: MeshdPreAuthKeySummary, nodeDID: string, now: Date = new Date()): boolean {
+  if (!key.key || !nodeDID) return false;
+  if (key.expiresAt) {
+    const expiresMs = new Date(key.expiresAt).getTime();
+    if (!Number.isFinite(expiresMs) || now.getTime() > expiresMs) {
+      return false;
+    }
+  }
+  if (key.usedBy.includes(nodeDID)) {
+    return true;
+  }
+  return Boolean(key.reusable) || key.usedBy.length === 0;
+}
+
+async function verifyInviteProof(
+  key: MeshdPreAuthKeySummary,
+  networkId: string,
+  nodeDID: string,
+  proof?: string
+): Promise<boolean> {
+  if (!proof || !key.key) return false;
+  const expected = await inviteProof(key.key, networkId, nodeDID);
+  return constantTimeEqual(expected, proof);
+}
+
+async function readPreAuthKey(
+  session: MeshdAdminSession,
+  network: MeshdNetworkSummary,
+  request: MeshdNodeRequestSummary
+): Promise<MeshdPreAuthKeySummary> {
+  if (!request.preAuthKeyId || !request.preAuthProof) {
+    throw new Error("The pending invite request is missing preauth data.");
+  }
+  const entries = await queryRecords(
+    session,
+    MESHD_PROTOCOL_URI,
+    "network/preAuthKey",
+    network.recordId,
+    { recordId: request.preAuthKeyId }
+  );
+  const key = entries
+    .map(parseMeshdPreAuthKeyRecord)
+    .find((entry) => entry?.recordId === request.preAuthKeyId);
+  if (!key) {
+    throw new Error("The preauth key for this request was not found.");
+  }
+  if (!preAuthKeyAllows(key, request.nodeDID)) {
+    throw new Error("The preauth key for this request is expired or already used.");
+  }
+  if (!await verifyInviteProof(key, network.recordId, request.nodeDID, request.preAuthProof)) {
+    throw new Error("The pending request preauth proof could not be verified.");
+  }
+  return key;
+}
+
+async function markPreAuthKeyUsed(
+  session: MeshdAdminSession,
+  network: MeshdNetworkSummary,
+  key: MeshdPreAuthKeySummary,
+  nodeDID: string
+): Promise<void> {
+  if (key.usedBy.includes(nodeDID)) {
+    return;
+  }
+  await writeRecord(
+    session,
+    MESHD_PROTOCOL_URI,
+    {
+      protocol: MESHD_PROTOCOL_URI,
+      protocolPath: "network/preAuthKey",
+      schema: "https://enbox.id/schemas/wireguard-mesh/pre-auth-key",
+      dataFormat: "application/json",
+      parentContextId: network.recordId,
+      recordId: key.recordId,
+      ...(key.recordCreatedAt ? { dateCreated: key.recordCreatedAt } : {})
+    },
+    {
+      key: key.key,
+      ...(key.createdAt ? { createdAt: key.createdAt } : {}),
+      ...(key.expiresAt ? { expiresAt: key.expiresAt } : {}),
+      ...(key.reusable !== undefined ? { reusable: key.reusable } : {}),
+      ...(key.ephemeral !== undefined ? { ephemeral: key.ephemeral } : {}),
+      ...(key.label ? { label: key.label } : {}),
+      usedBy: [...key.usedBy, nodeDID]
+    },
+    true
+  );
+}
+
+function validateNodeKeyDelivery(nodeDID: string, key?: MeshdNodeKeyDelivery): MeshdNodeKeyDelivery {
+  if (!key) {
+    throw new Error("The pending request is missing node key-delivery data. Ask the node to run an updated meshd CLI.");
+  }
+  const rootKeyId = key.rootKeyId || key.publicKeyJwk?.kid;
+  if (!rootKeyId) {
+    throw new Error("The pending request is missing node key-delivery rootKeyId.");
+  }
+  if (rootKeyId !== `${nodeDID}#1`) {
+    throw new Error(`The pending request key-delivery rootKeyId does not match node DID ${nodeDID}.`);
+  }
+  if (key.publicKeyJwk?.kid && key.publicKeyJwk.kid !== rootKeyId) {
+    throw new Error("The pending request key-delivery public key id does not match rootKeyId.");
+  }
+  if (key.publicKeyJwk?.kty !== "OKP" || key.publicKeyJwk?.crv !== "X25519") {
+    throw new Error("The pending request key-delivery public key must be an X25519 OKP key.");
+  }
+  if (!key.publicKeyJwk?.x || base64UrlDecodeBytes(key.publicKeyJwk.x).length !== 32) {
+    throw new Error("The pending request node key-delivery public key must be 32 bytes.");
+  }
+  return key;
+}
+
+function ipv4ToInt(ip: string): number {
+  const parts = ip.split(".").map((part) => Number.parseInt(part, 10));
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+    throw new Error(`Invalid IPv4 address: ${ip}`);
+  }
+  return (
+    ((parts[0] << 24) >>> 0)
+    + (parts[1] << 16)
+    + (parts[2] << 8)
+    + parts[3]
+  ) >>> 0;
+}
+
+function intToIpv4(value: number): string {
+  return [
+    (value >>> 24) & 0xff,
+    (value >>> 16) & 0xff,
+    (value >>> 8) & 0xff,
+    value & 0xff
+  ].join(".");
+}
+
+function normalizeMeshCIDR(cidr: string): string {
+  const parts = cidr.split("/");
+  if (parts.length !== 2 || !parts[0] || !/^\d+$/.test(parts[1])) {
+    throw new Error(`Invalid mesh CIDR: ${cidr}`);
+  }
+
+  const address = ipv4ToInt(parts[0]);
+  const prefix = Number.parseInt(parts[1], 10);
+  if (!Number.isInteger(prefix) || prefix < 0 || prefix > 30) {
+    throw new Error(`Mesh CIDR ${cidr} must be an IPv4 CIDR with at least 2 host bits.`);
+  }
+
+  const hostBits = 32 - prefix;
+  const mask = prefix === 0 ? 0 : (0xffffffff << hostBits) >>> 0;
+  const baseInt = (address & mask) >>> 0;
+  return `${intToIpv4(baseInt)}/${prefix}`;
+}
+
+async function allocateMeshIp(cidr: string, nodeDID: string): Promise<string> {
+  const [ip, prefixText] = cidr.split("/");
+  const prefix = Number.parseInt(prefixText, 10);
+  if (!ip || !Number.isInteger(prefix) || prefix < 0 || prefix > 30) {
+    throw new Error(`Invalid mesh CIDR: ${cidr}`);
+  }
+  const hostBits = 32 - prefix;
+  if (hostBits < 2) {
+    throw new Error(`Mesh CIDR ${cidr} has too few host bits.`);
+  }
+  const mask = prefix === 0 ? 0 : (0xffffffff << hostBits) >>> 0;
+  const baseInt = (ipv4ToInt(ip) & mask) >>> 0;
+  const hash = new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(nodeDID)));
+  const hashPrefix = (
+    ((hash[0] << 24) >>> 0)
+    + (hash[1] << 16)
+    + (hash[2] << 8)
+    + hash[3]
+  ) >>> 0;
+  const maxHosts = (2 ** hostBits) - 3;
+  return intToIpv4((baseInt + (hashPrefix % maxHosts) + 2) >>> 0);
+}
+
+async function ensureMemberRecord(
+  session: MeshdAdminSession,
+  network: MeshdNetworkSummary,
+  nodeOwnerDID: string,
+  label?: string
+): Promise<AuthoredRecord> {
+  const existingEntries = await queryRecords(
+    session,
+    MESHD_PROTOCOL_URI,
+    "network/member",
+    network.recordId,
+    { recipient: nodeOwnerDID }
+  );
+  const existing = existingEntries
+    .map(parseMeshdMemberRecord)
+    .find((member) => member?.did === nodeOwnerDID);
+  if (existing) {
+    return {
+      recordId: existing.recordId,
+      dateCreated: existing.createdAt
+    };
+  }
+
+  return writeRecord(
+    session,
+    MESHD_PROTOCOL_URI,
+    {
+      protocol: MESHD_PROTOCOL_URI,
+      protocolPath: "network/member",
+      schema: "https://enbox.id/schemas/wireguard-mesh/member",
+      dataFormat: "application/json",
+      recipient: nodeOwnerDID,
+      parentContextId: network.recordId
+    },
+    {
+      addedAt: new Date().toISOString(),
+      ...(label ? { label } : {})
+    },
+    true
+  );
+}
+
+function exportedContextKeyFor(session: MeshdAdminSession, network: MeshdNetworkSummary) {
+  if (!session.delegateDid) {
+    return undefined;
+  }
+  const exported = session.agent.dwn?.exportDelegateContextKeys?.(session.delegateDid) ?? [];
+  return exported.find((value): value is { protocol: string; contextId: string; derivedPrivateKey: unknown } => {
+    if (!isObject(value)) return false;
+    return value.protocol === MESHD_PROTOCOL_URI
+      && value.contextId === network.recordId
+      && isObject(value.derivedPrivateKey);
+  });
+}
+
+async function deriveNetworkContextKey(
+  session: MeshdAdminSession,
+  network: MeshdNetworkSummary
+): Promise<unknown> {
+  const exported = exportedContextKeyFor(session, network);
+  if (exported?.derivedPrivateKey) {
+    return exported.derivedPrivateKey;
+  }
+
+  const contextKeys = await EnboxConnectProtocol.deriveContextKeysForDelegate(
+    session.agent as never,
+    session.ownerDid,
+    MeshNodePermissionRequest.protocolDefinition as never,
+    MeshNodePermissionRequest.permissionScopes as never
+  );
+  const networkContextKey = (contextKeys as unknown[]).find((value): value is { protocol: string; contextId: string; derivedPrivateKey: unknown } => {
+    if (!isObject(value)) return false;
+    return value.protocol === MESHD_PROTOCOL_URI
+      && value.contextId === network.recordId
+      && isObject(value.derivedPrivateKey);
+  });
+  if (!networkContextKey?.derivedPrivateKey) {
+    throw new Error("Could not derive or export the mesh network context key. Reconnect the dashboard wallet session and try again.");
+  }
+  return networkContextKey.derivedPrivateKey;
+}
+
+async function ensureKeyDeliveryReady(session: MeshdAdminSession) {
+  const existing = await session.agent.dwn?.getProtocolDefinition?.(
+    session.ownerDid,
+    MESHD_KEY_DELIVERY_PROTOCOL_URI,
+    session.delegateDid
+  );
+  if (!existing) {
+    throw new Error("The key-delivery protocol is not installed for this owner. Reconnect the wallet and approve meshd Admin again.");
+  }
+}
+
+async function deliverNetworkContextKey(
+  session: MeshdAdminSession,
+  network: MeshdNetworkSummary,
+  request: MeshdNodeRequestSummary,
+  nodeKeyDelivery: MeshdNodeKeyDelivery
+) {
+  const contextKeyData = await deriveNetworkContextKey(session, network);
+  await writeContextKeyRecordWithAgent(
+    session.agent as never,
+    {
+      tenantDid: session.ownerDid,
+      recipientDid: request.nodeDID,
+      contextKeyData: contextKeyData as never,
+      sourceProtocol: MESHD_PROTOCOL_URI,
+      sourceContextId: network.recordId,
+      recipientKeyDeliveryPublicKey: nodeKeyDelivery as never
+    },
+    (requestParams: Record<string, unknown>) =>
+      processDwnRequest(session, requestParams, MESHD_KEY_DELIVERY_PROTOCOL_URI) as never,
+    () => ensureKeyDeliveryReady(session),
+    async (_tenantDid: string, message: DwnMessage[typeof DwnInterface.RecordsWrite]) => {
+      if (!session.agent.sendDwnRequest) {
+        return;
+      }
+      const messageCid = await Message.getCid(message as never);
+      await sendDwnMessage(session, DwnInterface.RecordsWrite, messageCid);
+    },
+    (promise: Promise<void>) => promise
+  );
+}
+
+export async function approveMeshdNodeRequest(
+  session: MeshdAdminSession,
+  network: MeshdNetworkSummary,
+  request: MeshdNodeRequestSummary
+): Promise<ApproveMeshdNodeRequestResult> {
+  const ownerScopedRequest = isOwnerNodeRequest(request);
+  if (ownerScopedRequest) {
+    if (!await verifyOwnerNodeRequestProof(request)) {
+      throw new Error("The pending owner request node proof could not be verified.");
+    }
+  } else if (!await verifyNodeJoinProof(request, network.recordId)) {
+    throw new Error("The pending invite request node proof could not be verified.");
+  }
+
+  const preAuthKey = ownerScopedRequest ? undefined : await readPreAuthKey(session, network, request);
+  const nodeKeyDelivery = validateNodeKeyDelivery(request.nodeDID, request.nodeKeyDelivery);
+  const requestOwnerDID = nodeOwnerDID(request);
+  const member = await ensureMemberRecord(session, network, requestOwnerDID, request.label);
+  const meshIP = await allocateMeshIp(network.meshCIDR, request.nodeDID);
+
+  const nodeRecord = await writeRecord(
+    session,
+    MESHD_PROTOCOL_URI,
+    {
+      protocol: MESHD_PROTOCOL_URI,
+      protocolPath: "network/member/node",
+      schema: "https://enbox.id/schemas/wireguard-mesh/node",
+      dataFormat: "application/json",
+      recipient: request.nodeDID,
+      parentContextId: `${network.recordId}/${member.recordId}`
+    },
+    {
+      meshIP,
+      addedAt: new Date().toISOString(),
+      ...(request.label ? { label: request.label } : {}),
+      ownerDID: requestOwnerDID,
+      memberDID: requestOwnerDID,
+      ...(request.delegateDID ? { delegateDID: request.delegateDID } : {}),
+      ...(request.expiresAt ? { expiresAt: request.expiresAt } : {}),
+      nodeKeyDelivery
+    },
+    true
+  );
+
+  await deliverNetworkContextKey(session, network, request, nodeKeyDelivery);
+  if (preAuthKey) {
+    await markPreAuthKeyUsed(session, network, preAuthKey, request.nodeDID);
+  }
+
+  if (ownerScopedRequest) {
+    await writeRecord(
+      session,
+      MESHD_PROTOCOL_URI,
+      {
+        protocol: MESHD_PROTOCOL_URI,
+        protocolPath: "nodeApproval",
+        schema: "https://enbox.id/schemas/wireguard-mesh/node-approval",
+        dataFormat: "application/json",
+        recipient: request.nodeDID
+      },
+      {
+        ownerDID: session.ownerDid,
+        nodeDID: request.nodeDID,
+        networkRecordId: network.recordId,
+        networkName: network.name,
+        meshCIDR: network.meshCIDR,
+        meshIP,
+        ...(network.anchorEndpoint ? { anchorEndpoint: network.anchorEndpoint } : {}),
+        memberRecordId: member.recordId,
+        ...(member.dateCreated ? { memberDateCreated: member.dateCreated } : {}),
+        nodeRecordId: nodeRecord.recordId,
+        ...(nodeRecord.dateCreated ? { nodeDateCreated: nodeRecord.dateCreated } : {}),
+        ...(request.label ? { label: request.label } : {}),
+        ...(request.expiresAt ? { expiresAt: request.expiresAt } : {}),
+        approvedAt: new Date().toISOString(),
+        requestRecordId: request.recordId
+      }
+    );
+  }
+
+  await deleteRecord(session, MESHD_PROTOCOL_URI, request.recordId, false);
+  return {
+    memberRecordId: member.recordId,
+    nodeRecordId: nodeRecord.recordId,
+    meshIP,
+    deliveredContextKey: true
+  };
+}
+
+export async function rejectMeshdNodeRequest(
+  session: MeshdAdminSession,
+  request: MeshdNodeRequestSummary
+): Promise<void> {
+  await deleteRecord(session, MESHD_PROTOCOL_URI, request.recordId, false);
+}
+
+function getRecordIdFromEntry(rawEntry: unknown): string | undefined {
+  const wrapper = isObject(rawEntry) ? rawEntry : undefined;
+  const entry = getRecordWrite(rawEntry);
+  if (!entry || !wrapper) return undefined;
+  const descriptor = isObject(entry.descriptor) ? entry.descriptor : {};
+  return getRecordId(entry, wrapper, descriptor);
+}
+
+export async function removeMeshdNode(
+  session: MeshdAdminSession,
+  network: MeshdNetworkSummary,
+  node: MeshdNodeSummary
+): Promise<{ removedContextKeys: number; contextKeyCleanupError?: string }> {
+  await deleteRecord(session, MESHD_PROTOCOL_URI, node.recordId, true);
+  try {
+    const contextKeyEntries = await queryRecords(
+      session,
+      MESHD_KEY_DELIVERY_PROTOCOL_URI,
+      "contextKey",
+      undefined,
+      {
+        recipient: node.did,
+        tags: {
+          protocol: MESHD_PROTOCOL_URI,
+          contextId: network.recordId
+        }
+      }
+    );
+    let removedContextKeys = 0;
+    for (const entry of contextKeyEntries) {
+      const recordId = getRecordIdFromEntry(entry);
+      if (!recordId) continue;
+      await deleteRecord(session, MESHD_KEY_DELIVERY_PROTOCOL_URI, recordId, false);
+      removedContextKeys++;
+    }
+    return { removedContextKeys };
+  } catch (error) {
+    return {
+      removedContextKeys: 0,
+      contextKeyCleanupError: error instanceof Error ? error.message : "Context key cleanup failed"
+    };
+  }
+}

--- a/admin-dapp/src/styles.css
+++ b/admin-dapp/src/styles.css
@@ -1,0 +1,627 @@
+:root {
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #17201d;
+  background: #f5f7f4;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
+code {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border-radius: 6px;
+  background: #edf0ec;
+  padding: 0.25rem 0.45rem;
+  color: #3f4a45;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.78rem;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 64px;
+  border-bottom: 1px solid #dfe5dd;
+  background: rgba(250, 251, 249, 0.92);
+  padding: 0.75rem 1rem;
+  backdrop-filter: blur(16px);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  padding: 0;
+}
+
+.brand-mark,
+.panel-icon,
+.row-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  border-radius: 8px;
+  background: #17201d;
+  color: #f7faf5;
+}
+
+.brand-mark {
+  width: 38px;
+  height: 38px;
+}
+
+.panel-icon {
+  width: 44px;
+  height: 44px;
+  background: #245a52;
+}
+
+.row-icon {
+  width: 32px;
+  height: 32px;
+  background: #e1efe9;
+  color: #245a52;
+}
+
+.brand-copy {
+  display: grid;
+  text-align: left;
+  line-height: 1.05;
+}
+
+.brand-copy span {
+  font-weight: 720;
+}
+
+.brand-copy small {
+  margin-top: 0.15rem;
+  color: #6b746f;
+  font-size: 0.72rem;
+  letter-spacing: 0;
+}
+
+.topbar-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-width: 0;
+}
+
+.identity-pill {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  max-width: min(52vw, 360px);
+  gap: 0.4rem;
+  border: 1px solid #d8dfd5;
+  border-radius: 999px;
+  background: #ffffff;
+  padding: 0.45rem 0.7rem;
+  color: #3f4a45;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.78rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace {
+  width: 100%;
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.connect-panel,
+.state-panel {
+  display: grid;
+  gap: 1rem;
+  width: min(100%, 520px);
+  margin: clamp(2rem, 12vh, 7rem) auto;
+  border: 1px solid #dfe5dd;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 1.25rem;
+  box-shadow: 0 12px 40px rgba(23, 32, 29, 0.08);
+}
+
+.connect-title {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  min-width: 0;
+}
+
+h1,
+p {
+  margin: 0;
+}
+
+.connect-title h1,
+.state-panel h1,
+.network-header h1 {
+  font-size: 1.35rem;
+  line-height: 1.2;
+  letter-spacing: 0;
+}
+
+.connect-title p,
+.state-panel p,
+.network-header p {
+  margin-top: 0.25rem;
+  color: #68736d;
+  line-height: 1.45;
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.sidebar,
+.main-panel {
+  border: 1px solid #dfe5dd;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.sidebar {
+  position: sticky;
+  top: 80px;
+  display: grid;
+  gap: 1rem;
+  padding: 0.9rem;
+}
+
+.main-panel {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+  min-width: 0;
+}
+
+.section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  color: #303a35;
+  font-size: 0.82rem;
+  font-weight: 720;
+  text-transform: uppercase;
+}
+
+.section-heading small {
+  color: #6b746f;
+  font-size: 0.78rem;
+}
+
+.network-list,
+.stack {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.network-row {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  gap: 0.55rem;
+  align-items: center;
+  width: 100%;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  padding: 0.65rem;
+  color: #303a35;
+  text-align: left;
+}
+
+.network-row:hover,
+.network-row.active {
+  border-color: #c8d8d1;
+  background: #eef6f2;
+}
+
+.network-row span,
+.row-main span {
+  min-width: 0;
+}
+
+.network-row strong,
+.row-main strong {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.network-row small,
+.row-main small {
+  display: block;
+  margin-top: 0.15rem;
+  overflow: hidden;
+  color: #6b746f;
+  font-size: 0.78rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.create-box {
+  display: grid;
+  gap: 0.65rem;
+  border-top: 1px solid #edf0ec;
+  padding-top: 0.9rem;
+}
+
+label {
+  display: grid;
+  gap: 0.3rem;
+  color: #49534e;
+  font-size: 0.82rem;
+  font-weight: 650;
+}
+
+input,
+select {
+  width: 100%;
+  border: 1px solid #d5ddd2;
+  border-radius: 7px;
+  background: #fbfcfa;
+  color: #17201d;
+  padding: 0.58rem 0.65rem;
+}
+
+input:focus,
+select:focus {
+  border-color: #4c8f7e;
+  outline: 3px solid rgba(76, 143, 126, 0.16);
+}
+
+.network-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid #edf0ec;
+  padding-bottom: 1rem;
+}
+
+.header-buttons,
+.row-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 0 0 auto;
+}
+
+.primary-button,
+.secondary-button,
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  border-radius: 8px;
+  min-height: 38px;
+  border: 1px solid transparent;
+  font-weight: 680;
+}
+
+.primary-button {
+  background: #245a52;
+  color: #ffffff;
+  padding: 0.58rem 0.85rem;
+}
+
+.secondary-button {
+  border-color: #d5ddd2;
+  background: #ffffff;
+  color: #25302b;
+  padding: 0.55rem 0.78rem;
+}
+
+.icon-button {
+  width: 38px;
+  height: 38px;
+  border-color: #d5ddd2;
+  background: #ffffff;
+  color: #25302b;
+}
+
+.icon-button.small {
+  width: 31px;
+  height: 31px;
+  min-height: 31px;
+  border-radius: 7px;
+}
+
+.icon-button.success {
+  border-color: #bfdccb;
+  color: #1f7a49;
+}
+
+.icon-button.danger {
+  border-color: #edd2d2;
+  color: #9b2f2f;
+}
+
+.primary-button:hover,
+.secondary-button:hover,
+.icon-button:hover {
+  filter: brightness(0.98);
+}
+
+.content-section {
+  display: grid;
+  gap: 0.65rem;
+  min-width: 0;
+}
+
+.invite-composer {
+  display: grid;
+  gap: 0.7rem;
+  border-bottom: 1px solid #edf0ec;
+  padding-bottom: 1rem;
+  min-width: 0;
+}
+
+.invite-fields {
+  display: grid;
+  grid-template-columns: minmax(160px, 1fr) minmax(140px, 180px) minmax(110px, auto) auto;
+  align-items: end;
+  gap: 0.65rem;
+  min-width: 0;
+}
+
+.toggle-field {
+  display: inline-flex;
+  align-items: center;
+  min-height: 38px;
+  gap: 0.45rem;
+  padding-bottom: 0.08rem;
+}
+
+.toggle-field input {
+  width: 17px;
+  height: 17px;
+  accent-color: #245a52;
+}
+
+.data-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(120px, 0.8fr) auto;
+  align-items: center;
+  gap: 0.75rem;
+  border: 1px solid #e3e9e1;
+  border-radius: 8px;
+  padding: 0.65rem;
+  min-width: 0;
+}
+
+.row-main {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  min-width: 0;
+}
+
+.node-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 0.65rem;
+}
+
+.node-card {
+  display: grid;
+  gap: 0.75rem;
+  border: 1px solid #e3e9e1;
+  border-radius: 8px;
+  padding: 0.75rem;
+  min-width: 0;
+}
+
+.node-card-header {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.node-card-header strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+dl {
+  display: grid;
+  gap: 0.45rem;
+  margin: 0;
+}
+
+dl div {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr);
+  gap: 0.5rem;
+}
+
+dt {
+  color: #6b746f;
+  font-size: 0.78rem;
+}
+
+dd {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: #303a35;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.78rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.invite-result {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem;
+  border: 1px solid #c8d8d1;
+  border-radius: 8px;
+  background: #eef6f2;
+  padding: 0.75rem;
+  min-width: 0;
+}
+
+.invite-result strong {
+  display: block;
+  margin-bottom: 0.35rem;
+}
+
+.invite-result code {
+  display: block;
+}
+
+.empty-row,
+.muted-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: 1px dashed #d9e1d6;
+  border-radius: 8px;
+  padding: 0.85rem;
+  color: #6b746f;
+}
+
+.error-banner {
+  border: 1px solid #efcaca;
+  border-radius: 8px;
+  background: #fff4f4;
+  color: #8d2c2c;
+  padding: 0.75rem;
+  overflow-wrap: anywhere;
+}
+
+.state-panel {
+  justify-items: start;
+}
+
+.spin {
+  animation: spin 0.85s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 860px) {
+  .workspace {
+    padding: 0.75rem;
+  }
+
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: static;
+  }
+
+  .network-header {
+    display: grid;
+  }
+
+  .header-buttons {
+    width: 100%;
+    justify-content: stretch;
+  }
+
+  .header-buttons > button {
+    flex: 1 1 auto;
+  }
+
+  .invite-fields {
+    grid-template-columns: minmax(0, 1fr) minmax(130px, 0.65fr);
+  }
+
+  .invite-fields .primary-button {
+    grid-column: 1 / -1;
+  }
+
+  .data-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .data-row > code {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 560px) {
+  .identity-pill {
+    max-width: 44vw;
+  }
+
+  .connect-title {
+    align-items: flex-start;
+  }
+
+  .data-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .invite-fields {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .row-actions {
+    justify-content: flex-end;
+  }
+}

--- a/admin-dapp/src/vite-env.d.ts
+++ b/admin-dapp/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/admin-dapp/tsconfig.json
+++ b/admin-dapp/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client", "node"]
+  },
+  "include": ["src", "../protocols/**/*.json"],
+  "references": []
+}

--- a/admin-dapp/vite.config.ts
+++ b/admin-dapp/vite.config.ts
@@ -1,0 +1,21 @@
+import path from "path";
+
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { nodePolyfills } from "vite-plugin-node-polyfills";
+
+export default defineConfig({
+  base: "/",
+  define: {
+    global: "globalThis"
+  },
+  plugins: [
+    nodePolyfills(),
+    react()
+  ],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src")
+    }
+  }
+});

--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -8,7 +8,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
+	"net"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -29,6 +33,7 @@ import (
 	"github.com/enboxorg/meshd/internal/mesh"
 	"github.com/enboxorg/meshd/internal/profile"
 	"github.com/enboxorg/meshd/internal/state"
+	"github.com/enboxorg/meshd/internal/walletconnect"
 	"github.com/enboxorg/meshd/pkg/dids"
 	"github.com/enboxorg/meshd/pkg/dids/didcore"
 	"github.com/enboxorg/meshd/protocols"
@@ -42,6 +47,7 @@ Usage:
 
 Identity:
   auth login        Create a new identity profile
+  auth connect      Connect this CLI profile to an Enbox Wallet
   auth list         List all profiles
   auth use <name>   Set the default profile
   auth logout       Remove a profile from config
@@ -56,20 +62,24 @@ Network:
   network leave     Leave the current mesh network
   invite create     Create an invite URL for joining this network
   join <url>        Join a network from a meshd://invite URL
-  peer add          Add a peer to the mesh (anchor only)
+  peer add          Add a peer node to the mesh (anchor only)
+  peer remove       Remove a peer node from the mesh (anchor only)
   peer list         List all peers in the mesh
   peer approve      Deliver encryption keys to a peer (anchor only)
   acl set <file>    Set ACL policy from a JSON file (anchor only)
   acl show          Show the current ACL policy
+  admin             Open the meshd admin dashboard
   status            Show mesh status and identity info
+  doctor            Diagnose identity, wallet, daemon, TUN, and routes
   up                Start the mesh agent daemon
   down              Stop the mesh agent daemon
 
 Up flags:
   --create <name>   Create a new network and start (anchor mode)
-  --endpoint <url>  DWN endpoint (or set DWN_ENDPOINT env var)
+  --endpoint <url>  DWN endpoint for local-vault creation/join (or DWN_ENDPOINT)
   --anchor <did>    Anchor DID when joining a network
   --network <id>    Network record ID when joining a network
+  --owner <did>     Wallet owner DID for this local node when joining
   --tun [name]      Create a real TUN device (default; asks sudo when needed)
   --no-tun          Use userspace mode without OS routes
   --port <n>        WireGuard UDP listen port (default: auto)
@@ -78,6 +88,8 @@ Up flags:
   -v, --verbose     Enable debug logging
 
 Quick start:
+  meshd auth connect
+  meshd up
   meshd up --create my-network --endpoint https://dwn.example.com
   meshd invite create
   meshd join meshd://invite/<token>
@@ -96,6 +108,8 @@ Environment:
   MESHD_VAULT_CACHE_TTL
                      Cache interactive vault unlocks for this duration (default: 5m, 0 disables)
   DWN_ENDPOINT       Default DWN endpoint URL
+  MESHD_WALLET_RESPONSE_ENDPOINT
+                     DWN endpoint for wallet approval handoff on headless devices
 `
 
 var version = "dev"
@@ -105,6 +119,10 @@ const (
 	upBackgroundEnv = "MESHD_UP_BACKGROUND_CHILD"
 	backgroundWait  = 30 * time.Second
 	daemonLogName   = "meshd.log"
+	walletWaitTime  = 10 * time.Minute
+
+	walletResponseEndpointEnv     = "MESHD_WALLET_RESPONSE_ENDPOINT"
+	defaultWalletResponseEndpoint = "https://dev.aws.dwn.enbox.id"
 )
 
 func main() {
@@ -121,9 +139,9 @@ func main() {
 		switch combined {
 		case "network create", "network join", "network leave",
 			"invite create",
-			"peer list", "peer add", "peer approve",
+			"peer list", "peer add", "peer remove", "peer approve",
 			"acl set", "acl show",
-			"auth login", "auth list", "auth use", "auth logout",
+			"auth login", "auth connect", "auth list", "auth use", "auth logout",
 			"vault status", "vault init", "vault unlock":
 			cmd = combined
 			args = os.Args[3:]
@@ -145,6 +163,8 @@ func main() {
 		return
 	case "auth", "auth login":
 		err = cmdAuthLogin(ctx, args)
+	case "auth connect":
+		err = cmdAuthConnect(ctx, args, flagProfile)
 	case "auth list":
 		err = cmdAuthList()
 	case "auth use":
@@ -171,6 +191,8 @@ func main() {
 		err = cmdJoin(ctx, args, flagProfile)
 	case "peer add":
 		err = cmdPeerAdd(ctx, args, flagProfile)
+	case "peer remove":
+		err = cmdPeerRemove(ctx, args, flagProfile)
 	case "peer list":
 		err = cmdPeerList(ctx, args, flagProfile)
 	case "peer approve":
@@ -179,8 +201,12 @@ func main() {
 		err = cmdACLSet(ctx, args, flagProfile)
 	case "acl show":
 		err = cmdACLShow(ctx, args, flagProfile)
+	case "admin":
+		err = cmdAdmin(ctx, args, flagProfile)
 	case "status":
 		err = cmdStatus(ctx, args, flagProfile)
+	case "doctor":
+		err = cmdDoctor(ctx, args, flagProfile)
 	case "up":
 		err = cmdUp(ctx, args, flagProfile)
 	case "down":
@@ -333,39 +359,62 @@ func cmdVaultUnlock(args []string, flagProfile string) error {
 	}
 
 	fmt.Println("Vault unlocked.")
-	fmt.Printf("DID: %s\n", identity.URI)
+	fmt.Printf("Local Node DID: %s\n", identity.URI)
 	fmt.Printf("State: %s\n", stateDir)
 	return nil
 }
 
 // cmdNetworkCreate creates a new mesh network.
 //
-// Usage: meshd network create [name] [--endpoint <dwn-url>]
+// Usage: meshd network create [name] [--endpoint <dwn-url>] [--no-wait]
+// Usage: meshd network create --response <wallet-response.json>
 func cmdNetworkCreate(ctx context.Context, args []string, flagProfile string) error {
-	name, endpoint := parseNetworkCreateArgs(args)
-	if name == "" || endpoint == "" {
+	opts, err := parseNetworkCreateOptions(args)
+	if err != nil {
+		return err
+	}
+	if opts.responseIn != "" {
+		return importNetworkCreateResponse(ctx, flagProfile, opts.responseIn)
+	}
+
+	name, endpoint := opts.name, opts.endpoint
+	if opts.meshCIDR == "" {
+		opts.meshCIDR = "10.200.0.0/16"
+	}
+	if name == "" {
 		if !stdinIsTerminal() {
 			return fmt.Errorf("usage: meshd network create [name] [--endpoint <dwn-url>]")
 		}
 		scanner := bufio.NewScanner(os.Stdin)
-		var err error
-		if name == "" {
-			name, err = promptRequired(scanner, "Network name")
-			if err != nil {
-				return err
-			}
+		name, err = promptRequired(scanner, "Network name")
+		if err != nil {
+			return err
 		}
-		if endpoint == "" {
-			endpoint, err = promptRequired(scanner, "DWN endpoint URL")
-			if err != nil {
-				return err
-			}
-		}
+	}
+	if endpoint == "" && !stdinIsTerminal() && !isWalletAuthorizedNodeProfile(flagProfile) {
+		return fmt.Errorf("usage: meshd network create [name] [--endpoint <dwn-url>]")
 	}
 
 	stateDir, identity, err := ensureIdentityForCommand(ctx, flagProfile, endpoint)
 	if err != nil {
 		return err
+	}
+	meta := resolveIdentityMetadata(flagProfile, identity.URI)
+	nodeDID := firstNonEmpty(meta.NodeDID, identity.URI)
+	ownerDID := firstNonEmpty(meta.OwnerDID, nodeDID)
+	if meta.AuthType == profile.AuthTypeWalletAuthorizedNode && ownerDID != nodeDID {
+		return createWalletNetworkCreateRequest(ctx, flagProfile, stateDir, identity, name, endpoint, opts)
+	}
+
+	if endpoint == "" {
+		if !stdinIsTerminal() {
+			return fmt.Errorf("usage: meshd network create [name] [--endpoint <dwn-url>]")
+		}
+		scanner := bufio.NewScanner(os.Stdin)
+		endpoint, err = promptRequired(scanner, "DWN endpoint URL")
+		if err != nil {
+			return err
+		}
 	}
 
 	if state.HasNetwork(stateDir) {
@@ -420,10 +469,11 @@ func cmdNetworkCreate(ctx context.Context, args []string, flagProfile string) er
 	// 2. Create the network record.
 	// The "network" type does NOT have encryptionRequired — it's publicly
 	// readable as the anchor record. No encryption on this write.
-	meshCIDR := "10.200.0.0/16"
+	meshCIDR := opts.meshCIDR
 	networkData, _ := json.Marshal(map[string]any{
-		"name":     name,
-		"meshCIDR": meshCIDR,
+		"name":           name,
+		"meshCIDR":       meshCIDR,
+		"anchorEndpoint": endpoint,
 	})
 
 	record, writeStatus, err := api.Write(ctx, identity.URI, dwn.WriteParams{
@@ -448,7 +498,7 @@ func cmdNetworkCreate(ctx context.Context, args []string, flagProfile string) er
 	}
 	if err := kdm.DeliverContextKey(ctx, mesh.DeliverContextKeyParams{
 		AnchorDID:      identity.URI,
-		RecipientDID:   identity.URI,
+		RecipientDID:   nodeDID,
 		SourceProtocol: protocols.MeshProtocolURI,
 		ContextID:      record.ID,
 	}); err != nil {
@@ -458,7 +508,7 @@ func cmdNetworkCreate(ctx context.Context, args []string, flagProfile string) er
 	}
 
 	// 4. Allocate mesh IP.
-	meshIP, err := mesh.AllocateMeshIP(meshCIDR, identity.URI)
+	meshIP, err := mesh.AllocateMeshIP(meshCIDR, nodeDID)
 	if err != nil {
 		return fmt.Errorf("allocating mesh IP: %w", err)
 	}
@@ -467,14 +517,21 @@ func cmdNetworkCreate(ctx context.Context, args []string, flagProfile string) er
 	// Use context encryption so that peers with the shared context key can
 	// decrypt the anchor's node record. The anchor already self-delivered the
 	// context key above, and as the DWN owner it can derive the key from root.
+	nodeKeyDelivery, err := walletconnect.NewKeyDeliveryPublic(identity)
+	if err != nil {
+		return fmt.Errorf("deriving node key-delivery public key: %w", err)
+	}
 	reg, err := mesh.RegisterNode(ctx, mesh.RegisterNodeParams{
 		AnchorEndpoint:       endpoint,
 		AnchorDID:            identity.URI,
 		NetworkRecordID:      record.ID,
-		NodeDID:              identity.URI,
+		NodeDID:              nodeDID,
 		Signer:               signer,
 		EncryptionKeyManager: encMgr,
 		MeshIP:               meshIP.String(),
+		OwnerDID:             ownerDID,
+		DelegateDID:          meta.DelegateDID,
+		NodeKeyDelivery:      nodeKeyDelivery,
 		UseContextEncryption: true,
 	})
 	if err != nil {
@@ -506,6 +563,10 @@ func cmdNetworkCreate(ctx context.Context, args []string, flagProfile string) er
 		NetworkName:     name,
 		MeshCIDR:        meshCIDR,
 		MeshIP:          meshIP.String(),
+		NodeDID:         nodeDID,
+		OwnerDID:        ownerDID,
+		MemberDID:       ownerDID,
+		DelegateDID:     meta.DelegateDID,
 	}
 	if reg != nil {
 		ns.NodeRecordID = reg.NodeRecordID
@@ -527,24 +588,734 @@ func cmdNetworkCreate(ctx context.Context, args []string, flagProfile string) er
 	return nil
 }
 
+type networkCreateOptions struct {
+	name       string
+	endpoint   string
+	meshCIDR   string
+	requestOut string
+	responseIn string
+	walletURL  string
+	noWait     bool
+}
+
 func parseNetworkCreateArgs(args []string) (name string, endpoint string) {
+	opts, _ := parseNetworkCreateOptions(args)
+	return opts.name, opts.endpoint
+}
+
+func parseNetworkCreateOptions(args []string) (networkCreateOptions, error) {
+	opts := networkCreateOptions{
+		meshCIDR:  "10.200.0.0/16",
+		walletURL: "https://wallet.enbox.id",
+	}
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--endpoint":
 			if i+1 < len(args) {
-				endpoint = args[i+1]
+				opts.endpoint = args[i+1]
 				i++
+			} else {
+				return opts, fmt.Errorf("--endpoint requires a URL")
 			}
+		case "--cidr":
+			if i+1 < len(args) {
+				opts.meshCIDR = args[i+1]
+				i++
+			} else {
+				return opts, fmt.Errorf("--cidr requires a CIDR")
+			}
+		case "--request-out":
+			if i+1 < len(args) {
+				opts.requestOut = args[i+1]
+				i++
+			} else {
+				return opts, fmt.Errorf("--request-out requires a path")
+			}
+		case "--response":
+			if i+1 < len(args) {
+				opts.responseIn = args[i+1]
+				i++
+			} else {
+				return opts, fmt.Errorf("--response requires a path")
+			}
+		case "--wallet":
+			if i+1 < len(args) {
+				opts.walletURL = args[i+1]
+				i++
+			} else {
+				return opts, fmt.Errorf("--wallet requires a URL")
+			}
+		case "--no-wait":
+			opts.noWait = true
 		default:
-			if name == "" && !strings.HasPrefix(args[i], "-") {
-				name = args[i]
+			if strings.HasPrefix(args[i], "-") {
+				return opts, fmt.Errorf("unknown network create flag %q", args[i])
+			}
+			if opts.name == "" {
+				opts.name = args[i]
+			} else {
+				return opts, fmt.Errorf("unexpected argument %q", args[i])
 			}
 		}
 	}
-	if endpoint == "" {
-		endpoint = os.Getenv("DWN_ENDPOINT")
+	if opts.endpoint == "" {
+		opts.endpoint = os.Getenv("DWN_ENDPOINT")
 	}
-	return name, endpoint
+	return opts, nil
+}
+
+type walletResponseCallback struct {
+	url        string
+	server     *http.Server
+	responseCh chan []byte
+	errCh      chan error
+}
+
+type walletResponseRelay struct {
+	endpoint string
+	token    string
+}
+
+func shouldWaitForWalletResponse(walletURL, requestOut string, noWait bool) bool {
+	return walletURL != "" && requestOut == "" && !noWait && stdinIsTerminal()
+}
+
+func shouldUseWalletResponseRelay(walletURL, requestOut string, noWait bool) bool {
+	return walletURL != "" && requestOut == "" && !noWait
+}
+
+func walletResponseEndpoint(fallbackEndpoint string) string {
+	if endpoint := strings.TrimSpace(os.Getenv(walletResponseEndpointEnv)); endpoint != "" {
+		return strings.TrimRight(endpoint, "/")
+	}
+	if fallbackEndpoint = strings.TrimSpace(fallbackEndpoint); fallbackEndpoint != "" {
+		return strings.TrimRight(fallbackEndpoint, "/")
+	}
+	if endpoint := strings.TrimSpace(os.Getenv("DWN_ENDPOINT")); endpoint != "" {
+		return strings.TrimRight(endpoint, "/")
+	}
+	return defaultWalletResponseEndpoint
+}
+
+func setupWalletResponseRelay(ctx context.Context, endpoint string, identity *did.DID) (*walletResponseRelay, error) {
+	endpoint = strings.TrimRight(strings.TrimSpace(endpoint), "/")
+	if endpoint == "" || identity == nil {
+		return nil, nil
+	}
+	token, err := walletconnect.GenerateChallenge()
+	if err != nil {
+		return nil, err
+	}
+	if err := dwn.RegisterTenant(ctx, endpoint, identity.URI); err != nil {
+		return nil, fmt.Errorf("registering wallet response tenant: %w", err)
+	}
+	signer := &dwn.Signer{DID: identity.URI, PrivateKey: identity.SigningKey}
+	api := dwn.NewDwnAPI(dwn.NewSimpleAgent(endpoint, signer))
+	status, err := api.ConfigureProtocol(ctx, identity.URI, protocols.WalletResponseProtocolJSON)
+	if err != nil {
+		return nil, fmt.Errorf("configuring wallet response protocol: %w", err)
+	}
+	if status.Code >= 300 && status.Code != 409 {
+		return nil, fmt.Errorf("wallet response protocol configure failed: %d %s", status.Code, status.Detail)
+	}
+	return &walletResponseRelay{endpoint: endpoint, token: token}, nil
+}
+
+func browserOpenCommand(goos string, rawURL string) (string, []string, bool) {
+	switch goos {
+	case "darwin":
+		return "open", []string{rawURL}, true
+	case "windows":
+		return "rundll32", []string{"url.dll,FileProtocolHandler", rawURL}, true
+	default:
+		return "xdg-open", []string{rawURL}, true
+	}
+}
+
+func openBrowser(rawURL string) error {
+	if rawURL == "" {
+		return fmt.Errorf("wallet URL is empty")
+	}
+	name, args, ok := browserOpenCommand(runtime.GOOS, rawURL)
+	if !ok {
+		return fmt.Errorf("unsupported OS")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return fmt.Errorf("%s did not return within 5s", name)
+	}
+	if err != nil {
+		detail := strings.TrimSpace(string(output))
+		if detail != "" {
+			return fmt.Errorf("%s failed: %w: %s", name, err, detail)
+		}
+		return fmt.Errorf("%s failed: %w", name, err)
+	}
+	return nil
+}
+
+func printWalletURL(rawURL string, autoOpen bool, remoteHandoff bool) {
+	fmt.Printf("\nOpen in wallet:\n  %s\n", rawURL)
+	if remoteHandoff {
+		fmt.Printf("  This URL can be opened on another device; meshd will wait for the wallet response over DWN.\n")
+	}
+	if !autoOpen {
+		return
+	}
+	if err := openBrowser(rawURL); err != nil {
+		fmt.Printf("  Could not open browser automatically: %v\n", err)
+	} else {
+		fmt.Printf("  Browser opened. Approve the request there, then return here.\n")
+	}
+}
+
+type adminOptions struct {
+	dashboardURL string
+	printOnly    bool
+}
+
+const defaultAdminDashboardURL = "https://meshd-admin.pages.dev"
+
+func parseAdminArgs(args []string) (adminOptions, error) {
+	opts := adminOptions{dashboardURL: defaultAdminDashboardURL}
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--dashboard", "--wallet":
+			if i+1 >= len(args) {
+				return opts, fmt.Errorf("%s requires a URL", args[i])
+			}
+			opts.dashboardURL = args[i+1]
+			i++
+		case "--print", "--no-open":
+			opts.printOnly = true
+		default:
+			return opts, fmt.Errorf("unknown admin flag %q", args[i])
+		}
+	}
+	return opts, nil
+}
+
+// cmdAdmin opens the meshd admin dashboard, preselecting the active owner and
+// network when local state is available.
+func cmdAdmin(ctx context.Context, args []string, flagProfile string) error {
+	opts, err := parseAdminArgs(args)
+	if err != nil {
+		return err
+	}
+	adminURL := buildAdminURL(opts.dashboardURL, adminContextFromProfile(flagProfile))
+	fmt.Printf("meshd admin:\n  %s\n", adminURL)
+	if opts.printOnly || !stdinIsTerminal() {
+		return nil
+	}
+	if err := openBrowser(adminURL); err != nil {
+		fmt.Printf("  Could not open browser automatically: %v\n", err)
+	} else {
+		fmt.Printf("  Browser opened.\n")
+	}
+	return nil
+}
+
+type adminContext struct {
+	OwnerDID        string
+	NetworkRecordID string
+}
+
+func adminContextFromProfile(flagProfile string) adminContext {
+	ctx := adminContext{}
+	if os.Getenv("MESHD_STATE_DIR") == "" {
+		if name, err := profile.Resolve(flagProfile); err == nil {
+			if cfg, cfgErr := profile.ReadConfig(); cfgErr == nil && cfg.Profiles[name] != nil {
+				ctx.OwnerDID = cfg.Profiles[name].EffectiveOwnerDID()
+			}
+		}
+	}
+	stateDir, err := resolveStateDir(flagProfile)
+	if err != nil {
+		return ctx
+	}
+	ns, err := state.LoadNetworkState(stateDir)
+	if err != nil || ns == nil {
+		return ctx
+	}
+	ctx.OwnerDID = networkOwnerDID(ns, ctx.OwnerDID)
+	ctx.NetworkRecordID = ns.NetworkRecordID
+	return ctx
+}
+
+func buildAdminURL(walletURL string, ctx adminContext) string {
+	base := strings.TrimRight(strings.TrimSpace(walletURL), "/")
+	if base == "" {
+		base = defaultAdminDashboardURL
+	}
+	adminURL := base
+	values := url.Values{}
+	if ctx.OwnerDID != "" {
+		values.Set("owner", ctx.OwnerDID)
+	}
+	if ctx.NetworkRecordID != "" {
+		values.Set("network", ctx.NetworkRecordID)
+	}
+	if encoded := values.Encode(); encoded != "" {
+		adminURL += "?" + encoded
+	}
+	return adminURL
+}
+
+func startWalletResponseCallback() (*walletResponseCallback, error) {
+	token, err := walletconnect.GenerateChallenge()
+	if err != nil {
+		return nil, err
+	}
+	path := "/meshd/wallet-callback/" + token
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("start wallet callback listener: %w", err)
+	}
+
+	cb := &walletResponseCallback{
+		responseCh: make(chan []byte, 1),
+		errCh:      make(chan error, 1),
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		w.Header().Set("Access-Control-Allow-Private-Network", "true")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		defer r.Body.Close()
+		data, err := io.ReadAll(io.LimitReader(r.Body, 4<<20))
+		if err != nil {
+			http.Error(w, "read response", http.StatusBadRequest)
+			return
+		}
+		if len(data) == 0 {
+			http.Error(w, "empty response", http.StatusBadRequest)
+			return
+		}
+		select {
+		case cb.responseCh <- data:
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte("ok\n"))
+		default:
+			http.Error(w, "response already received", http.StatusConflict)
+		}
+	})
+
+	cb.server = &http.Server{Handler: mux}
+	addr := ln.Addr().(*net.TCPAddr)
+	cb.url = fmt.Sprintf("http://127.0.0.1:%d%s", addr.Port, path)
+	go func() {
+		if err := cb.server.Serve(ln); err != nil && err != http.ErrServerClosed {
+			select {
+			case cb.errCh <- err:
+			default:
+			}
+		}
+	}()
+	return cb, nil
+}
+
+func (cb *walletResponseCallback) close() {
+	if cb == nil || cb.server == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_ = cb.server.Shutdown(ctx)
+}
+
+func (cb *walletResponseCallback) wait(ctx context.Context) ([]byte, error) {
+	timer := time.NewTimer(walletWaitTime)
+	defer timer.Stop()
+	select {
+	case data := <-cb.responseCh:
+		return data, nil
+	case err := <-cb.errCh:
+		return nil, fmt.Errorf("wallet callback failed: %w", err)
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-timer.C:
+		return nil, fmt.Errorf("timed out waiting for wallet response")
+	}
+}
+
+func waitForWalletDelivery(ctx context.Context, callback *walletResponseCallback, relay *walletResponseRelay, identity *did.DID) ([]byte, error) {
+	waitCtx, cancel := context.WithTimeout(ctx, walletWaitTime)
+	defer cancel()
+
+	type result struct {
+		data []byte
+		err  error
+	}
+	results := make(chan result, 2)
+	pending := 0
+	if callback != nil {
+		pending++
+		go func() {
+			data, err := callback.wait(waitCtx)
+			results <- result{data: data, err: err}
+		}()
+	}
+	if relay != nil {
+		pending++
+		go func() {
+			data, err := relay.wait(waitCtx, identity)
+			results <- result{data: data, err: err}
+		}()
+	}
+	if pending == 0 {
+		return nil, fmt.Errorf("no wallet response delivery channel configured")
+	}
+
+	var lastErr error
+	for pending > 0 {
+		select {
+		case res := <-results:
+			pending--
+			if res.err == nil {
+				return res.data, nil
+			}
+			lastErr = res.err
+		case <-waitCtx.Done():
+			if lastErr != nil {
+				return nil, lastErr
+			}
+			return nil, waitCtx.Err()
+		}
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, fmt.Errorf("wallet response was not received")
+}
+
+func (r *walletResponseRelay) wait(ctx context.Context, identity *did.DID) ([]byte, error) {
+	if r == nil || r.endpoint == "" || r.token == "" || identity == nil {
+		return nil, fmt.Errorf("wallet response relay is not configured")
+	}
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	var lastErr error
+	for {
+		data, ok, err := r.fetch(ctx, identity)
+		if err != nil {
+			lastErr = err
+		}
+		if ok {
+			return data, nil
+		}
+		select {
+		case <-ctx.Done():
+			if lastErr != nil {
+				return nil, fmt.Errorf("timed out waiting for wallet response relay: %w", lastErr)
+			}
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (r *walletResponseRelay) fetch(ctx context.Context, identity *did.DID) ([]byte, bool, error) {
+	signer := &dwn.Signer{DID: identity.URI, PrivateKey: identity.SigningKey}
+	api := dwn.NewDwnAPI(dwn.NewSimpleAgent(r.endpoint, signer))
+	records, status, err := api.Query(ctx, identity.URI, dwn.QueryParams{
+		Filter: dwn.RecordsFilter{
+			Protocol:     protocols.WalletResponseProtocolURI,
+			ProtocolPath: "response",
+			Recipient:    identity.URI,
+		},
+		DateSort: "createdDescending",
+	}, "")
+	if err != nil {
+		return nil, false, err
+	}
+	if status.Code != 200 {
+		return nil, false, fmt.Errorf("wallet response query failed: %d %s", status.Code, status.Detail)
+	}
+	for _, queryRecord := range records {
+		record, readStatus, err := api.Read(ctx, identity.URI, dwn.RecordsFilter{
+			RecordID: queryRecord.ID,
+		}, "")
+		if err != nil {
+			return nil, false, err
+		}
+		if readStatus.Code != 200 || record == nil {
+			continue
+		}
+		data, err := record.Data().Bytes(ctx)
+		if err != nil {
+			return nil, false, err
+		}
+		var env walletconnect.ResponseEnvelope
+		if err := json.Unmarshal(data, &env); err != nil {
+			continue
+		}
+		if env.ResponseToken != r.token {
+			continue
+		}
+		if err := env.Validate(); err != nil {
+			return nil, false, err
+		}
+		if status, err := api.Delete(ctx, identity.URI, queryRecord.ID, false, ""); err != nil {
+			fmt.Printf("  Warning: wallet response cleanup failed: %v\n", err)
+		} else if status.Code >= 300 && status.Code != 404 {
+			fmt.Printf("  Warning: wallet response cleanup failed: %d %s\n", status.Code, status.Detail)
+		}
+		return append([]byte(nil), env.Response...), true, nil
+	}
+	return nil, false, nil
+}
+
+func createWalletNetworkCreateRequest(ctx context.Context, flagProfile string, stateDir string, identity *did.DID, name string, endpoint string, opts networkCreateOptions) error {
+	if state.HasNetwork(stateDir) {
+		return fmt.Errorf("already in a network. Use 'meshd network leave' first.")
+	}
+	var err error
+	var callback *walletResponseCallback
+	if shouldWaitForWalletResponse(opts.walletURL, opts.requestOut, opts.noWait) {
+		callback, err = startWalletResponseCallback()
+		if err != nil {
+			return err
+		}
+		defer callback.close()
+	}
+	var relay *walletResponseRelay
+	if shouldUseWalletResponseRelay(opts.walletURL, opts.requestOut, opts.noWait) {
+		relay, err = setupWalletResponseRelay(ctx, walletResponseEndpoint(endpoint), identity)
+		if err != nil {
+			fmt.Printf("  Warning: wallet response handoff unavailable: %v\n", err)
+			relay = nil
+		}
+	}
+	profileName := profileNameForWrite(flagProfile)
+	delegateIdentity, err := ensureWalletDelegateIdentity(stateDir)
+	if err != nil {
+		return err
+	}
+	req, err := walletconnect.NewNetworkCreateRequest(profileName, identity, name, endpoint, opts.meshCIDR, delegateIdentity)
+	if err != nil {
+		return err
+	}
+	if callback != nil {
+		req.CallbackURL = callback.url
+	}
+	if relay != nil {
+		req.ResponseEndpoint = relay.endpoint
+		req.ResponseToken = relay.token
+	}
+	if err := walletconnect.SignNetworkCreateRequest(identity, &req); err != nil {
+		return err
+	}
+	requestURL, err := walletconnect.EncodeNetworkCreateRequest(req)
+	if err != nil {
+		return err
+	}
+	if opts.requestOut != "" {
+		data, err := json.MarshalIndent(req, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal network create request: %w", err)
+		}
+		if err := os.WriteFile(opts.requestOut, data, 0600); err != nil {
+			return fmt.Errorf("write network create request: %w", err)
+		}
+	}
+
+	fmt.Println("Wallet approval required to create this network.")
+	fmt.Printf("  Profile: %s\n", profileName)
+	fmt.Printf("  Node DID: %s\n", identity.URI)
+	fmt.Printf("  Delegate DID: %s\n", delegateIdentity.URI)
+	fmt.Printf("  Network: %s\n", name)
+	fmt.Printf("  CIDR: %s\n", opts.meshCIDR)
+	if endpoint != "" {
+		fmt.Printf("  Requested DWN: %s\n", endpoint)
+	}
+	if opts.requestOut != "" {
+		fmt.Printf("  Request: %s\n", opts.requestOut)
+	}
+	if relay != nil {
+		fmt.Printf("  Response handoff: %s\n", relay.endpoint)
+	}
+	fmt.Printf("\nRequest URL:\n  %s\n", requestURL)
+	if opts.walletURL != "" {
+		walletURL := strings.TrimRight(opts.walletURL, "/") + "/meshd/create?request=" + url.QueryEscape(requestURL)
+		printWalletURL(walletURL, callback != nil, relay != nil)
+	}
+	if callback == nil && relay == nil {
+		fmt.Printf("\nAfter wallet approval, save the response JSON and run:\n")
+		fmt.Printf("  meshd network create --response <response.json>\n")
+		return nil
+	}
+	fmt.Printf("\nWaiting for wallet approval...\n")
+	data, err := waitForWalletDelivery(ctx, callback, relay, identity)
+	if err != nil {
+		return err
+	}
+	return importNetworkCreateResponseData(ctx, flagProfile, data)
+}
+
+func importNetworkCreateResponse(ctx context.Context, flagProfile string, responsePath string) error {
+	var data []byte
+	var err error
+	if responsePath == "-" {
+		data, err = io.ReadAll(os.Stdin)
+	} else {
+		data, err = os.ReadFile(responsePath)
+	}
+	if err != nil {
+		return fmt.Errorf("read network create response: %w", err)
+	}
+	return importNetworkCreateResponseData(ctx, flagProfile, data)
+}
+
+func importNetworkCreateResponseData(ctx context.Context, flagProfile string, data []byte) error {
+	var resp walletconnect.NetworkCreateResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return fmt.Errorf("parse network create response: %w", err)
+	}
+	if err := resp.Validate(); err != nil {
+		return err
+	}
+	resp.NormalizeOwnerDID()
+	ownerDID := resp.EffectiveOwnerDID()
+
+	profileFlag := firstNonEmpty(flagProfile, resp.ProfileName)
+	stateDir, identity, err := ensureIdentityForCommand(ctx, profileFlag, resp.AnchorEndpoint)
+	if err != nil {
+		return err
+	}
+	if resp.NodeDID != identity.URI {
+		return fmt.Errorf("network create response node DID %s does not match local node DID %s", resp.NodeDID, identity.URI)
+	}
+	if state.HasNetwork(stateDir) {
+		return fmt.Errorf("already in a network. Use 'meshd network leave' first.")
+	}
+
+	password, err := vaultPasswordForUnlock(stateDir)
+	if err != nil {
+		return err
+	}
+	if _, err := requireWalletResponseDelegateIdentity(stateDir, resp.DelegateDID, resp.NodeDID, "network create response"); err != nil {
+		return err
+	}
+	existingSession, err := state.LoadWalletSession(stateDir, password)
+	if err != nil {
+		return err
+	}
+	nodeContextKeys := resp.EffectiveNodeContextKeys()
+	nodeProtocols := resp.EffectiveNodeMultiPartyProtocols()
+	session := &state.WalletSession{
+		Version:                 1,
+		OwnerDID:                ownerDID,
+		ConnectedDID:            ownerDID,
+		DelegateDID:             resp.DelegateDID,
+		NodeDID:                 resp.NodeDID,
+		WalletOrigin:            resp.WalletOrigin,
+		ExpiresAt:               resp.ExpiresAt,
+		Grants:                  resp.Grants,
+		NodeContextKeys:         nodeContextKeys,
+		NodeMultiPartyProtocols: nodeProtocols,
+	}
+	if existingSession != nil {
+		if existingOwnerDID := existingSession.EffectiveOwnerDID(); existingOwnerDID != "" && existingOwnerDID != ownerDID {
+			return fmt.Errorf("wallet session owner DID %s does not match network response owner DID %s", existingOwnerDID, ownerDID)
+		}
+		if existingSession.NodeDID != "" && existingSession.NodeDID != resp.NodeDID {
+			return fmt.Errorf("wallet session node DID %s does not match network response node DID %s", existingSession.NodeDID, resp.NodeDID)
+		}
+		if session.DelegateDID == "" {
+			session.DelegateDID = existingSession.DelegateDID
+		}
+		if existingSession.DelegateDID != "" && session.DelegateDID != "" && existingSession.DelegateDID != session.DelegateDID {
+			return fmt.Errorf("wallet session delegate DID %s does not match network response delegate DID %s", existingSession.DelegateDID, session.DelegateDID)
+		}
+		session.Grants = append(existingSession.Grants, resp.Grants...)
+		session.DelegateDecryptionKeys = existingSession.DelegateDecryptionKeys
+		session.NodeContextKeys = append(existingSession.EffectiveNodeContextKeys(), nodeContextKeys...)
+		if len(nodeProtocols) == 0 {
+			session.NodeMultiPartyProtocols = existingSession.EffectiveNodeMultiPartyProtocols()
+		}
+	}
+	if err := state.StoreWalletSession(stateDir, password, session); err != nil {
+		return err
+	}
+
+	contextKeyCount, err := storeWalletNodeContextKeys(stateDir, password, nodeContextKeys)
+	if err != nil {
+		return err
+	}
+
+	ns := &state.NetworkState{
+		NetworkRecordID:   resp.NetworkRecordID,
+		AnchorDID:         ownerDID,
+		AnchorEndpoint:    resp.AnchorEndpoint,
+		NetworkName:       resp.NetworkName,
+		MeshCIDR:          resp.MeshCIDR,
+		MeshIP:            resp.MeshIP,
+		NodeDID:           resp.NodeDID,
+		OwnerDID:          ownerDID,
+		MemberDID:         ownerDID,
+		DelegateDID:       session.DelegateDID,
+		NodeRecordID:      resp.NodeRecordID,
+		NodeDateCreated:   resp.NodeDateCreated,
+		MemberRecordID:    resp.MemberRecordID,
+		MemberDateCreated: resp.MemberDateCreated,
+	}
+	if err := state.SaveNetworkState(stateDir, ns); err != nil {
+		return fmt.Errorf("saving network state: %w", err)
+	}
+
+	if os.Getenv("MESHD_STATE_DIR") == "" {
+		profileName := profileNameForWrite(profileFlag)
+		if err := profile.UpsertProfileEntry(&profile.Entry{
+			Name:         profileName,
+			DID:          identity.URI,
+			AuthType:     profile.AuthTypeWalletAuthorizedNode,
+			OwnerDID:     ownerDID,
+			ConnectedDID: ownerDID,
+			DelegateDID:  session.DelegateDID,
+			NodeDID:      identity.URI,
+			WalletOrigin: resp.WalletOrigin,
+			ExpiresAt:    resp.ExpiresAt,
+		}); err != nil {
+			return fmt.Errorf("saving wallet-connected profile: %w", err)
+		}
+	}
+
+	fmt.Println("Wallet-created network imported.")
+	fmt.Printf("  Name: %s\n", resp.NetworkName)
+	fmt.Printf("  CIDR: %s\n", resp.MeshCIDR)
+	fmt.Printf("  Mesh IP: %s\n", resp.MeshIP)
+	fmt.Printf("  Wallet Owner DID: %s\n", ownerDID)
+	if session.DelegateDID != "" {
+		fmt.Printf("  Delegate DID: %s\n", session.DelegateDID)
+	}
+	fmt.Printf("  Node DID: %s\n", resp.NodeDID)
+	fmt.Printf("  Anchor DID: %s\n", ownerDID)
+	fmt.Printf("  Anchor Endpoint: %s\n", resp.AnchorEndpoint)
+	fmt.Printf("  Network Record: %s\n", resp.NetworkRecordID)
+	if resp.MemberRecordID != "" {
+		fmt.Printf("  Member Record: %s\n", resp.MemberRecordID)
+	}
+	if resp.NodeRecordID != "" {
+		fmt.Printf("  Node Record: %s\n", resp.NodeRecordID)
+	}
+	if contextKeyCount > 0 {
+		fmt.Printf("  Context keys: %d imported\n", contextKeyCount)
+	}
+	fmt.Printf("\nRun 'meshd up' to start the mesh.\n")
+	return nil
 }
 
 // cmdNetworkJoin joins an existing mesh network.
@@ -556,7 +1327,9 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 		return cmdJoin(ctx, args, flagProfile)
 	}
 
-	endpoint, anchorDID, networkID, preauthRequested := parseNetworkJoinArgs(args)
+	joinOpts := parseNetworkJoinOptions(args)
+	endpoint, anchorDID, networkID, preauthRequested := joinOpts.endpoint, joinOpts.anchorDID, joinOpts.networkID, joinOpts.preauthRequested
+	requestedOwnerDID := parseOwnerDIDArg(args)
 	if endpoint == "" || anchorDID == "" || networkID == "" {
 		if !stdinIsTerminal() {
 			return fmt.Errorf("usage: meshd network join <invite-url> OR meshd network join --endpoint <url> --anchor <did> --network <id>")
@@ -601,6 +1374,9 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 	if err != nil {
 		return err
 	}
+	meta := resolveIdentityMetadata(flagProfile, identity.URI)
+	nodeDID := firstNonEmpty(meta.NodeDID, identity.URI)
+	ownerDID := firstNonEmpty(requestedOwnerDID, meta.OwnerDID, nodeDID)
 
 	if state.HasNetwork(stateDir) {
 		return fmt.Errorf("already in a network. Use 'meshd network leave' first.")
@@ -656,7 +1432,7 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 			Protocol:     protocols.MeshProtocolURI,
 			ProtocolPath: "network/node",
 			ContextID:    networkID,
-			Recipient:    identity.URI,
+			Recipient:    nodeDID,
 		},
 		DateSort: "createdDescending",
 	}, "")
@@ -683,7 +1459,7 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 				Protocol:     protocols.MeshProtocolURI,
 				ProtocolPath: "network/member",
 				ContextID:    networkID,
-				Recipient:    identity.URI,
+				Recipient:    ownerDID,
 			},
 			DateSort: "createdDescending",
 		}, "network/member")
@@ -696,7 +1472,7 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 						Protocol:     protocols.MeshProtocolURI,
 						ProtocolPath: "network/member/node",
 						ContextID:    networkID + "/" + memberRecord.ID,
-						Recipient:    identity.URI,
+						Recipient:    nodeDID,
 					},
 					DateSort: "createdDescending",
 				}, "network/member")
@@ -731,7 +1507,7 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 				Protocol:     protocols.MeshProtocolURI,
 				ProtocolPath: "network/member",
 				ContextID:    networkID,
-				Recipient:    identity.URI,
+				Recipient:    ownerDID,
 			},
 			DateSort: "createdDescending",
 		}, "network/member")
@@ -742,7 +1518,7 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 	// If no node record found, the anchor hasn't added us yet.
 	// Allocate a mesh IP deterministically and save partial state.
 	if meshIP == "" {
-		allocatedIP, allocErr := mesh.AllocateMeshIP(networkData.MeshCIDR, identity.URI)
+		allocatedIP, allocErr := mesh.AllocateMeshIP(networkData.MeshCIDR, nodeDID)
 		if allocErr != nil {
 			return fmt.Errorf("allocating mesh IP: %w", allocErr)
 		}
@@ -750,12 +1526,9 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 	}
 
 	if nodeRecordID == "" {
-		if preauthRequested {
-			fmt.Printf("  Join request submitted. Waiting for the anchor to approve this invite.\n")
-			fmt.Printf("  Run 'meshd up' again after the anchor has processed the request.\n")
-		} else {
+		if !preauthRequested {
 			fmt.Printf("  No node record found — the anchor needs to run:\n")
-			fmt.Printf("    meshd peer add %s\n", identity.URI)
+			fmt.Printf("    meshd peer add %s\n", nodeDID)
 		}
 	}
 
@@ -780,15 +1553,28 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 
 	// Write nodeInfo if we have a node record (so the network sees our hostname/OS).
 	if nodeRecordID != "" {
+		nodeInfoGrantID, grantErr := walletGrantIDForDWNOperation(stateDir, meta, dwn.InterfaceRecordsWrite, protocols.MeshProtocolURI, nodeInfoProtocolPath(&state.NetworkState{MemberRecordID: memberRecordID}), networkID, false)
+		if grantErr != nil {
+			return grantErr
+		}
+		nodeInfoSigner := signer
+		if nodeInfoGrantID != "" {
+			operationIdentity, err := loadDWNOperationIdentity(stateDir, meta, identity)
+			if err != nil {
+				return err
+			}
+			nodeInfoSigner = dwnSigner(operationIdentity)
+		}
 		if err := mesh.WriteNodeInfo(ctx, mesh.WriteNodeInfoParams{
 			AnchorEndpoint:       endpoint,
 			AnchorDID:            anchorDID,
 			NetworkRecordID:      networkID,
 			MemberRecordID:       memberRecordID,
 			NodeRecordID:         nodeRecordID,
-			Signer:               signer,
+			Signer:               nodeInfoSigner,
 			EncryptionKeyManager: encMgr,
 			UseContextEncryption: useContextEnc,
+			PermissionGrantID:    nodeInfoGrantID,
 		}); err != nil {
 			fmt.Printf("  Warning: nodeInfo write failed: %v\n", err)
 		} else {
@@ -804,6 +1590,10 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 		NetworkName:     networkData.Name,
 		MeshCIDR:        networkData.MeshCIDR,
 		MeshIP:          meshIP,
+		NodeDID:         nodeDID,
+		OwnerDID:        ownerDID,
+		MemberDID:       ownerDID,
+		DelegateDID:     meta.DelegateDID,
 		NodeRecordID:    nodeRecordID,
 		NodeDateCreated: nodeDateCreated,
 		MemberRecordID:  memberRecordID,
@@ -815,42 +1605,92 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 		return fmt.Errorf("saving network state: %w", err)
 	}
 
+	if nodeRecordID == "" {
+		if preauthRequested {
+			fmt.Printf("Join request is pending approval.\n")
+			fmt.Printf("  Name: %s\n", networkData.Name)
+			fmt.Printf("  CIDR: %s\n", networkData.MeshCIDR)
+			fmt.Printf("  Reserved Mesh IP: %s\n", meshIP)
+			fmt.Printf("  Anchor: %s\n", anchorDID)
+			if !joinOpts.noStartHint {
+				fmt.Printf("\nAfter approval, run 'meshd up' to start the mesh.\n")
+			}
+		} else {
+			fmt.Printf("Join state saved, but this node has not been approved yet.\n")
+			if !joinOpts.noStartHint {
+				fmt.Printf("\nAfter the anchor adds this node, run 'meshd up' to start the mesh.\n")
+			}
+		}
+		return nil
+	}
+
 	fmt.Printf("Joined network.\n")
 	fmt.Printf("  Name: %s\n", networkData.Name)
 	fmt.Printf("  CIDR: %s\n", networkData.MeshCIDR)
 	fmt.Printf("  Mesh IP: %s\n", meshIP)
 	fmt.Printf("  Anchor: %s\n", anchorDID)
-	fmt.Printf("\nRun 'meshd up' to start the mesh.\n")
+	if !joinOpts.noStartHint {
+		fmt.Printf("\nRun 'meshd up' to start the mesh.\n")
+	}
 
 	return nil
 }
 
+type networkJoinOptions struct {
+	endpoint         string
+	anchorDID        string
+	networkID        string
+	preauthRequested bool
+	noStartHint      bool
+}
+
 func parseNetworkJoinArgs(args []string) (endpoint string, anchorDID string, networkID string, preauthRequested bool) {
+	opts := parseNetworkJoinOptions(args)
+	return opts.endpoint, opts.anchorDID, opts.networkID, opts.preauthRequested
+}
+
+func parseNetworkJoinOptions(args []string) networkJoinOptions {
+	var opts networkJoinOptions
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--endpoint":
 			if i+1 < len(args) {
-				endpoint = args[i+1]
+				opts.endpoint = args[i+1]
 				i++
 			}
 		case "--anchor":
 			if i+1 < len(args) {
-				anchorDID = args[i+1]
+				opts.anchorDID = args[i+1]
 				i++
 			}
 		case "--network":
 			if i+1 < len(args) {
-				networkID = args[i+1]
+				opts.networkID = args[i+1]
 				i++
 			}
 		case "--preauth":
-			preauthRequested = true
+			opts.preauthRequested = true
+		case "--no-start-hint":
+			opts.noStartHint = true
 		}
 	}
-	if endpoint == "" {
-		endpoint = os.Getenv("DWN_ENDPOINT")
+	if opts.endpoint == "" {
+		opts.endpoint = os.Getenv("DWN_ENDPOINT")
 	}
-	return endpoint, anchorDID, networkID, preauthRequested
+	return opts
+}
+
+func parseOwnerDIDArg(args []string) string {
+	for i := 0; i < len(args); i++ {
+		if (args[i] == "--owner" || args[i] == "--member") && i+1 < len(args) {
+			return strings.TrimSpace(args[i+1])
+		}
+	}
+	return ""
+}
+
+func parseMemberDIDArg(args []string) string {
+	return parseOwnerDIDArg(args)
 }
 
 // cmdNetworkLeave leaves the current mesh network.
@@ -933,10 +1773,19 @@ func cmdInviteCreate(ctx context.Context, args []string, flagProfile string) err
 	if ns == nil {
 		return fmt.Errorf("not in a network. Use 'meshd network create' first.")
 	}
-	if ns.AnchorDID != identity.URI {
-		return fmt.Errorf("only the network anchor (%s) can create invites", ns.AnchorDID)
+	meta, useContextEncryption, err := requireNetworkOwnerProfile(flagProfile, identity, ns)
+	if err != nil {
+		return err
 	}
 
+	encMgr, err := prepareNetworkCommandEncryption(stateDir, identity, ns, useContextEncryption)
+	if err != nil {
+		return err
+	}
+	writeGrantID, err := walletGrantIDForDWNOperation(stateDir, meta, dwn.InterfaceRecordsWrite, protocols.MeshProtocolURI, "", ns.NetworkRecordID, useContextEncryption)
+	if err != nil {
+		return err
+	}
 	expiresAt := time.Time{}
 	if expires > 0 {
 		expiresAt = time.Now().Add(expires)
@@ -945,18 +1794,24 @@ func cmdInviteCreate(ctx context.Context, args []string, flagProfile string) err
 		label = ns.NetworkName
 	}
 
-	signer := &dwn.Signer{DID: identity.URI, PrivateKey: identity.SigningKey}
+	operationIdentity, err := loadDWNOperationIdentity(stateDir, meta, identity)
+	if err != nil {
+		return err
+	}
+	signer := dwnSigner(operationIdentity)
 	result, err := mesh.CreatePreAuthKey(ctx, mesh.CreatePreAuthKeyParams{
 		AnchorEndpoint:       ns.AnchorEndpoint,
 		AnchorDID:            ns.AnchorDID,
 		NetworkRecordID:      ns.NetworkRecordID,
 		NetworkName:          ns.NetworkName,
 		Signer:               signer,
-		EncryptionKeyManager: newEncryptionKeyManager(identity),
+		EncryptionKeyManager: encMgr,
 		Label:                label,
 		ExpiresAt:            expiresAt,
 		Reusable:             reusable,
 		Ephemeral:            ephemeral,
+		PermissionGrantID:    writeGrantID,
+		UseContextEncryption: useContextEncryption,
 	})
 	if err != nil {
 		return err
@@ -982,10 +1837,15 @@ func cmdInviteCreate(ctx context.Context, args []string, flagProfile string) err
 // Usage: meshd join <meshd://invite/...>
 func cmdJoin(ctx context.Context, args []string, flagProfile string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("usage: meshd join <meshd://invite/...>")
+		return fmt.Errorf("usage: meshd join <meshd://invite/...> [--owner <did>]")
 	}
 
-	payload, err := invite.Decode(args[0])
+	inviteURL, requestedOwnerDID, noStartHint, err := parseJoinCommandArgs(args)
+	if err != nil {
+		return err
+	}
+
+	payload, err := invite.Decode(inviteURL)
 	if err != nil {
 		return err
 	}
@@ -1003,7 +1863,7 @@ func cmdJoin(ctx context.Context, args []string, flagProfile string) error {
 			if err := ensureDWNTenantRegistered(ctx, payload.Endpoint, identity); err != nil {
 				return err
 			}
-			refreshed, err := refreshPendingJoin(ctx, stateDir, ns, flagProfile)
+			refreshed, err := refreshPendingJoin(ctx, stateDir, ns, flagProfile, noStartHint)
 			if err != nil {
 				return err
 			}
@@ -1017,6 +1877,9 @@ func cmdJoin(ctx context.Context, args []string, flagProfile string) error {
 	if err := ensureDWNTenantRegistered(ctx, payload.Endpoint, identity); err != nil {
 		return err
 	}
+	meta := resolveIdentityMetadata(flagProfile, identity.URI)
+	nodeDID := firstNonEmpty(meta.NodeDID, identity.URI)
+	ownerDID := firstNonEmpty(requestedOwnerDID, meta.OwnerDID, nodeDID)
 
 	preauth := payload.TokenID != "" || payload.Secret != ""
 	if preauth {
@@ -1025,11 +1888,19 @@ func cmdJoin(ctx context.Context, args []string, flagProfile string) error {
 		}
 		label, _ := os.Hostname()
 		signer := &dwn.Signer{DID: identity.URI, PrivateKey: identity.SigningKey}
+		nodeKeyDelivery, err := walletconnect.NewKeyDeliveryPublic(identity)
+		if err != nil {
+			return fmt.Errorf("deriving node key-delivery public key: %w", err)
+		}
 		if err := mesh.WritePreAuthNodeRequest(ctx, mesh.WritePreAuthNodeRequestParams{
-			Invite:  payload,
-			NodeDID: identity.URI,
-			Signer:  signer,
-			Label:   label,
+			Invite:          payload,
+			NodeDID:         nodeDID,
+			MemberDID:       ownerDID,
+			DelegateDID:     meta.DelegateDID,
+			RequestedBy:     identity.URI,
+			Signer:          signer,
+			Label:           label,
+			NodeKeyDelivery: nodeKeyDelivery,
 		}); err != nil {
 			return err
 		}
@@ -1044,7 +1915,39 @@ func cmdJoin(ctx context.Context, args []string, flagProfile string) error {
 	if preauth {
 		joinArgs = append(joinArgs, "--preauth")
 	}
+	if ownerDID != "" && ownerDID != nodeDID {
+		joinArgs = append(joinArgs, "--owner", ownerDID)
+	}
+	if noStartHint {
+		joinArgs = append(joinArgs, "--no-start-hint")
+	}
 	return cmdNetworkJoin(ctx, joinArgs, flagProfile)
+}
+
+func parseJoinCommandArgs(args []string) (inviteURL string, ownerDID string, noStartHint bool, err error) {
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--owner", "--member":
+			if i+1 >= len(args) {
+				return "", "", false, fmt.Errorf("%s requires a DID", args[i])
+			}
+			ownerDID = strings.TrimSpace(args[i+1])
+			i++
+		case "--no-start-hint":
+			noStartHint = true
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return "", "", false, fmt.Errorf("unknown join flag %q", args[i])
+			}
+			if inviteURL == "" {
+				inviteURL = args[i]
+			}
+		}
+	}
+	if inviteURL == "" {
+		return "", "", false, fmt.Errorf("usage: meshd join <meshd://invite/...> [--owner <did>]")
+	}
+	return inviteURL, ownerDID, noStartHint, nil
 }
 
 // cmdPeerList lists all peers in the current mesh network.
@@ -1065,11 +1968,15 @@ func cmdPeerList(ctx context.Context, args []string, flagProfile string) error {
 	if ns == nil {
 		return fmt.Errorf("not in a network. Use 'meshd network join' first.")
 	}
+	selfNodeDID := networkNodeDID(ns, identity.URI)
+	meta := resolveIdentityMetadata(flagProfile, identity.URI)
+	selfOwnerDID := networkOwnerDID(ns, firstNonEmpty(meta.OwnerDID, identity.URI))
 
-	signer := &dwn.Signer{
-		DID:        identity.URI,
-		PrivateKey: identity.SigningKey,
+	operationIdentity, err := loadDWNOperationIdentity(stateDir, meta, identity)
+	if err != nil {
+		return err
 	}
+	signer := dwnSigner(operationIdentity)
 	agent := dwn.NewSimpleAgent(ns.AnchorEndpoint, signer)
 	api := dwn.NewDwnAPI(agent)
 
@@ -1077,6 +1984,18 @@ func cmdPeerList(ctx context.Context, args []string, flagProfile string) error {
 	queryRole := ""
 	if ns.AnchorDID != identity.URI {
 		queryRole = "network/node"
+	}
+	readGrantID, err := walletGrantIDForDWNOperation(stateDir, meta, dwn.InterfaceRecordsQuery, protocols.MeshProtocolURI, "", ns.NetworkRecordID, false)
+	if err != nil {
+		return err
+	}
+	encMgr := newEncryptionKeyManager(identity)
+	if ns.AnchorDID != selfNodeDID {
+		_, _, _ = loadLocalContextKeyForCLI(stateDir, ns, encMgr)
+	}
+	if resp, err := loadControlStateForCLI(ctx, ns, identity, operationIdentity, encMgr, readGrantID); err == nil {
+		printPeerListRows(ns.NetworkName, peerListRowsFromMapResponse(ns, resp, selfNodeDID, selfOwnerDID))
+		return nil
 	}
 
 	// Query owner-provisioned node records (network/node).
@@ -1086,7 +2005,8 @@ func cmdPeerList(ctx context.Context, args []string, flagProfile string) error {
 			ProtocolPath: "network/node",
 			ContextID:    ns.NetworkRecordID,
 		},
-		DateSort: "createdAscending",
+		DateSort:          "createdAscending",
+		PermissionGrantID: readGrantID,
 	}, queryRole)
 	if err != nil {
 		return fmt.Errorf("querying peers: %w", err)
@@ -1104,7 +2024,8 @@ func cmdPeerList(ctx context.Context, args []string, flagProfile string) error {
 			ProtocolPath: "network/member",
 			ContextID:    ns.NetworkRecordID,
 		},
-		DateSort: "createdAscending",
+		DateSort:          "createdAscending",
+		PermissionGrantID: readGrantID,
 	}, queryRole)
 	if mErr == nil && mStatus.Code == 200 {
 		for _, memberRecord := range memberRecords {
@@ -1114,7 +2035,8 @@ func cmdPeerList(ctx context.Context, args []string, flagProfile string) error {
 					ProtocolPath: "network/member/node",
 					ContextID:    ns.NetworkRecordID + "/" + memberRecord.ID,
 				},
-				DateSort: "createdAscending",
+				DateSort:          "createdAscending",
+				PermissionGrantID: readGrantID,
 			}, queryRole)
 			if mnErr == nil && mnStatus.Code == 200 {
 				records = append(records, memberNodeRecords...)
@@ -1127,41 +2049,130 @@ func cmdPeerList(ctx context.Context, args []string, flagProfile string) error {
 		return nil
 	}
 
-	fmt.Printf("Peers in %q:\n", ns.NetworkName)
-	fmt.Printf("%-50s %-16s %-12s %-12s %s\n", "DID", "MESH IP", "DEVICE", "LABEL", "PATH")
-	fmt.Println(strings.Repeat("-", 105))
-
+	var rows []peerListRow
 	for _, r := range records {
 		peerDID := r.Recipient
 		displayDID := peerDID
 		if displayDID == "" {
 			displayDID = "(unknown)"
 		}
-		device := peerListDevice(peerDID, identity.URI)
+		device := peerListDevice(peerDID, selfNodeDID)
 
 		var node struct {
-			MeshIP string `json:"meshIP"`
-			Label  string `json:"label"`
+			MeshIP    string `json:"meshIP"`
+			Label     string `json:"label"`
+			MemberDID string `json:"memberDID"`
 		}
 		if err := r.Data().JSON(ctx, &node); err != nil {
 			// Data may not be inline (encrypted records need context key).
-			fmt.Printf("%-50s %-16s %-12s %-12s %s\n",
-				truncate(displayDID, 50),
-				peerListMeshIP(ns.MeshCIDR, peerDID, ""),
-				device,
-				"(encrypted)",
-				r.ProtocolPath)
+			rows = append(rows, peerListRow{
+				NodeDID: displayDID,
+				MeshIP:  peerListMeshIP(ns.MeshCIDR, peerDID, ""),
+				Device:  device,
+				Owner:   peerListOwner(peerDID, "", selfNodeDID, selfOwnerDID),
+				Label:   "(encrypted)",
+				Path:    r.ProtocolPath,
+			})
 			continue
 		}
-		fmt.Printf("%-50s %-16s %-12s %-12s %s\n",
-			truncate(displayDID, 50),
-			peerListMeshIP(ns.MeshCIDR, peerDID, node.MeshIP),
-			device,
-			node.Label,
-			r.ProtocolPath)
+		rows = append(rows, peerListRow{
+			NodeDID: displayDID,
+			MeshIP:  peerListMeshIP(ns.MeshCIDR, peerDID, node.MeshIP),
+			Device:  device,
+			Owner:   peerListOwner(peerDID, node.MemberDID, selfNodeDID, selfOwnerDID),
+			Label:   node.Label,
+			Path:    r.ProtocolPath,
+		})
 	}
+	printPeerListRows(ns.NetworkName, rows)
 
 	return nil
+}
+
+func loadControlStateForCLI(ctx context.Context, ns *state.NetworkState, identity *did.DID, signerIdentity *did.DID, encMgr *dwncrypto.EncryptionKeyManager, readGrantID string) (*control.MapResponse, error) {
+	if ns == nil || identity == nil {
+		return nil, fmt.Errorf("network state and identity are required")
+	}
+	if signerIdentity == nil {
+		signerIdentity = identity
+	}
+	selfNodeDID := networkNodeDID(ns, identity.URI)
+	protocolRole := ""
+	if ns.AnchorDID != selfNodeDID {
+		protocolRole = "network/node"
+	}
+	signer := dwnSigner(signerIdentity)
+	client := control.NewDWNClient(
+		ns.AnchorEndpoint,
+		ns.AnchorDID,
+		ns.NetworkRecordID,
+		selfNodeDID,
+		signer,
+		control.WithEncryptionKeyManager(encMgr),
+		control.WithProtocolRole(protocolRole),
+		control.WithPermissionGrantID(readGrantID),
+	)
+	return client.LoadState(ctx)
+}
+
+type peerListRow struct {
+	NodeDID string
+	MeshIP  string
+	Device  string
+	Owner   string
+	Label   string
+	Path    string
+}
+
+func peerListRowsFromMapResponse(ns *state.NetworkState, resp *control.MapResponse, selfNodeDID string, selfOwnerDID string) []peerListRow {
+	if resp == nil {
+		return nil
+	}
+	nodes := make([]*control.Node, 0, 1+len(resp.Peers))
+	if resp.Node != nil {
+		nodes = append(nodes, resp.Node)
+	}
+	nodes = append(nodes, resp.Peers...)
+
+	rows := make([]peerListRow, 0, len(nodes))
+	for _, node := range nodes {
+		if node == nil || node.DID == "" {
+			continue
+		}
+		meshIP := ""
+		if node.MeshIP.IsValid() {
+			meshIP = node.MeshIP.String()
+		}
+		rows = append(rows, peerListRow{
+			NodeDID: node.DID,
+			MeshIP:  peerListMeshIP(ns.MeshCIDR, node.DID, meshIP),
+			Device:  peerListDevice(node.DID, selfNodeDID),
+			Owner:   peerListOwner(node.DID, node.MemberDID, selfNodeDID, selfOwnerDID),
+			Label:   node.Name,
+			Path:    peerListPath(node),
+		})
+	}
+	return rows
+}
+
+func printPeerListRows(networkName string, rows []peerListRow) {
+	if len(rows) == 0 {
+		fmt.Println("No peers found.")
+		return
+	}
+	fmt.Printf("Peers in %q:\n", networkName)
+	fmt.Printf("%-48s %-16s %-12s %-36s %-12s %s\n", "NODE DID", "MESH IP", "DEVICE", "OWNER", "LABEL", "PATH")
+	fmt.Println(strings.Repeat("-", 132))
+	for _, row := range rows {
+		fmt.Printf("%-48s %-16s %-12s %-36s %-12s %s\n",
+			truncate(firstNonEmpty(row.NodeDID, "(unknown)"), 48),
+			row.MeshIP,
+			row.Device,
+			truncate(row.Owner, 36),
+			row.Label,
+			row.Path,
+		)
+	}
 }
 
 func peerListDevice(peerDID string, selfDID string) string {
@@ -1169,6 +2180,24 @@ func peerListDevice(peerDID string, selfDID string) string {
 		return "this device"
 	}
 	return "peer"
+}
+
+func peerListOwner(peerDID string, recordOwnerDID string, selfNodeDID string, selfOwnerDID string) string {
+	ownerDID := recordOwnerDID
+	if ownerDID == "" && peerDID != "" && peerDID == selfNodeDID {
+		ownerDID = selfOwnerDID
+	}
+	if ownerDID == "" || ownerDID == peerDID {
+		return "node"
+	}
+	return ownerDID
+}
+
+func peerListPath(node *control.Node) string {
+	if node != nil && node.MemberRecordID != "" {
+		return "network/member/node"
+	}
+	return "network/node"
 }
 
 func peerListMeshIP(meshCIDR string, peerDID string, recordMeshIP string) string {
@@ -1192,20 +2221,13 @@ func peerListMeshIP(meshCIDR string, peerDID string, recordMeshIP string) string
 // This must be run by the network anchor (owner). It combines the node
 // record creation and key delivery into a single command.
 //
-// Usage: meshd peer add <did> [--label <label>]
+// Usage: meshd peer add <node-did> [--owner <owner-did>] [--label <label>]
 func cmdPeerAdd(ctx context.Context, args []string, flagProfile string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("usage: meshd peer add <did> [--label <label>]")
+	opts, err := parsePeerAddOptions(args)
+	if err != nil {
+		return err
 	}
-
-	peerDID := args[0]
-	label := "peer"
-	for i := 1; i < len(args); i++ {
-		if args[i] == "--label" && i+1 < len(args) {
-			label = args[i+1]
-			i++
-		}
-	}
+	peerDID := opts.nodeDID
 
 	stateDir, err := resolveStateDir(flagProfile)
 	if err != nil {
@@ -1224,16 +2246,28 @@ func cmdPeerAdd(ctx context.Context, args []string, flagProfile string) error {
 		return fmt.Errorf("not in a network. Use 'meshd network create' first.")
 	}
 
-	// Only the anchor (network owner) can add peers.
-	if ns.AnchorDID != identity.URI {
-		return fmt.Errorf("only the network anchor (%s) can add peers", ns.AnchorDID)
+	meta, useContextEncryption, err := requireNetworkOwnerProfile(flagProfile, identity, ns)
+	if err != nil {
+		return err
+	}
+	encMgr, err := prepareNetworkCommandEncryption(stateDir, identity, ns, useContextEncryption)
+	if err != nil {
+		return err
+	}
+	writeGrantID, err := walletGrantIDForDWNOperation(stateDir, meta, dwn.InterfaceRecordsWrite, protocols.MeshProtocolURI, "", ns.NetworkRecordID, useContextEncryption)
+	if err != nil {
+		return err
+	}
+	keyDeliveryGrantID, err := walletGrantIDForDWNOperation(stateDir, meta, dwn.InterfaceRecordsWrite, protocols.KeyDeliveryProtocolURI, "", "", useContextEncryption)
+	if err != nil {
+		return err
 	}
 
-	signer := &dwn.Signer{
-		DID:        identity.URI,
-		PrivateKey: identity.SigningKey,
+	operationIdentity, err := loadDWNOperationIdentity(stateDir, meta, identity)
+	if err != nil {
+		return err
 	}
-	encMgr := newEncryptionKeyManager(identity)
+	signer := dwnSigner(operationIdentity)
 
 	// 1. Create a node record for the peer (assigns the network/node role).
 	// The peer's mesh IP is derived deterministically from their DID.
@@ -1252,13 +2286,18 @@ func cmdPeerAdd(ctx context.Context, args []string, flagProfile string) error {
 		Signer:               signer,
 		EncryptionKeyManager: encMgr,
 		MeshIP:               peerMeshIP.String(),
-		Label:                label,
+		Label:                opts.label,
+		OwnerDID:             opts.ownerDID,
 		UseContextEncryption: true,
+		PermissionGrantID:    writeGrantID,
 	})
 	if err != nil {
 		return fmt.Errorf("creating node record: %w", err)
 	}
 	fmt.Printf("  Node record created (IP=%s).\n", peerMeshIP)
+	if opts.ownerDID != "" && opts.ownerDID != peerDID {
+		fmt.Printf("  Owner: %s\n", opts.ownerDID)
+	}
 
 	// 2. Deliver the context encryption key so the peer can decrypt records.
 	kdm := &mesh.KeyDeliveryManager{
@@ -1267,10 +2306,11 @@ func cmdPeerAdd(ctx context.Context, args []string, flagProfile string) error {
 		EncryptionKeyManager: encMgr,
 	}
 	err = kdm.DeliverContextKey(ctx, mesh.DeliverContextKeyParams{
-		AnchorDID:      identity.URI,
-		RecipientDID:   peerDID,
-		SourceProtocol: protocols.MeshProtocolURI,
-		ContextID:      ns.NetworkRecordID,
+		AnchorDID:         ns.AnchorDID,
+		RecipientDID:      peerDID,
+		SourceProtocol:    protocols.MeshProtocolURI,
+		ContextID:         ns.NetworkRecordID,
+		PermissionGrantID: keyDeliveryGrantID,
 	})
 	if err != nil {
 		// Non-fatal: the node was created, key delivery can be retried
@@ -1291,6 +2331,324 @@ func cmdPeerAdd(ctx context.Context, args []string, flagProfile string) error {
 	fmt.Printf("  meshd join %s\n", joinURL)
 
 	return nil
+}
+
+type peerAddOptions struct {
+	nodeDID  string
+	ownerDID string
+	label    string
+}
+
+func parsePeerAddOptions(args []string) (peerAddOptions, error) {
+	opts := peerAddOptions{label: "peer"}
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--label":
+			if i+1 >= len(args) {
+				return opts, fmt.Errorf("--label requires a value")
+			}
+			opts.label = args[i+1]
+			i++
+		case "--member", "--owner":
+			if i+1 >= len(args) {
+				return opts, fmt.Errorf("%s requires a DID", args[i])
+			}
+			opts.ownerDID = args[i+1]
+			i++
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return opts, fmt.Errorf("unknown peer add flag %q", args[i])
+			}
+			if opts.nodeDID != "" {
+				return opts, fmt.Errorf("unexpected argument %q", args[i])
+			}
+			opts.nodeDID = args[i]
+		}
+	}
+	if opts.nodeDID == "" {
+		return opts, fmt.Errorf("usage: meshd peer add <node-did> [--owner <owner-did>] [--label <label>]")
+	}
+	return opts, nil
+}
+
+// cmdPeerRemove removes a peer node record from the mesh network.
+//
+// This removes the device from peer discovery by deleting its network/node or
+// network/member/node record and pruning child records such as nodeInfo and
+// endpoints. It does not delete the owning member record.
+//
+// Usage: meshd peer remove <node-did>
+func cmdPeerRemove(ctx context.Context, args []string, flagProfile string) error {
+	opts, err := parsePeerRemoveOptions(args)
+	if err != nil {
+		return err
+	}
+	peerDID := opts.nodeDID
+
+	stateDir, err := resolveStateDir(flagProfile)
+	if err != nil {
+		return err
+	}
+	identity, err := loadIdentity(stateDir)
+	if err != nil {
+		return err
+	}
+
+	ns, err := state.LoadNetworkState(stateDir)
+	if err != nil {
+		return fmt.Errorf("loading network state: %w", err)
+	}
+	if ns == nil {
+		return fmt.Errorf("not in a network. Use 'meshd network create' first.")
+	}
+
+	selfNodeDID := networkNodeDID(ns, identity.URI)
+	if peerDID == selfNodeDID {
+		return fmt.Errorf("refusing to remove this device from the mesh; use 'meshd network leave' on this device")
+	}
+
+	meta, useContextEncryption, err := requireNetworkOwnerProfile(flagProfile, identity, ns)
+	if err != nil {
+		return err
+	}
+	readGrantID, err := walletGrantIDForDWNOperation(stateDir, meta, dwn.InterfaceRecordsQuery, protocols.MeshProtocolURI, "", ns.NetworkRecordID, useContextEncryption)
+	if err != nil {
+		return err
+	}
+	deleteGrantID, err := walletGrantIDForDWNOperation(stateDir, meta, dwn.InterfaceRecordsDelete, protocols.MeshProtocolURI, "", ns.NetworkRecordID, useContextEncryption)
+	if err != nil {
+		return err
+	}
+	keyDeliveryReadGrantID, err := walletGrantIDForDWNOperation(stateDir, meta, dwn.InterfaceRecordsQuery, protocols.KeyDeliveryProtocolURI, "", "", false)
+	if err != nil {
+		return err
+	}
+	keyDeliveryDeleteGrantID, err := walletGrantIDForDWNOperation(stateDir, meta, dwn.InterfaceRecordsDelete, protocols.KeyDeliveryProtocolURI, "", "", false)
+	if err != nil {
+		return err
+	}
+
+	operationIdentity, err := loadDWNOperationIdentity(stateDir, meta, identity)
+	if err != nil {
+		return err
+	}
+	signer := dwnSigner(operationIdentity)
+	api := dwn.NewDwnAPI(dwn.NewSimpleAgent(ns.AnchorEndpoint, signer))
+	protocolRole := ""
+	if ns.AnchorDID != selfNodeDID {
+		protocolRole = "network/node"
+	}
+
+	candidates, err := queryPeerRemoveCandidates(ctx, api, ns, peerDID, readGrantID, protocolRole)
+	if err != nil {
+		return err
+	}
+	if len(candidates) == 0 {
+		return fmt.Errorf("peer node %s was not found in %q", peerDID, ns.NetworkName)
+	}
+
+	fmt.Printf("Removing peer %s from %q...\n", peerDID, ns.NetworkName)
+	for _, candidate := range candidates {
+		status, err := api.Delete(ctx, ns.AnchorDID, candidate.RecordID, true, protocolRole, deleteGrantID)
+		if err != nil {
+			return fmt.Errorf("deleting %s record %s: %w", candidate.Path, candidate.RecordID, err)
+		}
+		if status.Code >= 300 {
+			return fmt.Errorf("delete %s record %s failed: %d %s", candidate.Path, candidate.RecordID, status.Code, status.Detail)
+		}
+		fmt.Printf("  Removed %s record %s\n", candidate.Path, candidate.RecordID)
+	}
+	removedContextKeys, err := removeDeliveredContextKeysForPeer(ctx, api, ns, peerDID, keyDeliveryReadGrantID, keyDeliveryDeleteGrantID)
+	if err != nil {
+		fmt.Printf("  Warning: delivered context key cleanup failed: %v\n", err)
+	} else if removedContextKeys > 0 {
+		fmt.Printf("  Removed delivered context keys: %d\n", removedContextKeys)
+	}
+	fmt.Printf("Peer removed. For cryptographic revocation, rotate network context keys before re-adding this node.\n")
+	return nil
+}
+
+type peerRemoveOptions struct {
+	nodeDID string
+}
+
+func parsePeerRemoveOptions(args []string) (peerRemoveOptions, error) {
+	var opts peerRemoveOptions
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			return opts, fmt.Errorf("unknown peer remove flag %q", arg)
+		}
+		if opts.nodeDID != "" {
+			return opts, fmt.Errorf("unexpected argument %q", arg)
+		}
+		opts.nodeDID = arg
+	}
+	if opts.nodeDID == "" {
+		return opts, fmt.Errorf("usage: meshd peer remove <node-did>")
+	}
+	return opts, nil
+}
+
+type peerRemoveCandidate struct {
+	RecordID       string
+	Path           string
+	MemberRecordID string
+}
+
+func queryPeerRemoveCandidates(ctx context.Context, api *dwn.DwnAPI, ns *state.NetworkState, peerDID, readGrantID, protocolRole string) ([]peerRemoveCandidate, error) {
+	if api == nil || ns == nil || peerDID == "" {
+		return nil, nil
+	}
+	var candidates []peerRemoveCandidate
+
+	records, status, err := api.Query(ctx, ns.AnchorDID, dwn.QueryParams{
+		Filter: dwn.RecordsFilter{
+			Protocol:     protocols.MeshProtocolURI,
+			ProtocolPath: "network/node",
+			ContextID:    ns.NetworkRecordID,
+			Recipient:    peerDID,
+		},
+		DateSort:          "createdAscending",
+		PermissionGrantID: readGrantID,
+	}, protocolRole)
+	if err != nil {
+		return nil, fmt.Errorf("querying owner node records: %w", err)
+	}
+	if status.Code != 200 {
+		return nil, fmt.Errorf("owner node query failed: %d %s", status.Code, status.Detail)
+	}
+	candidates = appendPeerRemoveCandidates(candidates, records, "")
+
+	memberRecords, status, err := api.Query(ctx, ns.AnchorDID, dwn.QueryParams{
+		Filter: dwn.RecordsFilter{
+			Protocol:     protocols.MeshProtocolURI,
+			ProtocolPath: "network/member",
+			ContextID:    ns.NetworkRecordID,
+		},
+		DateSort:          "createdAscending",
+		PermissionGrantID: readGrantID,
+	}, protocolRole)
+	if err != nil {
+		return nil, fmt.Errorf("querying member records: %w", err)
+	}
+	if status.Code != 200 {
+		return nil, fmt.Errorf("member query failed: %d %s", status.Code, status.Detail)
+	}
+	for _, memberRecord := range memberRecords {
+		if memberRecord == nil || memberRecord.ID == "" {
+			continue
+		}
+		memberNodeRecords, mnStatus, mnErr := api.Query(ctx, ns.AnchorDID, dwn.QueryParams{
+			Filter: dwn.RecordsFilter{
+				Protocol:     protocols.MeshProtocolURI,
+				ProtocolPath: "network/member/node",
+				ContextID:    ns.NetworkRecordID + "/" + memberRecord.ID,
+				Recipient:    peerDID,
+			},
+			DateSort:          "createdAscending",
+			PermissionGrantID: readGrantID,
+		}, protocolRole)
+		if mnErr != nil {
+			return nil, fmt.Errorf("querying member node records for %s: %w", memberRecord.ID, mnErr)
+		}
+		if mnStatus.Code != 200 {
+			return nil, fmt.Errorf("member node query for %s failed: %d %s", memberRecord.ID, mnStatus.Code, mnStatus.Detail)
+		}
+		candidates = appendPeerRemoveCandidates(candidates, memberNodeRecords, memberRecord.ID)
+	}
+	return candidates, nil
+}
+
+func appendPeerRemoveCandidates(candidates []peerRemoveCandidate, records []*dwn.Record, memberRecordID string) []peerRemoveCandidate {
+	for _, record := range records {
+		candidate, ok := peerRemoveCandidateFromRecord(record, memberRecordID)
+		if ok {
+			candidates = append(candidates, candidate)
+		}
+	}
+	return candidates
+}
+
+func peerRemoveCandidateFromRecord(record *dwn.Record, memberRecordID string) (peerRemoveCandidate, bool) {
+	if record == nil || record.ID == "" {
+		return peerRemoveCandidate{}, false
+	}
+	path := record.ProtocolPath
+	if path == "" {
+		if memberRecordID != "" {
+			path = "network/member/node"
+		} else {
+			path = "network/node"
+		}
+	}
+	return peerRemoveCandidate{
+		RecordID:       record.ID,
+		Path:           path,
+		MemberRecordID: memberRecordID,
+	}, true
+}
+
+func removeDeliveredContextKeysForPeer(ctx context.Context, api *dwn.DwnAPI, ns *state.NetworkState, peerDID, readGrantID, deleteGrantID string) (int, error) {
+	if api == nil || ns == nil || peerDID == "" {
+		return 0, nil
+	}
+	records, status, err := api.Query(ctx, ns.AnchorDID, dwn.QueryParams{
+		Filter: dwn.RecordsFilter{
+			Protocol:     protocols.KeyDeliveryProtocolURI,
+			ProtocolPath: "contextKey",
+			Recipient:    peerDID,
+		},
+		DateSort:          "createdAscending",
+		PermissionGrantID: readGrantID,
+	}, "")
+	if err != nil {
+		return 0, fmt.Errorf("querying delivered context keys: %w", err)
+	}
+	if status.Code != 200 {
+		return 0, fmt.Errorf("context key query failed: %d %s", status.Code, status.Detail)
+	}
+
+	removed := 0
+	for _, record := range records {
+		if !deliveredContextKeyMatchesNetwork(record, ns.NetworkRecordID) {
+			continue
+		}
+		status, err := api.Delete(ctx, ns.AnchorDID, record.ID, false, "", deleteGrantID)
+		if err != nil {
+			return removed, fmt.Errorf("deleting contextKey record %s: %w", record.ID, err)
+		}
+		if status.Code >= 300 {
+			return removed, fmt.Errorf("delete contextKey record %s failed: %d %s", record.ID, status.Code, status.Detail)
+		}
+		removed++
+	}
+	return removed, nil
+}
+
+func deliveredContextKeyMatchesNetwork(record *dwn.Record, networkRecordID string) bool {
+	if record == nil || record.ID == "" || networkRecordID == "" {
+		return false
+	}
+	return tagString(record.Tags, "protocol") == protocols.MeshProtocolURI &&
+		tagString(record.Tags, "contextId") == networkRecordID
+}
+
+func tagString(tags map[string]any, key string) string {
+	if tags == nil {
+		return ""
+	}
+	value, ok := tags[key]
+	if !ok {
+		return ""
+	}
+	switch v := value.(type) {
+	case string:
+		return v
+	case fmt.Stringer:
+		return v.String()
+	default:
+		return fmt.Sprint(v)
+	}
 }
 
 // cmdPeerApprove delivers encryption keys to a peer so they can decrypt
@@ -1321,16 +2679,32 @@ func cmdPeerApprove(ctx context.Context, args []string, flagProfile string) erro
 		return fmt.Errorf("not in a network. Use 'meshd network create' first.")
 	}
 
-	// Only the anchor (network owner) can deliver context keys.
-	if ns.AnchorDID != identity.URI {
-		return fmt.Errorf("only the network anchor (%s) can approve peers", ns.AnchorDID)
+	meta, useContextEncryption, err := requireNetworkOwnerProfile(flagProfile, identity, ns)
+	if err != nil {
+		return err
+	}
+	readGrantID, err := walletGrantIDForDWNOperation(stateDir, meta, dwn.InterfaceRecordsQuery, protocols.MeshProtocolURI, "", ns.NetworkRecordID, useContextEncryption)
+	if err != nil {
+		return err
+	}
+	keyDeliveryGrantID, err := walletGrantIDForDWNOperation(stateDir, meta, dwn.InterfaceRecordsWrite, protocols.KeyDeliveryProtocolURI, "", "", useContextEncryption)
+	if err != nil {
+		return err
 	}
 
-	signer := &dwn.Signer{
-		DID:        identity.URI,
-		PrivateKey: identity.SigningKey,
+	operationIdentity, err := loadDWNOperationIdentity(stateDir, meta, identity)
+	if err != nil {
+		return err
 	}
-	encMgr := newEncryptionKeyManager(identity)
+	signer := dwnSigner(operationIdentity)
+	encMgr, err := prepareNetworkCommandEncryption(stateDir, identity, ns, useContextEncryption)
+	if err != nil {
+		return err
+	}
+	recipientKeyDelivery, lookupErr := lookupPeerKeyDelivery(ctx, stateDir, ns, identity, operationIdentity, encMgr, readGrantID, peerDID)
+	if lookupErr != nil {
+		fmt.Printf("  Warning: node key-delivery lookup failed: %v\n", lookupErr)
+	}
 
 	kdm := &mesh.KeyDeliveryManager{
 		Endpoint:             ns.AnchorEndpoint,
@@ -1339,17 +2713,56 @@ func cmdPeerApprove(ctx context.Context, args []string, flagProfile string) erro
 	}
 
 	err = kdm.DeliverContextKey(ctx, mesh.DeliverContextKeyParams{
-		AnchorDID:      identity.URI,
-		RecipientDID:   peerDID,
-		SourceProtocol: protocols.MeshProtocolURI,
-		ContextID:      ns.NetworkRecordID,
+		AnchorDID:            ns.AnchorDID,
+		RecipientDID:         peerDID,
+		SourceProtocol:       protocols.MeshProtocolURI,
+		ContextID:            ns.NetworkRecordID,
+		PermissionGrantID:    keyDeliveryGrantID,
+		RecipientKeyDelivery: recipientKeyDelivery,
 	})
 	if err != nil {
 		return fmt.Errorf("delivering context key: %w", err)
 	}
 
 	fmt.Printf("Context key delivered to %s.\n", peerDID)
+	if recipientKeyDelivery != nil {
+		fmt.Printf("  Encrypted to node key-delivery key: %s\n", recipientKeyDelivery.RootKeyID)
+	}
 	fmt.Printf("The peer can now decrypt mesh records in this network.\n")
+	return nil
+}
+
+func lookupPeerKeyDelivery(ctx context.Context, stateDir string, ns *state.NetworkState, identity *did.DID, signerIdentity *did.DID, encMgr *dwncrypto.EncryptionKeyManager, readGrantID string, peerDID string) (*dwncrypto.KeyDeliveryPublic, error) {
+	if ns == nil || identity == nil || peerDID == "" {
+		return nil, nil
+	}
+	if encMgr == nil {
+		encMgr = newEncryptionKeyManager(identity)
+	}
+	if ns.AnchorDID != networkNodeDID(ns, identity.URI) && !encMgr.HasContextKey(ns.NetworkRecordID) {
+		if _, _, err := loadLocalContextKeyForCLI(stateDir, ns, encMgr); err != nil {
+			return nil, err
+		}
+	}
+	resp, err := loadControlStateForCLI(ctx, ns, identity, signerIdentity, encMgr, readGrantID)
+	if err != nil {
+		return nil, err
+	}
+	return keyDeliveryForNode(resp, peerDID), nil
+}
+
+func keyDeliveryForNode(resp *control.MapResponse, nodeDID string) *dwncrypto.KeyDeliveryPublic {
+	if resp == nil || nodeDID == "" {
+		return nil
+	}
+	if resp.Node != nil && resp.Node.DID == nodeDID {
+		return resp.Node.KeyDelivery
+	}
+	for _, peer := range resp.Peers {
+		if peer != nil && peer.DID == nodeDID {
+			return peer.KeyDelivery
+		}
+	}
 	return nil
 }
 
@@ -1374,12 +2787,28 @@ func cmdStatus(ctx context.Context, args []string, flagProfile string) error {
 	}
 
 	fmt.Printf("Identity:\n")
-	fmt.Printf("  DID: %s\n", identity.URI)
+	meta := resolveIdentityMetadata(flagProfile, identity.URI)
+	fmt.Printf("  Local Node DID: %s\n", identity.URI)
+	fmt.Printf("  Auth: %s\n", authDisplayName(meta.AuthType))
+	if meta.OwnerDID != "" && meta.OwnerDID != identity.URI {
+		fmt.Printf("  Wallet Owner DID: %s\n", meta.OwnerDID)
+	}
+	if meta.DelegateDID != "" {
+		fmt.Printf("  Session Delegate DID: %s\n", meta.DelegateDID)
+	}
+	if meta.NodeDID != "" && meta.NodeDID != identity.URI {
+		fmt.Printf("  Configured Node DID: %s\n", meta.NodeDID)
+	}
 	fmt.Printf("  State: %s\n", stateDir)
 	if did.EncryptedExists(stateDir) {
 		fmt.Printf("  Vault: encrypted\n")
 	} else {
 		fmt.Printf("  Vault: plaintext legacy\n")
+	}
+	if meta.AuthType == profile.AuthTypeWalletAuthorizedNode {
+		if err := printWalletSessionStatus(stateDir, meta); err != nil {
+			return err
+		}
 	}
 
 	// Network.
@@ -1398,18 +2827,29 @@ func cmdStatus(ctx context.Context, args []string, flagProfile string) error {
 	fmt.Printf("  Anchor DID: %s\n", ns.AnchorDID)
 	fmt.Printf("  Anchor Endpoint: %s\n", ns.AnchorEndpoint)
 	fmt.Printf("  Network Record: %s\n", ns.NetworkRecordID)
+	selfNodeDID := networkNodeDID(ns, identity.URI)
+	selfOwnerDID := networkOwnerDID(ns, firstNonEmpty(meta.OwnerDID, identity.URI))
+	if selfNodeDID != "" {
+		fmt.Printf("  Node DID: %s\n", selfNodeDID)
+	}
+	if selfOwnerDID != "" && selfOwnerDID != selfNodeDID {
+		fmt.Printf("  Wallet Owner DID: %s\n", selfOwnerDID)
+	}
 	if ns.MeshIP != "" {
 		fmt.Printf("  Mesh IP: %s\n", ns.MeshIP)
 	}
-	// WireGuard public key is derived from the identity, not stored.
-	if identity != nil {
-		wgPubKey, wgErr := mesh.WireGuardPubKeyFromDID(identity.URI)
+	// WireGuard public key is derived from the node DID, not stored.
+	if selfNodeDID != "" {
+		wgPubKey, wgErr := mesh.WireGuardPubKeyFromDID(selfNodeDID)
 		if wgErr == nil {
 			fmt.Printf("  WireGuard Key: %s\n", wgPubKey)
 		}
 	}
 	if ns.NodeRecordID != "" {
 		fmt.Printf("  Node Record: %s\n", ns.NodeRecordID)
+	}
+	if ns.MemberRecordID != "" {
+		fmt.Printf("  Member Record: %s\n", ns.MemberRecordID)
 	}
 
 	// Query live daemon status if running.
@@ -1433,6 +2873,519 @@ func cmdStatus(ctx context.Context, args []string, flagProfile string) error {
 	return nil
 }
 
+type doctorLevel string
+
+const (
+	doctorOK   doctorLevel = "ok"
+	doctorWarn doctorLevel = "warn"
+	doctorFail doctorLevel = "fail"
+	doctorInfo doctorLevel = "info"
+)
+
+type doctorCheck struct {
+	Level  doctorLevel
+	Title  string
+	Detail string
+	Next   string
+}
+
+// cmdDoctor diagnoses local state and common runtime issues without mutating
+// network or DWN state.
+func cmdDoctor(ctx context.Context, args []string, flagProfile string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("usage: meshd doctor")
+	}
+
+	fmt.Println("meshd doctor")
+	checks := collectDoctorChecks(ctx, flagProfile)
+	for _, check := range checks {
+		printDoctorCheck(os.Stdout, check)
+	}
+	if doctorHasLevel(checks, doctorFail) {
+		fmt.Println("\nResult: issues found. Follow the suggested next steps above.")
+	} else if doctorHasLevel(checks, doctorWarn) {
+		fmt.Println("\nResult: usable, with warnings.")
+	} else {
+		fmt.Println("\nResult: ready.")
+	}
+	return nil
+}
+
+func collectDoctorChecks(ctx context.Context, flagProfile string) []doctorCheck {
+	var checks []doctorCheck
+
+	stateDir, err := resolveStateDir(flagProfile)
+	if err != nil {
+		checks = append(checks, doctorCheck{
+			Level:  doctorFail,
+			Title:  "No active identity profile",
+			Detail: err.Error(),
+			Next:   "Run 'meshd auth connect' or select a profile with '--profile <name>'.",
+		})
+		return checks
+	}
+	checks = append(checks, doctorCheck{
+		Level:  doctorInfo,
+		Title:  "State directory",
+		Detail: stateDir,
+	})
+
+	if !identityExists(stateDir) {
+		checks = append(checks, doctorCheck{
+			Level:  doctorFail,
+			Title:  "Identity missing",
+			Detail: "This profile has no local node identity.",
+			Next:   "Run 'meshd auth connect' for wallet approval, or 'meshd auth login' for a local-vault profile.",
+		})
+		return checks
+	}
+
+	identity, err := loadIdentity(stateDir)
+	if err != nil {
+		checks = append(checks, doctorCheck{
+			Level:  doctorFail,
+			Title:  "Identity vault could not be opened",
+			Detail: err.Error(),
+			Next:   "Run 'meshd vault unlock' and check the vault password.",
+		})
+		return checks
+	}
+	meta := resolveIdentityMetadata(flagProfile, identity.URI)
+	checks = append(checks, doctorCheck{
+		Level:  doctorOK,
+		Title:  "Identity loaded",
+		Detail: fmt.Sprintf("node DID %s (%s)", firstNonEmpty(meta.NodeDID, identity.URI), authDisplayName(meta.AuthType)),
+	})
+	if did.EncryptedExists(stateDir) {
+		checks = append(checks, doctorCheck{Level: doctorOK, Title: "Vault encrypted"})
+	} else {
+		checks = append(checks, doctorCheck{
+			Level:  doctorWarn,
+			Title:  "Legacy plaintext identity",
+			Detail: "This profile is using the old plaintext identity file.",
+			Next:   "Run 'meshd vault init' to encrypt it.",
+		})
+	}
+
+	if meta.AuthType == profile.AuthTypeWalletAuthorizedNode {
+		checks = append(checks, walletDoctorChecks(stateDir, meta)...)
+	}
+
+	ns, err := state.LoadNetworkState(stateDir)
+	if err != nil {
+		checks = append(checks, doctorCheck{
+			Level:  doctorFail,
+			Title:  "Network state could not be read",
+			Detail: err.Error(),
+			Next:   "Inspect network.json or run 'meshd network leave' before joining again.",
+		})
+		return checks
+	}
+	if ns == nil {
+		checks = append(checks, doctorCheck{
+			Level:  doctorWarn,
+			Title:  "No network joined",
+			Detail: "This profile has an identity but no mesh membership.",
+			Next:   "Run 'meshd up' to use the setup wizard, create a network, or join an invite.",
+		})
+		return checks
+	}
+
+	selfNodeDID := networkNodeDID(ns, identity.URI)
+	checks = append(checks, doctorCheck{
+		Level:  doctorOK,
+		Title:  "Network joined",
+		Detail: fmt.Sprintf("%s (%s)", ns.NetworkName, ns.MeshCIDR),
+	})
+	if ns.AnchorEndpoint == "" || ns.AnchorDID == "" || ns.NetworkRecordID == "" {
+		checks = append(checks, doctorCheck{
+			Level:  doctorFail,
+			Title:  "Network anchor metadata incomplete",
+			Detail: fmt.Sprintf("anchor=%q endpoint=%q record=%q", ns.AnchorDID, ns.AnchorEndpoint, ns.NetworkRecordID),
+			Next:   "Rejoin the network from a fresh invite or wallet approval.",
+		})
+	}
+	if ns.MeshIP == "" {
+		checks = append(checks, doctorCheck{
+			Level: "fail",
+			Title: "Mesh IP missing",
+			Next:  "Run 'meshd up' again after the anchor approves this node.",
+		})
+	} else {
+		checks = append(checks, doctorCheck{Level: doctorOK, Title: "Mesh IP assigned", Detail: ns.MeshIP})
+	}
+	if ns.NodeRecordID == "" {
+		checks = append(checks, doctorCheck{
+			Level:  doctorWarn,
+			Title:  "Node record missing",
+			Detail: "This usually means the join request is still waiting for anchor/wallet approval.",
+			Next:   "Open the wallet admin panel or keep the anchor online, then run 'meshd up' again.",
+		})
+	}
+	if meta.DelegateDID != "" && ns.DelegateDID != "" && meta.DelegateDID != ns.DelegateDID {
+		checks = append(checks, doctorCheck{
+			Level:  doctorFail,
+			Title:  "Delegate mismatch",
+			Detail: fmt.Sprintf("profile delegate %s, network delegate %s", meta.DelegateDID, ns.DelegateDID),
+			Next:   "Reconnect this profile with 'meshd auth connect'.",
+		})
+	}
+
+	live, daemonChecks := daemonDoctorChecks(ctx, ns)
+	checks = append(checks, daemonChecks...)
+	if live == nil {
+		return checks
+	}
+
+	if live.TUNDevice == "" {
+		checks = append(checks, doctorCheck{
+			Level:  doctorWarn,
+			Title:  "No TUN device",
+			Detail: "The daemon is running in userspace/no-route mode. OS ping will not work in this mode.",
+			Next:   "Run 'meshd down' and then 'meshd up' without '--no-tun'.",
+		})
+		return checks
+	}
+
+	checks = append(checks, interfaceDoctorChecks(ctx, live.TUNDevice, firstNonEmpty(live.MeshIP, ns.MeshIP))...)
+	routeChecks := peerRouteDoctorChecks(ctx, stateDir, ns, identity, meta, selfNodeDID, live.TUNDevice)
+	checks = append(checks, routeChecks...)
+	return checks
+}
+
+func walletDoctorChecks(stateDir string, meta identityMetadata) []doctorCheck {
+	if !state.WalletSessionExists(stateDir) {
+		return []doctorCheck{{
+			Level:  doctorFail,
+			Title:  "Wallet session missing",
+			Detail: "This profile is marked wallet-authorized but has no imported wallet grants.",
+			Next:   "Run 'meshd auth connect'.",
+		}}
+	}
+	status, err := loadWalletSessionStatus(stateDir, meta)
+	if err != nil {
+		return []doctorCheck{{
+			Level:  doctorFail,
+			Title:  "Wallet session could not be opened",
+			Detail: err.Error(),
+			Next:   "Run 'meshd vault unlock' and reconnect with 'meshd auth connect' if needed.",
+		}}
+	}
+	if status == nil || !status.Exists {
+		return []doctorCheck{{
+			Level: doctorFail,
+			Title: "Wallet session missing",
+			Next:  "Run 'meshd auth connect'.",
+		}}
+	}
+	checks := []doctorCheck{{
+		Level:  doctorOK,
+		Title:  "Wallet owner",
+		Detail: status.OwnerDID,
+	}}
+	if status.DelegateDID == "" {
+		checks = append(checks, doctorCheck{
+			Level:  doctorWarn,
+			Title:  "Delegate DID missing",
+			Detail: "This looks like an older wallet session that granted directly to the node DID.",
+			Next:   "Run 'meshd auth connect' to create a revocable local delegate.",
+		})
+	} else if _, err := verifyWalletDelegateIdentity(stateDir, status.DelegateDID); err != nil {
+		checks = append(checks, doctorCheck{
+			Level:  doctorFail,
+			Title:  "Delegate vault mismatch",
+			Detail: err.Error(),
+			Next:   "Run 'meshd auth connect' again from this profile.",
+		})
+	} else {
+		checks = append(checks, doctorCheck{
+			Level:  doctorOK,
+			Title:  "Delegate key loaded",
+			Detail: status.DelegateDID,
+		})
+	}
+	if status.OwnerDIDMismatch || status.NodeDIDMismatch {
+		checks = append(checks, doctorCheck{
+			Level:  doctorFail,
+			Title:  "Wallet session identity mismatch",
+			Detail: fmt.Sprintf("owner mismatch=%t node mismatch=%t", status.OwnerDIDMismatch, status.NodeDIDMismatch),
+			Next:   "Reconnect this profile with 'meshd auth connect'.",
+		})
+	}
+	if status.NodeRuntimeAccess {
+		checks = append(checks, doctorCheck{Level: doctorOK, Title: "Runtime grants present"})
+	} else {
+		checks = append(checks, doctorCheck{
+			Level:  doctorFail,
+			Title:  "Runtime grants missing",
+			Detail: "The daemon may not be able to read/write mesh control records.",
+			Next:   "Run 'meshd auth connect' and approve node runtime access in the wallet.",
+		})
+	}
+	if status.NodeContextKeyCount > 0 {
+		checks = append(checks, doctorCheck{Level: doctorOK, Title: "Context keys cached", Detail: strconv.Itoa(status.NodeContextKeyCount)})
+	} else {
+		checks = append(checks, doctorCheck{
+			Level:  doctorWarn,
+			Title:  "No cached context key",
+			Detail: "Non-anchor nodes need a delivered context key to decrypt mesh records.",
+			Next:   "Approve the node in the wallet admin panel or run 'meshd peer approve <node-did>' on the anchor.",
+		})
+	}
+	return checks
+}
+
+func daemonDoctorChecks(ctx context.Context, ns *state.NetworkState) (*daemon.Status, []doctorCheck) {
+	client := daemon.NewClient(daemon.DefaultSocketPath())
+	if !client.IsRunning() {
+		return nil, []doctorCheck{{
+			Level:  doctorFail,
+			Title:  "Daemon not running",
+			Detail: fmt.Sprintf("socket %s is not accepting connections", daemon.DefaultSocketPath()),
+			Next:   "Run 'meshd up'.",
+		}}
+	}
+	live, err := client.GetStatus(ctx)
+	if err != nil {
+		return nil, []doctorCheck{{
+			Level:  doctorFail,
+			Title:  "Daemon status unavailable",
+			Detail: err.Error(),
+			Next:   "Run 'meshd down' and then 'meshd up'.",
+		}}
+	}
+	checks := []doctorCheck{{
+		Level:  doctorOK,
+		Title:  "Daemon running",
+		Detail: fmt.Sprintf("pid %d, uptime %s", live.PID, live.Uptime),
+	}}
+	if ns != nil && ns.NetworkName != "" && live.Network != "" && live.Network != ns.NetworkName {
+		checks = append(checks, doctorCheck{
+			Level:  doctorWarn,
+			Title:  "Daemon network differs from local state",
+			Detail: fmt.Sprintf("daemon=%q local=%q", live.Network, ns.NetworkName),
+			Next:   "Run 'meshd down' and then 'meshd up' for the active profile.",
+		})
+	}
+	if ns != nil && ns.MeshIP != "" && live.MeshIP != "" && live.MeshIP != ns.MeshIP {
+		checks = append(checks, doctorCheck{
+			Level:  doctorWarn,
+			Title:  "Daemon mesh IP differs from local state",
+			Detail: fmt.Sprintf("daemon=%s local=%s", live.MeshIP, ns.MeshIP),
+			Next:   "Run 'meshd down' and then 'meshd up'.",
+		})
+	}
+	return live, checks
+}
+
+func interfaceDoctorChecks(ctx context.Context, tunName string, meshIP string) []doctorCheck {
+	output, err := inspectInterface(ctx, tunName)
+	if err != nil {
+		return []doctorCheck{{
+			Level:  doctorWarn,
+			Title:  "TUN device could not be inspected",
+			Detail: err.Error(),
+			Next:   "Check the interface manually with 'ip addr' on Linux or 'ifconfig' on macOS.",
+		}}
+	}
+	checks := []doctorCheck{{
+		Level:  doctorOK,
+		Title:  "TUN device exists",
+		Detail: tunName,
+	}}
+	if meshIP != "" {
+		if strings.Contains(output, meshIP) {
+			checks = append(checks, doctorCheck{Level: doctorOK, Title: "TUN has mesh IP", Detail: meshIP})
+		} else {
+			checks = append(checks, doctorCheck{
+				Level:  doctorWarn,
+				Title:  "TUN mesh IP not visible",
+				Detail: fmt.Sprintf("%s was not found in %s", meshIP, tunName),
+				Next:   "Run 'meshd down' and then 'meshd up'.",
+			})
+		}
+	}
+	return checks
+}
+
+func peerRouteDoctorChecks(ctx context.Context, stateDir string, ns *state.NetworkState, identity *did.DID, meta identityMetadata, selfNodeDID string, tunName string) []doctorCheck {
+	if ns == nil || identity == nil || tunName == "" {
+		return nil
+	}
+	routeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	peerIP, peerCount, err := doctorPeerRouteTarget(routeCtx, stateDir, ns, identity, meta, selfNodeDID)
+	if err != nil {
+		return []doctorCheck{{
+			Level:  doctorWarn,
+			Title:  "Peer route check skipped",
+			Detail: err.Error(),
+			Next:   "Run 'meshd peer list' to verify peer discovery.",
+		}}
+	}
+	if peerCount == 0 {
+		return []doctorCheck{{
+			Level:  doctorWarn,
+			Title:  "No peers discovered",
+			Detail: "The network map contains only this device.",
+			Next:   "Join another device and approve it in the wallet admin panel.",
+		}}
+	}
+	if peerIP == "" {
+		return []doctorCheck{{
+			Level:  doctorWarn,
+			Title:  "No peer mesh IP available",
+			Detail: fmt.Sprintf("%d peer records were found, but none had a usable mesh IP", peerCount),
+			Next:   "Run 'meshd peer list' and check that peers have mesh IPs.",
+		}}
+	}
+	output, err := routeForIP(ctx, peerIP)
+	if err != nil {
+		return []doctorCheck{{
+			Level:  doctorWarn,
+			Title:  "Peer route could not be inspected",
+			Detail: err.Error(),
+			Next:   "Check the route manually with 'ip route get <peer-ip>' on Linux or 'route -n get <peer-ip>' on macOS.",
+		}}
+	}
+	if routeUsesInterface(output, tunName) {
+		return []doctorCheck{{
+			Level:  doctorOK,
+			Title:  "Peer route uses meshd TUN",
+			Detail: fmt.Sprintf("%s via %s", peerIP, tunName),
+		}}
+	}
+	detected := routeInterface(output)
+	detail := strings.TrimSpace(firstLine(output))
+	if detected != "" {
+		detail = fmt.Sprintf("%s routes via %s, not %s", peerIP, detected, tunName)
+	}
+	return []doctorCheck{{
+		Level:  doctorFail,
+		Title:  "Peer route does not use meshd TUN",
+		Detail: detail,
+		Next:   "Run 'meshd down' and then 'meshd up'. If another VPN owns this route, check its route table.",
+	}}
+}
+
+func doctorPeerRouteTarget(ctx context.Context, stateDir string, ns *state.NetworkState, identity *did.DID, meta identityMetadata, selfNodeDID string) (string, int, error) {
+	readGrantID, err := walletGrantIDForDWNOperation(stateDir, meta, dwn.InterfaceRecordsQuery, protocols.MeshProtocolURI, "", ns.NetworkRecordID, false)
+	if err != nil {
+		return "", 0, err
+	}
+	operationIdentity, err := loadDWNOperationIdentity(stateDir, meta, identity)
+	if err != nil {
+		return "", 0, err
+	}
+	encMgr := newEncryptionKeyManager(identity)
+	if ns.AnchorDID != selfNodeDID {
+		_, _, _ = loadLocalContextKeyForCLI(stateDir, ns, encMgr)
+	}
+	resp, err := loadControlStateForCLI(ctx, ns, identity, operationIdentity, encMgr, readGrantID)
+	if err != nil {
+		return "", 0, err
+	}
+	peerCount := 0
+	for _, peer := range resp.Peers {
+		if peer == nil || peer.DID == selfNodeDID {
+			continue
+		}
+		peerCount++
+		if peer.MeshIP.IsValid() {
+			return peer.MeshIP.String(), peerCount, nil
+		}
+	}
+	return "", peerCount, nil
+}
+
+func inspectInterface(ctx context.Context, name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("interface name is empty")
+	}
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "linux":
+		cmd = exec.CommandContext(ctx, "ip", "addr", "show", "dev", name)
+	case "darwin":
+		cmd = exec.CommandContext(ctx, "ifconfig", name)
+	default:
+		return "", fmt.Errorf("interface inspection is not implemented for %s", runtime.GOOS)
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return strings.TrimSpace(string(out)), fmt.Errorf("%s: %w", strings.Join(cmd.Args, " "), err)
+	}
+	return string(out), nil
+}
+
+func routeForIP(ctx context.Context, ip string) (string, error) {
+	if ip == "" {
+		return "", fmt.Errorf("peer IP is empty")
+	}
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "linux":
+		cmd = exec.CommandContext(ctx, "ip", "route", "get", ip)
+	case "darwin":
+		cmd = exec.CommandContext(ctx, "route", "-n", "get", ip)
+	default:
+		return "", fmt.Errorf("route inspection is not implemented for %s", runtime.GOOS)
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return strings.TrimSpace(string(out)), fmt.Errorf("%s: %w", strings.Join(cmd.Args, " "), err)
+	}
+	return string(out), nil
+}
+
+func routeUsesInterface(output string, tunName string) bool {
+	return tunName != "" && routeInterface(output) == tunName
+}
+
+func routeInterface(output string) string {
+	fields := strings.Fields(output)
+	for i, field := range fields {
+		switch strings.TrimSuffix(field, ":") {
+		case "dev", "interface":
+			if i+1 < len(fields) {
+				return strings.TrimSpace(fields[i+1])
+			}
+		}
+	}
+	return ""
+}
+
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+func printDoctorCheck(w io.Writer, check doctorCheck) {
+	label := string(check.Level)
+	if label == "" {
+		label = string(doctorInfo)
+	}
+	fmt.Fprintf(w, "[%s] %s\n", label, check.Title)
+	if check.Detail != "" {
+		fmt.Fprintf(w, "     %s\n", check.Detail)
+	}
+	if check.Next != "" {
+		fmt.Fprintf(w, "     Next: %s\n", check.Next)
+	}
+}
+
+func doctorHasLevel(checks []doctorCheck, level doctorLevel) bool {
+	for _, check := range checks {
+		if check.Level == level {
+			return true
+		}
+	}
+	return false
+}
+
 // upFlags holds parsed flags for the `meshd up` command.
 type upFlags struct {
 	// Network setup flags.
@@ -1440,6 +3393,7 @@ type upFlags struct {
 	endpoint      string // --endpoint <url>: DWN endpoint
 	anchorDID     string // --anchor <did>: anchor DID for joining
 	networkID     string // --network <id>: network record ID for joining
+	ownerDID      string // --owner <did>: wallet owner DID for this node
 	inviteURL     string // positional meshd://invite URL
 
 	// Engine flags.
@@ -1473,6 +3427,11 @@ func parseUpFlags(args []string) upFlags {
 		case "--network":
 			if i+1 < len(args) {
 				f.networkID = args[i+1]
+				i++
+			}
+		case "--owner", "--member":
+			if i+1 < len(args) {
+				f.ownerDID = args[i+1]
 				i++
 			}
 		case "--port":
@@ -1703,7 +3662,7 @@ func sudoEnvironmentAssignments() []string {
 		assignments = append(assignments, vaultPasswordCacheDirEnv+"="+cacheDir)
 	}
 
-	for _, key := range []string{"PATH", "DWN_ENDPOINT", "ENBOX_PROFILE", "MESHD_STATE_DIR", vaultPasswordCacheTTLEnv} {
+	for _, key := range []string{"PATH", "DWN_ENDPOINT", "ENBOX_PROFILE", "MESHD_STATE_DIR", vaultPasswordCacheTTLEnv, walletResponseEndpointEnv} {
 		if value := os.Getenv(key); value != "" {
 			assignments = append(assignments, key+"="+value)
 		}
@@ -1818,21 +3777,41 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 		return fmt.Errorf("loading network state: %w", err)
 	}
 
+	createdFromInvite := false
 	if ns == nil {
 		// Not in a network. Use flags or prompt interactively.
+		createdFromInvite = f.inviteURL != ""
 		ns, err = ensureNetwork(ctx, f, stateDir, identity, flagProfile)
 		if err != nil {
 			return err
 		}
 	}
+	if ns != nil && ns.NetworkRecordID == "" && ns.NodeRecordID == "" && ns.AnchorDID != "" {
+		ns, err = refreshPendingOwnerApproval(ctx, stateDir, ns, identity)
+		if err != nil {
+			return err
+		}
+		if ns.NetworkRecordID == "" || ns.NodeRecordID == "" {
+			printPendingOwnerApproval(ns)
+			return nil
+		}
+	}
 	if ns.NodeRecordID == "" && ns.AnchorDID != identity.URI {
-		ns, err = refreshPendingJoin(ctx, stateDir, ns, flagProfile)
+		if createdFromInvite {
+			return fmt.Errorf("join request is waiting for approval; approve it in the wallet admin panel or keep the anchor online, then run 'meshd up'")
+		}
+		ns, err = refreshPendingJoin(ctx, stateDir, ns, flagProfile, true)
 		if err != nil {
 			return err
 		}
 		if ns.NodeRecordID == "" {
-			return fmt.Errorf("join request is still pending anchor approval; run 'meshd up' again after the anchor is online")
+			return fmt.Errorf("join request is waiting for approval; approve it in the wallet admin panel or keep the anchor online, then run 'meshd up'")
 		}
+	}
+	selfNodeDID := networkNodeDID(ns, identity.URI)
+	nodeIdentity, err := loadNodeIdentity(stateDir, selfNodeDID, identity)
+	if err != nil {
+		return err
 	}
 	if shouldElevate {
 		if !backgroundChild && !f.foreground {
@@ -1855,12 +3834,14 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 		Level: logLevel,
 	}))
 
-	signer := &dwn.Signer{
-		DID:        identity.URI,
-		PrivateKey: identity.SigningKey,
+	meta := resolveIdentityMetadata(flagProfile, identity.URI)
+	operationIdentity, err := loadDWNOperationIdentity(stateDir, meta, nodeIdentity)
+	if err != nil {
+		return err
 	}
+	signer := dwnSigner(operationIdentity)
 
-	encMgr := newEncryptionKeyManager(identity)
+	encMgr := newEncryptionKeyManager(nodeIdentity)
 
 	// Enable Protocol Context encryption so all nodes (including the anchor)
 	// write records that any peer with the shared context key can decrypt.
@@ -1885,7 +3866,7 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 
 		// Fall back to DWN fetch if not cached.
 		if !useContextEncryption {
-			contextKey, err := fetchContextKey(ctx, identity, ns)
+			contextKey, err := fetchContextKey(ctx, nodeIdentity, ns)
 			if err != nil {
 				slog.Warn("context key fetch failed (will retry on next up)",
 					slog.Any("error", err),
@@ -1911,16 +3892,42 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 	}
 
 	// Derive WireGuard key pair from identity (no separate WG key generation).
-	wgKeys, err := mesh.WireGuardKeyFromIdentity(identity.EncryptionPrivateKey)
+	wgKeys, err := mesh.WireGuardKeyFromIdentity(nodeIdentity.EncryptionPrivateKey)
 	if err != nil {
 		return fmt.Errorf("deriving WireGuard keys from identity: %w", err)
 	}
 
 	fmt.Printf("Starting meshd...\n")
 	fmt.Printf("  Network: %s\n", ns.NetworkName)
-	fmt.Printf("  DID: %s\n", identity.URI)
+	fmt.Printf("  DID: %s\n", nodeIdentity.URI)
+	if operationIdentity.URI != nodeIdentity.URI {
+		fmt.Printf("  DWN delegate: %s\n", operationIdentity.URI)
+	}
 	fmt.Printf("  Mesh IP: %s\n", ns.MeshIP)
 	fmt.Printf("  Anchor: %s\n", ns.AnchorEndpoint)
+
+	networkOwner := isNetworkOwnerProfile(meta, identity.URI, ns)
+	endpointWriteGrantID, err := walletGrantIDForDWNOperation(stateDir, meta, dwn.InterfaceRecordsWrite, protocols.MeshProtocolURI, endpointProtocolPath(ns), ns.NetworkRecordID, false)
+	if err != nil {
+		return err
+	}
+	ownerWriteGrantID, err := walletGrantIDForDWNOperation(stateDir, meta, dwn.InterfaceRecordsWrite, protocols.MeshProtocolURI, "", ns.NetworkRecordID, false)
+	if err != nil {
+		return err
+	}
+	readGrantID, err := walletGrantIDForDWNOperation(stateDir, meta, dwn.InterfaceRecordsQuery, protocols.MeshProtocolURI, "", ns.NetworkRecordID, false)
+	if err != nil {
+		return err
+	}
+	deleteGrantID, err := walletGrantIDForDWNOperation(stateDir, meta, dwn.InterfaceRecordsDelete, protocols.MeshProtocolURI, "", ns.NetworkRecordID, false)
+	if err != nil {
+		return err
+	}
+	keyDeliveryGrantID, err := walletGrantIDForDWNOperation(stateDir, meta, dwn.InterfaceRecordsWrite, protocols.KeyDeliveryProtocolURI, "", "", false)
+	if err != nil {
+		return err
+	}
+	ownerAutomation := ownerAutomationEnabled(ns, nodeIdentity.URI, networkOwner, readGrantID, ownerWriteGrantID, deleteGrantID, keyDeliveryGrantID)
 
 	// Write/update endpoint record (encrypted) before starting the engine.
 	if ns.NodeRecordID != "" {
@@ -1936,6 +3943,7 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 			LocalEndpoints:       localEndpoints,
 			NATType:              "unknown",
 			UseContextEncryption: useContextEncryption,
+			PermissionGrantID:    endpointWriteGrantID,
 		}
 		err = mesh.WriteEndpoint(ctx, wpParams)
 		if err != nil {
@@ -1945,10 +3953,10 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 		}
 	}
 
-	// If this node is the anchor, enable automatic context key delivery
-	// so new members get decryption keys without manual "peer approve".
+	// If this profile has owner authority, enable automatic context key
+	// delivery so new members get decryption keys without manual approval.
 	var autoKeyDelivery *engine.AutoKeyDelivery
-	if ns.AnchorDID == identity.URI {
+	if ownerAutomation && useContextEncryption {
 		autoKeyDelivery = engine.NewAutoKeyDelivery(engine.AutoKeyDeliveryConfig{
 			Endpoint:             ns.AnchorEndpoint,
 			AnchorDID:            ns.AnchorDID,
@@ -1956,43 +3964,49 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 			Signer:               signer,
 			EncryptionKeyManager: encMgr,
 			Logger:               logger,
+			PermissionGrantID:    keyDeliveryGrantID,
 		})
 		if autoKeyDelivery != nil {
-			fmt.Printf("  Auto key delivery: enabled (anchor node)\n")
+			fmt.Printf("  Auto key delivery: enabled (owner node)\n")
 		}
 	}
-	if ns.AnchorDID == identity.URI {
-		approvePreAuthRequests(ctx, ns, signer, encMgr, logger)
+	if networkOwner && !ownerAutomation && ns.AnchorDID != nodeIdentity.URI {
+		fmt.Printf("  Owner automation: disabled (use the wallet admin panel for approvals)\n")
+	}
+	if ownerAutomation {
+		approvePreAuthRequests(ctx, ns, signer, encMgr, logger, readGrantID, ownerWriteGrantID, deleteGrantID, keyDeliveryGrantID, useContextEncryption)
 	}
 
 	// Determine the protocol role for DWN queries. The anchor reads as
 	// author (no role needed). Non-anchor nodes use their node role.
 	protocolRole := ""
-	if ns.AnchorDID != identity.URI {
+	if ns.AnchorDID != nodeIdentity.URI {
 		protocolRole = "network/node"
 	}
 	discoRegistry := engine.NewInMemoryDiscoRegistry()
 
 	eng, err := engine.New(engine.Config{
-		AnchorEndpoint:       ns.AnchorEndpoint,
-		AnchorTenant:         ns.AnchorDID,
-		NetworkRecordID:      ns.NetworkRecordID,
-		SelfDID:              identity.URI,
-		Signer:               signer,
-		Resolver:             universalResolver{},
-		EncryptionKeyManager: encMgr,
-		NodeRecordID:         ns.NodeRecordID,
-		MemberRecordID:       ns.MemberRecordID,
-		ProtocolRole:         protocolRole,
-		AutoKeyDelivery:      autoKeyDelivery,
-		UseContextEncryption: useContextEncryption,
-		WireGuardPrivateKey:  wgKeys.PrivateKey,
-		DiscoKeyRegistry:     discoRegistry,
-		TUNName:              f.tunName,
-		Domain:               ns.NetworkName,
-		ListenPort:           f.listenPort,
-		PollInterval:         f.pollInterval,
-		Logger:               logger,
+		AnchorEndpoint:         ns.AnchorEndpoint,
+		AnchorTenant:           ns.AnchorDID,
+		NetworkRecordID:        ns.NetworkRecordID,
+		SelfDID:                nodeIdentity.URI,
+		Signer:                 signer,
+		Resolver:               universalResolver{},
+		EncryptionKeyManager:   encMgr,
+		NodeRecordID:           ns.NodeRecordID,
+		MemberRecordID:         ns.MemberRecordID,
+		ProtocolRole:           protocolRole,
+		PermissionGrantID:      readGrantID,
+		WritePermissionGrantID: endpointWriteGrantID,
+		AutoKeyDelivery:        autoKeyDelivery,
+		UseContextEncryption:   useContextEncryption,
+		WireGuardPrivateKey:    wgKeys.PrivateKey,
+		DiscoKeyRegistry:       discoRegistry,
+		TUNName:                f.tunName,
+		Domain:                 ns.NetworkName,
+		ListenPort:             f.listenPort,
+		PollInterval:           f.pollInterval,
+		Logger:                 logger,
 	})
 	if err != nil {
 		return fmt.Errorf("creating engine: %w", err)
@@ -2021,13 +4035,13 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 	}
 
 	var stopPreAuthApproval chan struct{}
-	if ns.AnchorDID == identity.URI {
+	if ownerAutomation {
 		stopPreAuthApproval = make(chan struct{})
 		interval := f.pollInterval
 		if interval == 0 {
 			interval = 30 * time.Second
 		}
-		go runPreAuthApprovalLoop(ctx, stopPreAuthApproval, interval, ns, signer, encMgr, logger)
+		go runPreAuthApprovalLoop(ctx, stopPreAuthApproval, interval, ns, signer, encMgr, logger, readGrantID, ownerWriteGrantID, deleteGrantID, keyDeliveryGrantID, useContextEncryption)
 		defer close(stopPreAuthApproval)
 	}
 
@@ -2150,6 +4164,8 @@ func ensureNetwork(ctx context.Context, f upFlags, stateDir string, identity *di
 		return setupCreateNetwork(ctx, f, stateDir, identity, flagProfile)
 	case f.anchorDID != "" && f.networkID != "":
 		return setupJoinNetwork(ctx, f, stateDir, identity, flagProfile)
+	case f.ownerDID != "":
+		return setupOwnerNodeRequest(ctx, f, stateDir, identity, nil)
 	default:
 		return setupInteractive(ctx, f, stateDir, identity, flagProfile)
 	}
@@ -2158,14 +4174,26 @@ func ensureNetwork(ctx context.Context, f upFlags, stateDir string, identity *di
 // setupCreateNetwork creates a new mesh network (anchor mode).
 // This is the --create flag path.
 func setupCreateNetwork(ctx context.Context, f upFlags, stateDir string, identity *did.DID, flagProfile string) (*state.NetworkState, error) {
-	if f.endpoint == "" {
+	walletOwned := isWalletAuthorizedNodeProfile(flagProfile)
+	if f.endpoint == "" && !walletOwned {
 		return nil, fmt.Errorf("--endpoint (or DWN_ENDPOINT env) is required to create a network")
 	}
+	if f.endpoint == "" && !stdinIsTerminal() {
+		return nil, fmt.Errorf("wallet-owned network creation requires an interactive terminal; run 'meshd network create %s' first", f.createNetwork)
+	}
 
-	fmt.Printf("Creating network %q on %s...\n", f.createNetwork, f.endpoint)
+	if f.endpoint == "" {
+		fmt.Printf("Creating wallet-owned network %q...\n", f.createNetwork)
+	} else {
+		fmt.Printf("Creating network %q on %s...\n", f.createNetwork, f.endpoint)
+	}
 
 	// Delegate to the existing network create logic.
-	err := cmdNetworkCreate(ctx, []string{f.createNetwork, "--endpoint", f.endpoint}, flagProfile)
+	createArgs := []string{f.createNetwork}
+	if f.endpoint != "" {
+		createArgs = append(createArgs, "--endpoint", f.endpoint)
+	}
+	err := cmdNetworkCreate(ctx, createArgs, flagProfile)
 	if err != nil {
 		return nil, err
 	}
@@ -2189,11 +4217,16 @@ func setupJoinNetwork(ctx context.Context, f upFlags, stateDir string, identity 
 
 	fmt.Printf("Joining network on %s...\n", f.endpoint)
 
-	err := cmdNetworkJoin(ctx, []string{
+	joinArgs := []string{
 		"--endpoint", f.endpoint,
 		"--anchor", f.anchorDID,
 		"--network", f.networkID,
-	}, flagProfile)
+	}
+	if f.ownerDID != "" {
+		joinArgs = append(joinArgs, "--owner", f.ownerDID)
+	}
+
+	err := cmdNetworkJoin(ctx, joinArgs, flagProfile)
 	if err != nil {
 		return nil, err
 	}
@@ -2210,7 +4243,11 @@ func setupJoinNetwork(ctx context.Context, f upFlags, stateDir string, identity 
 
 // setupJoinInvite joins an existing network from an invite URL.
 func setupJoinInvite(ctx context.Context, f upFlags, stateDir string, identity *did.DID, flagProfile string) (*state.NetworkState, error) {
-	if err := cmdJoin(ctx, []string{f.inviteURL}, flagProfile); err != nil {
+	joinArgs := []string{f.inviteURL, "--no-start-hint"}
+	if f.ownerDID != "" {
+		joinArgs = append(joinArgs, "--owner", f.ownerDID)
+	}
+	if err := cmdJoin(ctx, joinArgs, flagProfile); err != nil {
 		return nil, err
 	}
 	ns, err := state.LoadNetworkState(stateDir)
@@ -2223,7 +4260,155 @@ func setupJoinInvite(ctx context.Context, f upFlags, stateDir string, identity *
 	return ns, nil
 }
 
-func refreshPendingJoin(ctx context.Context, stateDir string, ns *state.NetworkState, flagProfile string) (*state.NetworkState, error) {
+func setupOwnerNodeRequest(ctx context.Context, f upFlags, stateDir string, identity *did.DID, scanner *bufio.Scanner) (*state.NetworkState, error) {
+	ownerDID := strings.TrimSpace(f.ownerDID)
+	var err error
+	if ownerDID == "" {
+		if scanner == nil {
+			return nil, fmt.Errorf("--owner <did> is required")
+		}
+		ownerDID, err = promptRequired(scanner, "Owner DID")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	endpoint, err := ownerDWNEndpointForRequest(ctx, ownerDID, f.endpoint, scanner)
+	if err != nil {
+		return nil, err
+	}
+	if state.HasNetwork(stateDir) {
+		return nil, fmt.Errorf("already in a network. Use 'meshd network leave' first.")
+	}
+	if err := ensureDWNTenantRegistered(ctx, endpoint, identity); err != nil {
+		return nil, err
+	}
+
+	label, _ := os.Hostname()
+	nodeKeyDelivery, err := walletconnect.NewKeyDeliveryPublic(identity)
+	if err != nil {
+		return nil, fmt.Errorf("deriving node key-delivery public key: %w", err)
+	}
+	requestID, err := mesh.WriteOwnerNodeRequest(ctx, mesh.OwnerNodeRequestParams{
+		OwnerEndpoint:   endpoint,
+		OwnerDID:        ownerDID,
+		NodeDID:         identity.URI,
+		Signer:          dwnSigner(identity),
+		Label:           label,
+		SourceDWN:       endpoint,
+		NodeKeyDelivery: nodeKeyDelivery,
+	})
+	if err != nil {
+		adminURL := buildAdminURL(defaultAdminDashboardURL, adminContext{OwnerDID: ownerDID})
+		return nil, fmt.Errorf("submitting owner approval request: %w\nOpen the dashboard once to initialize meshd for this owner: %s", err, adminURL)
+	}
+
+	ns := &state.NetworkState{
+		AnchorDID:             ownerDID,
+		AnchorEndpoint:        endpoint,
+		NetworkName:           "pending approval",
+		NodeDID:               identity.URI,
+		OwnerDID:              ownerDID,
+		MemberDID:             ownerDID,
+		PendingOwnerRequestID: requestID,
+		PendingOwnerRequestAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := state.SaveNetworkState(stateDir, ns); err != nil {
+		return nil, fmt.Errorf("saving pending owner request: %w", err)
+	}
+
+	fmt.Printf("Node approval request submitted.\n")
+	fmt.Printf("  Owner DID: %s\n", ownerDID)
+	fmt.Printf("  Node DID:  %s\n", identity.URI)
+	fmt.Printf("  Request:   %s\n", requestID)
+	fmt.Printf("  Dashboard: %s\n", buildAdminURL(defaultAdminDashboardURL, adminContext{OwnerDID: ownerDID}))
+	fmt.Printf("\nApprove this device in the dashboard, then run 'meshd up' again.\n")
+	return ns, nil
+}
+
+func ownerDWNEndpointForRequest(ctx context.Context, ownerDID, explicitEndpoint string, scanner *bufio.Scanner) (string, error) {
+	endpoint := strings.TrimSpace(explicitEndpoint)
+	if endpoint != "" {
+		return endpoint, nil
+	}
+	resolved, err := control.ResolvePeerDWNEndpoint(ctx, universalResolver{}, ownerDID, nil)
+	if err == nil && strings.TrimSpace(resolved) != "" {
+		return strings.TrimSpace(resolved), nil
+	}
+	if scanner != nil {
+		if err != nil {
+			fmt.Printf("Could not resolve an owner DWN endpoint automatically: %v\n", err)
+		}
+		return promptRequired(scanner, "Owner DWN endpoint URL")
+	}
+	return "", fmt.Errorf("--endpoint (or DWN_ENDPOINT env) is required because no DWN endpoint could be resolved for owner DID %s", ownerDID)
+}
+
+func refreshPendingOwnerApproval(ctx context.Context, stateDir string, ns *state.NetworkState, identity *did.DID) (*state.NetworkState, error) {
+	if ns == nil {
+		return nil, fmt.Errorf("network state is missing")
+	}
+	ownerDID := ns.EffectiveOwnerDID(ns.AnchorDID)
+	nodeDID := ns.EffectiveNodeDID(identity.URI)
+	fmt.Printf("Checking owner approval...\n")
+	approval, approvalRecordID, err := mesh.FindOwnerNodeApproval(ctx, ns.AnchorEndpoint, ownerDID, nodeDID, dwnSigner(identity))
+	if err != nil {
+		return nil, err
+	}
+	if approval == nil {
+		return ns, nil
+	}
+	if approval.ExpiresAt != "" {
+		expiresAt, parseErr := time.Parse(time.RFC3339, approval.ExpiresAt)
+		if parseErr != nil {
+			return nil, fmt.Errorf("approval has invalid expiry %q", approval.ExpiresAt)
+		}
+		if time.Now().UTC().After(expiresAt) {
+			return nil, fmt.Errorf("approval expired at %s; renew this node in the dashboard", approval.ExpiresAt)
+		}
+	}
+
+	refreshed := &state.NetworkState{
+		NetworkRecordID:   approval.NetworkRecordID,
+		AnchorDID:         ownerDID,
+		AnchorEndpoint:    firstNonEmpty(approval.AnchorEndpoint, ns.AnchorEndpoint),
+		NetworkName:       firstNonEmpty(approval.NetworkName, "mesh"),
+		MeshCIDR:          firstNonEmpty(approval.MeshCIDR, "10.200.0.0/16"),
+		MeshIP:            approval.MeshIP,
+		NodeDID:           nodeDID,
+		OwnerDID:          ownerDID,
+		MemberDID:         ownerDID,
+		NodeRecordID:      approval.NodeRecordID,
+		NodeDateCreated:   approval.NodeDateCreated,
+		MemberRecordID:    approval.MemberRecordID,
+		MemberDateCreated: approval.MemberDateCreated,
+	}
+	if err := state.SaveNetworkState(stateDir, refreshed); err != nil {
+		return nil, fmt.Errorf("saving approved network state: %w", err)
+	}
+	fmt.Printf("Owner approval accepted.\n")
+	fmt.Printf("  Network: %s\n", refreshed.NetworkName)
+	fmt.Printf("  Mesh IP: %s\n", refreshed.MeshIP)
+	if approvalRecordID != "" {
+		fmt.Printf("  Approval: %s\n", approvalRecordID)
+	}
+	return refreshed, nil
+}
+
+func printPendingOwnerApproval(ns *state.NetworkState) {
+	ownerDID := ""
+	if ns != nil {
+		ownerDID = ns.EffectiveOwnerDID(ns.AnchorDID)
+	}
+	fmt.Printf("Node approval is still pending.\n")
+	if ownerDID != "" {
+		fmt.Printf("  Owner DID: %s\n", ownerDID)
+		fmt.Printf("  Dashboard: %s\n", buildAdminURL(defaultAdminDashboardURL, adminContext{OwnerDID: ownerDID}))
+	}
+	fmt.Printf("\nApprove this device in the dashboard, then run 'meshd up' again.\n")
+}
+
+func refreshPendingJoin(ctx context.Context, stateDir string, ns *state.NetworkState, flagProfile string, noStartHint bool) (*state.NetworkState, error) {
 	if ns == nil {
 		return nil, fmt.Errorf("network state is missing")
 	}
@@ -2233,12 +4418,20 @@ func refreshPendingJoin(ctx context.Context, stateDir string, ns *state.NetworkS
 	if err := state.ClearNetworkState(stateDir); err != nil {
 		return nil, fmt.Errorf("clearing pending network state: %w", err)
 	}
-	err := cmdNetworkJoin(ctx, []string{
+	joinArgs := []string{
 		"--endpoint", ns.AnchorEndpoint,
 		"--anchor", ns.AnchorDID,
 		"--network", ns.NetworkRecordID,
 		"--preauth",
-	}, flagProfile)
+	}
+	ownerDID := ns.EffectiveOwnerDID("")
+	if ownerDID != "" && ownerDID != ns.NodeDID {
+		joinArgs = append(joinArgs, "--owner", ownerDID)
+	}
+	if noStartHint {
+		joinArgs = append(joinArgs, "--no-start-hint")
+	}
+	err := cmdNetworkJoin(ctx, joinArgs, flagProfile)
 	if err != nil {
 		_ = state.SaveNetworkState(stateDir, &previous)
 		return nil, err
@@ -2256,14 +4449,16 @@ func refreshPendingJoin(ctx context.Context, stateDir string, ns *state.NetworkS
 	return refreshed, nil
 }
 
-// setupInteractive prompts the user to create or join a network.
+// setupInteractive prompts the user to request owner approval, create, or join
+// a network.
 func setupInteractive(ctx context.Context, f upFlags, stateDir string, identity *did.DID, flagProfile string) (*state.NetworkState, error) {
 	fmt.Println("No network configured. What would you like to do?")
 	fmt.Println()
-	fmt.Println("  1) Create a new network")
-	fmt.Println("  2) Join an existing network")
+	fmt.Println("  1) Request access from an owner DID")
+	fmt.Println("  2) Create a new local-vault network")
+	fmt.Println("  3) Join with an invite URL")
 	fmt.Println()
-	fmt.Print("Choice [1/2]: ")
+	fmt.Print("Choice [1/2/3]: ")
 
 	scanner := bufio.NewScanner(os.Stdin)
 	if !scanner.Scan() {
@@ -2275,11 +4470,13 @@ func setupInteractive(ctx context.Context, f upFlags, stateDir string, identity 
 
 	switch choice {
 	case "1":
-		return interactiveCreate(ctx, f, stateDir, identity, flagProfile, scanner)
+		return setupOwnerNodeRequest(ctx, f, stateDir, identity, scanner)
 	case "2":
+		return interactiveCreate(ctx, f, stateDir, identity, flagProfile, scanner)
+	case "3":
 		return interactiveJoin(ctx, f, stateDir, identity, flagProfile, scanner)
 	default:
-		return nil, fmt.Errorf("invalid choice %q (expected 1 or 2)", choice)
+		return nil, fmt.Errorf("invalid choice %q (expected 1, 2, or 3)", choice)
 	}
 }
 
@@ -2302,7 +4499,7 @@ func promptRequired(scanner *bufio.Scanner, label string) (string, error) {
 // interactiveCreate guides the user through creating a new network.
 func interactiveCreate(ctx context.Context, f upFlags, stateDir string, identity *did.DID, flagProfile string, scanner *bufio.Scanner) (*state.NetworkState, error) {
 	endpoint := f.endpoint
-	if endpoint == "" {
+	if endpoint == "" && !isWalletAuthorizedNodeProfile(flagProfile) {
 		fmt.Print("DWN endpoint URL: ")
 		if !scanner.Scan() {
 			return nil, fmt.Errorf("no input received")
@@ -2330,41 +4527,73 @@ func interactiveCreate(ctx context.Context, f upFlags, stateDir string, identity
 
 // interactiveJoin guides the user through joining an existing network.
 func interactiveJoin(ctx context.Context, f upFlags, stateDir string, identity *did.DID, flagProfile string, scanner *bufio.Scanner) (*state.NetworkState, error) {
-	endpoint := f.endpoint
+	input, err := promptInteractiveJoin(scanner, f.endpoint)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Println()
+	if input.inviteURL != "" {
+		f.inviteURL = input.inviteURL
+		return setupJoinInvite(ctx, f, stateDir, identity, flagProfile)
+	}
+	f.endpoint = input.endpoint
+	f.anchorDID = input.anchorDID
+	f.networkID = input.networkID
+	return setupJoinNetwork(ctx, f, stateDir, identity, flagProfile)
+}
+
+type interactiveJoinInput struct {
+	inviteURL string
+	endpoint  string
+	anchorDID string
+	networkID string
+}
+
+func promptInteractiveJoin(scanner *bufio.Scanner, defaultEndpoint string) (interactiveJoinInput, error) {
+	fmt.Print("Invite URL (recommended; leave blank for manual details): ")
+	if !scanner.Scan() {
+		return interactiveJoinInput{}, fmt.Errorf("no input received")
+	}
+	inviteURL := strings.TrimSpace(scanner.Text())
+	if inviteURL != "" {
+		return interactiveJoinInput{inviteURL: inviteURL}, nil
+	}
+
+	endpoint := defaultEndpoint
 	if endpoint == "" {
 		fmt.Print("DWN endpoint URL: ")
 		if !scanner.Scan() {
-			return nil, fmt.Errorf("no input received")
+			return interactiveJoinInput{}, fmt.Errorf("no input received")
 		}
 		endpoint = strings.TrimSpace(scanner.Text())
 		if endpoint == "" {
-			return nil, fmt.Errorf("endpoint URL is required")
+			return interactiveJoinInput{}, fmt.Errorf("endpoint URL is required")
 		}
 	}
 
 	fmt.Print("Anchor DID: ")
 	if !scanner.Scan() {
-		return nil, fmt.Errorf("no input received")
+		return interactiveJoinInput{}, fmt.Errorf("no input received")
 	}
 	anchorDID := strings.TrimSpace(scanner.Text())
 	if anchorDID == "" {
-		return nil, fmt.Errorf("anchor DID is required")
+		return interactiveJoinInput{}, fmt.Errorf("anchor DID is required")
 	}
 
 	fmt.Print("Network ID: ")
 	if !scanner.Scan() {
-		return nil, fmt.Errorf("no input received")
+		return interactiveJoinInput{}, fmt.Errorf("no input received")
 	}
 	networkID := strings.TrimSpace(scanner.Text())
 	if networkID == "" {
-		return nil, fmt.Errorf("network ID is required")
+		return interactiveJoinInput{}, fmt.Errorf("network ID is required")
 	}
 
-	fmt.Println()
-	f.endpoint = endpoint
-	f.anchorDID = anchorDID
-	f.networkID = networkID
-	return setupJoinNetwork(ctx, f, stateDir, identity, flagProfile)
+	return interactiveJoinInput{
+		endpoint:  endpoint,
+		anchorDID: anchorDID,
+		networkID: networkID,
+	}, nil
 }
 
 // cmdDown stops the mesh agent daemon by sending a shutdown request via the
@@ -2404,6 +4633,8 @@ const (
 	vaultPasswordEnv           = "MESHD_VAULT_PASSWORD"
 	vaultPasswordCacheTTLEnv   = "MESHD_VAULT_CACHE_TTL"
 	vaultPasswordCacheDirEnv   = "MESHD_VAULT_CACHE_DIR"
+	nodeIdentityVaultFile      = "node.identity.vault.json"
+	delegateIdentityVaultFile  = "delegate.identity.vault.json"
 	defaultVaultPasswordCache  = 5 * time.Minute
 	vaultPasswordCacheFileMode = 0o600
 	vaultPasswordCacheDirMode  = 0o700
@@ -2439,6 +4670,345 @@ func profileNameForWrite(flagProfile string) string {
 		return name
 	}
 	return defaultProfileName(flagProfile)
+}
+
+type identityMetadata struct {
+	AuthType    string
+	OwnerDID    string
+	DelegateDID string
+	NodeDID     string
+}
+
+func authDisplayName(authType string) string {
+	switch profile.NormalizeAuthType(authType) {
+	case profile.AuthTypeLocalVault:
+		return "local vault"
+	case profile.AuthTypeWalletAuthorizedNode:
+		return "wallet-authorized node"
+	default:
+		return authType
+	}
+}
+
+func resolveIdentityMetadata(flagProfile string, fallbackDID string) identityMetadata {
+	meta := identityMetadata{
+		AuthType: profile.AuthTypeLocalVault,
+		OwnerDID: fallbackDID,
+		NodeDID:  fallbackDID,
+	}
+	if os.Getenv("MESHD_STATE_DIR") != "" {
+		return meta
+	}
+	name, err := profile.Resolve(flagProfile)
+	if err != nil {
+		return meta
+	}
+	cfg, err := profile.ReadConfig()
+	if err != nil || cfg.Profiles[name] == nil {
+		return meta
+	}
+	entry := cfg.Profiles[name]
+	meta.AuthType = entry.EffectiveAuthType()
+	meta.OwnerDID = firstNonEmpty(entry.EffectiveOwnerDID(), fallbackDID)
+	meta.DelegateDID = entry.DelegateDID
+	meta.NodeDID = firstNonEmpty(entry.EffectiveNodeDID(), fallbackDID)
+	return meta
+}
+
+func isWalletAuthorizedNodeProfile(flagProfile string) bool {
+	if os.Getenv("MESHD_STATE_DIR") != "" {
+		return false
+	}
+	name, err := profile.Resolve(flagProfile)
+	if err != nil {
+		return false
+	}
+	cfg, err := profile.ReadConfig()
+	if err != nil || cfg.Profiles[name] == nil {
+		return false
+	}
+	entry := cfg.Profiles[name]
+	return entry.EffectiveAuthType() == profile.AuthTypeWalletAuthorizedNode &&
+		entry.EffectiveOwnerDID() != "" &&
+		entry.EffectiveOwnerDID() != entry.EffectiveNodeDID()
+}
+
+func isNetworkOwnerProfile(meta identityMetadata, identityDID string, ns *state.NetworkState) bool {
+	if ns == nil || ns.AnchorDID == "" {
+		return false
+	}
+	if ns.AnchorDID == identityDID {
+		return true
+	}
+	return meta.AuthType == profile.AuthTypeWalletAuthorizedNode &&
+		meta.OwnerDID != "" &&
+		meta.OwnerDID == ns.AnchorDID
+}
+
+func ownerAutomationEnabled(ns *state.NetworkState, nodeDID string, networkOwner bool, readGrantID, writeGrantID, deleteGrantID, keyDeliveryWriteGrantID string) bool {
+	if !networkOwner || ns == nil {
+		return false
+	}
+	if ns.AnchorDID == nodeDID {
+		return true
+	}
+	return readGrantID != "" && writeGrantID != "" && deleteGrantID != "" && keyDeliveryWriteGrantID != ""
+}
+
+func nodeInfoProtocolPath(ns *state.NetworkState) string {
+	if ns != nil && ns.MemberRecordID != "" {
+		return "network/member/node/nodeInfo"
+	}
+	return "network/node/nodeInfo"
+}
+
+func endpointProtocolPath(ns *state.NetworkState) string {
+	if ns != nil && ns.MemberRecordID != "" {
+		return "network/member/node/endpoint"
+	}
+	return "network/node/endpoint"
+}
+
+func requireNetworkOwnerProfile(flagProfile string, identity *did.DID, ns *state.NetworkState) (identityMetadata, bool, error) {
+	if identity == nil {
+		return identityMetadata{}, false, fmt.Errorf("identity is required")
+	}
+	meta := resolveIdentityMetadata(flagProfile, identity.URI)
+	if !isNetworkOwnerProfile(meta, identity.URI, ns) {
+		return meta, false, fmt.Errorf("only the network owner (%s) can perform this action", ns.AnchorDID)
+	}
+	return meta, ns.AnchorDID != identity.URI, nil
+}
+
+func prepareNetworkCommandEncryption(stateDir string, identity *did.DID, ns *state.NetworkState, useContextEncryption bool) (*dwncrypto.EncryptionKeyManager, error) {
+	encMgr := newEncryptionKeyManager(identity)
+	if !useContextEncryption {
+		return encMgr, nil
+	}
+	_, loaded, err := loadLocalContextKeyForCLI(stateDir, ns, encMgr)
+	if err != nil {
+		return nil, err
+	}
+	if !loaded {
+		return nil, fmt.Errorf("wallet-owned network is missing its local context key; reconnect this profile with 'meshd auth connect'")
+	}
+	return encMgr, nil
+}
+
+func walletGrantIDForDWNOperation(stateDir string, meta identityMetadata, messageType dwn.DwnInterface, protocolURI, protocolPath, contextID string, required bool) (string, error) {
+	if meta.AuthType != profile.AuthTypeWalletAuthorizedNode {
+		return "", nil
+	}
+	if !state.WalletSessionExists(stateDir) {
+		if required {
+			return "", fmt.Errorf("wallet-connected profile is missing an imported wallet session; run 'meshd auth connect --response <file>'")
+		}
+		return "", nil
+	}
+	password, err := vaultPasswordForUnlock(stateDir)
+	if err != nil {
+		return "", err
+	}
+	session, err := state.LoadWalletSession(stateDir, password)
+	if err != nil {
+		return "", err
+	}
+	if session == nil {
+		if required {
+			return "", fmt.Errorf("wallet-connected profile is missing an imported wallet session; run 'meshd auth connect --response <file>'")
+		}
+		return "", nil
+	}
+	sessionOwnerDID := session.EffectiveOwnerDID()
+	if sessionOwnerDID != "" && meta.OwnerDID != "" && sessionOwnerDID != meta.OwnerDID {
+		return "", fmt.Errorf("wallet session owner DID %s does not match profile owner DID %s", sessionOwnerDID, meta.OwnerDID)
+	}
+	if session.NodeDID != "" && meta.NodeDID != "" && session.NodeDID != meta.NodeDID {
+		return "", fmt.Errorf("wallet session node DID %s does not match profile node DID %s", session.NodeDID, meta.NodeDID)
+	}
+	granteeDID, _ := walletSessionGrantGranteeDID(session, meta)
+	grantID, err := dwn.FindPermissionGrantID(session.Grants, dwn.PermissionGrantMatch{
+		Grantor:      firstNonEmpty(sessionOwnerDID, meta.OwnerDID),
+		Grantee:      granteeDID,
+		MessageType:  messageType,
+		Protocol:     protocolURI,
+		ProtocolPath: protocolPath,
+		ContextID:    contextID,
+		Now:          time.Now().UTC(),
+	})
+	if err != nil {
+		return "", err
+	}
+	if grantID == "" && required {
+		target := protocolURI
+		if protocolPath != "" {
+			target += " " + protocolPath
+		}
+		return "", fmt.Errorf("wallet session has no permission grant for %s %s; run 'meshd auth connect --admin' to approve admin control", messageType, target)
+	}
+	return grantID, nil
+}
+
+func walletSessionGrantGranteeDID(session *state.WalletSession, meta identityMetadata) (string, bool) {
+	delegateDID := firstNonEmpty(session.DelegateDID, meta.DelegateDID)
+	if delegateDID != "" {
+		return delegateDID, true
+	}
+	return firstNonEmpty(session.NodeDID, meta.NodeDID), false
+}
+
+type walletSessionStatus struct {
+	Exists                  bool
+	OwnerDID                string
+	NodeDID                 string
+	WalletOrigin            string
+	ExpiresAt               string
+	DelegateDID             string
+	GrantCount              int
+	NodeContextKeyCount     int
+	NodeProtocolCount       int
+	NodeRuntimeAccess       bool
+	AdminControlAccess      bool
+	OwnerDIDMismatch        bool
+	NodeDIDMismatch         bool
+	LegacyDelegateKeyFields bool
+}
+
+func loadWalletSessionStatus(stateDir string, meta identityMetadata) (*walletSessionStatus, error) {
+	status := &walletSessionStatus{}
+	if !state.WalletSessionExists(stateDir) {
+		return status, nil
+	}
+	password, err := vaultPasswordForUnlock(stateDir)
+	if err != nil {
+		return nil, err
+	}
+	session, err := state.LoadWalletSession(stateDir, password)
+	if err != nil {
+		return nil, err
+	}
+	if session == nil {
+		return status, nil
+	}
+	status.Exists = true
+	status.OwnerDID = session.EffectiveOwnerDID()
+	status.NodeDID = session.NodeDID
+	status.WalletOrigin = session.WalletOrigin
+	status.ExpiresAt = session.ExpiresAt
+	status.DelegateDID = session.DelegateDID
+	status.GrantCount = len(session.Grants)
+	status.NodeContextKeyCount = len(session.EffectiveNodeContextKeys())
+	status.NodeProtocolCount = len(session.EffectiveNodeMultiPartyProtocols())
+	status.NodeRuntimeAccess = walletSessionHasNodeRuntimeGrants(session, meta)
+	status.AdminControlAccess = walletSessionHasAdminControlGrants(session, meta)
+	status.LegacyDelegateKeyFields = len(session.NodeContextKeys) == 0 && len(session.DelegateContextKeys) > 0
+	status.OwnerDIDMismatch = meta.OwnerDID != "" && status.OwnerDID != "" && meta.OwnerDID != status.OwnerDID
+	status.NodeDIDMismatch = meta.NodeDID != "" && session.NodeDID != "" && meta.NodeDID != session.NodeDID
+	return status, nil
+}
+
+func walletSessionHasNodeRuntimeGrants(session *state.WalletSession, meta identityMetadata) bool {
+	if session == nil {
+		return false
+	}
+	return walletSessionHasGrant(session, meta, dwn.InterfaceRecordsQuery, protocols.MeshProtocolURI, "") &&
+		walletSessionHasGrant(session, meta, dwn.InterfaceRecordsWrite, protocols.MeshProtocolURI, "network/node/nodeInfo") &&
+		walletSessionHasGrant(session, meta, dwn.InterfaceRecordsWrite, protocols.MeshProtocolURI, "network/node/endpoint") &&
+		walletSessionHasGrant(session, meta, dwn.InterfaceRecordsWrite, protocols.MeshProtocolURI, "network/member/node/nodeInfo") &&
+		walletSessionHasGrant(session, meta, dwn.InterfaceRecordsWrite, protocols.MeshProtocolURI, "network/member/node/endpoint") &&
+		walletSessionHasGrant(session, meta, dwn.InterfaceRecordsQuery, protocols.KeyDeliveryProtocolURI, "")
+}
+
+func walletSessionHasAdminControlGrants(session *state.WalletSession, meta identityMetadata) bool {
+	if session == nil {
+		return false
+	}
+	return walletSessionHasGrant(session, meta, dwn.InterfaceRecordsQuery, protocols.MeshProtocolURI, "") &&
+		walletSessionHasGrant(session, meta, dwn.InterfaceRecordsWrite, protocols.MeshProtocolURI, "") &&
+		walletSessionHasGrant(session, meta, dwn.InterfaceRecordsDelete, protocols.MeshProtocolURI, "") &&
+		walletSessionHasGrant(session, meta, dwn.InterfaceRecordsQuery, protocols.KeyDeliveryProtocolURI, "") &&
+		walletSessionHasGrant(session, meta, dwn.InterfaceRecordsWrite, protocols.KeyDeliveryProtocolURI, "") &&
+		walletSessionHasGrant(session, meta, dwn.InterfaceRecordsDelete, protocols.KeyDeliveryProtocolURI, "")
+}
+
+func walletSessionHasGrant(session *state.WalletSession, meta identityMetadata, messageType dwn.DwnInterface, protocolURI, protocolPath string) bool {
+	if session == nil {
+		return false
+	}
+	granteeDID, _ := walletSessionGrantGranteeDID(session, meta)
+	grantID, err := dwn.FindPermissionGrantID(session.Grants, dwn.PermissionGrantMatch{
+		Grantor:      firstNonEmpty(session.EffectiveOwnerDID(), meta.OwnerDID),
+		Grantee:      granteeDID,
+		MessageType:  messageType,
+		Protocol:     protocolURI,
+		ProtocolPath: protocolPath,
+		Now:          time.Now().UTC(),
+	})
+	return err == nil && grantID != ""
+}
+
+func printWalletSessionStatus(stateDir string, meta identityMetadata) error {
+	status, err := loadWalletSessionStatus(stateDir, meta)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("  Wallet Session: ")
+	if status == nil || !status.Exists {
+		fmt.Printf("missing (run 'meshd auth connect')\n")
+		return nil
+	}
+	fmt.Printf("imported\n")
+	if status.WalletOrigin != "" {
+		fmt.Printf("    Wallet: %s\n", status.WalletOrigin)
+	}
+	if status.OwnerDID != "" && status.OwnerDID != meta.OwnerDID {
+		fmt.Printf("    Wallet Owner DID: %s\n", status.OwnerDID)
+	}
+	if status.NodeDID != "" && status.NodeDID != meta.NodeDID {
+		fmt.Printf("    Node DID: %s\n", status.NodeDID)
+	}
+	if status.DelegateDID != "" {
+		fmt.Printf("    Session Delegate DID: %s\n", status.DelegateDID)
+	}
+	fmt.Printf("    Grants: %d\n", status.GrantCount)
+	if status.NodeRuntimeAccess {
+		fmt.Printf("    Node Runtime Access: yes\n")
+	} else {
+		fmt.Printf("    Node Runtime Access: no\n")
+	}
+	if status.AdminControlAccess {
+		fmt.Printf("    Admin Control Access: yes\n")
+	} else {
+		fmt.Printf("    Admin Control Access: no (run 'meshd auth connect --admin')\n")
+	}
+	fmt.Printf("    Node Context Keys: %d\n", status.NodeContextKeyCount)
+	if status.NodeProtocolCount > 0 {
+		fmt.Printf("    Node Protocols: %d\n", status.NodeProtocolCount)
+	}
+	if status.ExpiresAt != "" {
+		fmt.Printf("    Expires: %s\n", status.ExpiresAt)
+	}
+	if status.OwnerDIDMismatch || status.NodeDIDMismatch {
+		fmt.Printf("    Warning: session identity does not match profile metadata\n")
+	}
+	if status.LegacyDelegateKeyFields {
+		fmt.Printf("    Compatibility: using legacy delegateContextKeys as node context keys\n")
+	}
+	return nil
+}
+
+func networkNodeDID(ns *state.NetworkState, fallbackDID string) string {
+	if ns == nil {
+		return fallbackDID
+	}
+	return ns.EffectiveNodeDID(fallbackDID)
+}
+
+func networkOwnerDID(ns *state.NetworkState, fallbackDID string) string {
+	if ns == nil {
+		return fallbackDID
+	}
+	return ns.EffectiveOwnerDID(fallbackDID)
 }
 
 func identityExists(stateDir string) bool {
@@ -2714,6 +5284,33 @@ func loadIdentity(stateDir string) (*did.DID, error) {
 	return identity, nil
 }
 
+func loadNodeIdentity(stateDir string, nodeDID string, fallback *did.DID) (*did.DID, error) {
+	if fallback == nil {
+		return nil, fmt.Errorf("fallback identity is required")
+	}
+	if nodeDID == "" || nodeDID == fallback.URI {
+		return fallback, nil
+	}
+	if !did.EncryptedExistsAs(stateDir, nodeIdentityVaultFile) {
+		return nil, fmt.Errorf("node identity %s is recorded, but %s is missing", nodeDID, nodeIdentityVaultFile)
+	}
+	password, err := vaultPasswordForUnlock(stateDir)
+	if err != nil {
+		return nil, err
+	}
+	nodeIdentity, err := did.LoadEncryptedAs(stateDir, nodeIdentityVaultFile, password)
+	if err != nil {
+		return nil, fmt.Errorf("unlocking node identity vault: %w", err)
+	}
+	if nodeIdentity == nil {
+		return nil, fmt.Errorf("node identity vault is missing")
+	}
+	if nodeIdentity.URI != nodeDID {
+		return nil, fmt.Errorf("node identity vault DID %s does not match network node DID %s", nodeIdentity.URI, nodeDID)
+	}
+	return nodeIdentity, nil
+}
+
 func loadLocalContextKeyForCLI(stateDir string, ns *state.NetworkState, encMgr *dwncrypto.EncryptionKeyManager) (string, bool, error) {
 	if ns == nil || ns.NetworkRecordID == "" {
 		return "", false, nil
@@ -2808,26 +5405,114 @@ func fetchContextKey(ctx context.Context, identity *did.DID, ns *state.NetworkSt
 		PrivateKey: identity.SigningKey,
 	}
 
-	// contextKey records are written unencrypted (access controlled by
-	// key-delivery protocol $actions). The recipient can query and read
-	// their own records via the DWN's implicit recipient authorization.
 	return mesh.FetchContextKey(ctx, mesh.FetchContextKeyParams{
-		AnchorEndpoint: ns.AnchorEndpoint,
-		AnchorDID:      ns.AnchorDID,
-		SelfDID:        identity.URI,
-		ContextID:      ns.NetworkRecordID,
-		Signer:         signer,
+		AnchorEndpoint:       ns.AnchorEndpoint,
+		AnchorDID:            ns.AnchorDID,
+		SelfDID:              identity.URI,
+		ContextID:            ns.NetworkRecordID,
+		Signer:               signer,
+		EncryptionKeyManager: newEncryptionKeyManager(identity),
 	})
 }
 
-func approvePreAuthRequests(ctx context.Context, ns *state.NetworkState, signer *dwn.Signer, encMgr *dwncrypto.EncryptionKeyManager, logger *slog.Logger) {
+func ensureWalletDelegateIdentity(stateDir string) (*did.DID, error) {
+	password, err := vaultPasswordForUnlock(stateDir)
+	if err != nil {
+		return nil, err
+	}
+	if did.EncryptedExistsAs(stateDir, delegateIdentityVaultFile) {
+		delegateIdentity, err := did.LoadEncryptedAs(stateDir, delegateIdentityVaultFile, password)
+		if err != nil {
+			return nil, fmt.Errorf("unlocking delegate identity vault: %w", err)
+		}
+		if delegateIdentity == nil {
+			return nil, fmt.Errorf("delegate identity vault is missing")
+		}
+		return delegateIdentity, nil
+	}
+	delegateIdentity, err := did.Generate()
+	if err != nil {
+		return nil, fmt.Errorf("generating delegate DID: %w", err)
+	}
+	if err := delegateIdentity.StoreEncryptedAs(stateDir, delegateIdentityVaultFile, password); err != nil {
+		return nil, fmt.Errorf("storing delegate identity: %w", err)
+	}
+	return delegateIdentity, nil
+}
+
+func verifyWalletDelegateIdentity(stateDir string, delegateDID string) (*did.DID, error) {
+	delegateDID = strings.TrimSpace(delegateDID)
+	if delegateDID == "" {
+		return nil, nil
+	}
+	if !did.EncryptedExistsAs(stateDir, delegateIdentityVaultFile) {
+		return nil, fmt.Errorf("wallet response grants to delegate DID %s, but the local delegate vault is missing; rerun 'meshd auth connect' from this profile", delegateDID)
+	}
+	password, err := vaultPasswordForUnlock(stateDir)
+	if err != nil {
+		return nil, err
+	}
+	delegateIdentity, err := did.LoadEncryptedAs(stateDir, delegateIdentityVaultFile, password)
+	if err != nil {
+		return nil, fmt.Errorf("unlocking delegate identity vault: %w", err)
+	}
+	if delegateIdentity == nil {
+		return nil, fmt.Errorf("delegate identity vault is missing")
+	}
+	if delegateIdentity.URI != delegateDID {
+		return nil, fmt.Errorf("delegate identity vault DID %s does not match wallet response delegate DID %s", delegateIdentity.URI, delegateDID)
+	}
+	return delegateIdentity, nil
+}
+
+func requireWalletResponseDelegateIdentity(stateDir string, delegateDID string, nodeDID string, responseLabel string) (*did.DID, error) {
+	delegateDID = strings.TrimSpace(delegateDID)
+	nodeDID = strings.TrimSpace(nodeDID)
+	if responseLabel == "" {
+		responseLabel = "wallet response"
+	}
+	if delegateDID == "" {
+		return nil, nil
+	}
+	if nodeDID != "" && delegateDID == nodeDID {
+		return nil, fmt.Errorf("%s delegate DID must be distinct from node DID %s", responseLabel, nodeDID)
+	}
+	return verifyWalletDelegateIdentity(stateDir, delegateDID)
+}
+
+func loadDWNOperationIdentity(stateDir string, meta identityMetadata, fallback *did.DID) (*did.DID, error) {
+	if fallback == nil {
+		return nil, fmt.Errorf("fallback identity is required")
+	}
+	if meta.AuthType != profile.AuthTypeWalletAuthorizedNode || meta.DelegateDID == "" || meta.DelegateDID == fallback.URI {
+		return fallback, nil
+	}
+	return verifyWalletDelegateIdentity(stateDir, meta.DelegateDID)
+}
+
+func dwnSigner(identity *did.DID) *dwn.Signer {
+	if identity == nil {
+		return nil
+	}
+	return &dwn.Signer{
+		DID:        identity.URI,
+		PrivateKey: identity.SigningKey,
+	}
+}
+
+func approvePreAuthRequests(ctx context.Context, ns *state.NetworkState, signer *dwn.Signer, encMgr *dwncrypto.EncryptionKeyManager, logger *slog.Logger, readGrantID, writeGrantID, deleteGrantID, keyDeliveryGrantID string, useContextEncryption bool) {
 	result, err := mesh.ApprovePreAuthRequests(ctx, mesh.ApprovePreAuthRequestsParams{
-		AnchorEndpoint:       ns.AnchorEndpoint,
-		AnchorDID:            ns.AnchorDID,
-		NetworkRecordID:      ns.NetworkRecordID,
-		MeshCIDR:             ns.MeshCIDR,
-		Signer:               signer,
-		EncryptionKeyManager: encMgr,
+		AnchorEndpoint:          ns.AnchorEndpoint,
+		AnchorDID:               ns.AnchorDID,
+		NetworkRecordID:         ns.NetworkRecordID,
+		MeshCIDR:                ns.MeshCIDR,
+		Signer:                  signer,
+		EncryptionKeyManager:    encMgr,
+		ReadPermissionGrantID:   readGrantID,
+		WritePermissionGrantID:  writeGrantID,
+		DeletePermissionGrantID: deleteGrantID,
+		KeyDeliveryGrantID:      keyDeliveryGrantID,
+		UseContextEncryption:    useContextEncryption,
 	})
 	if err != nil {
 		logger.Warn("preauth approval failed", slog.Any("error", err))
@@ -2845,7 +5530,7 @@ func approvePreAuthRequests(ctx context.Context, ns *state.NetworkState, signer 
 	}
 }
 
-func runPreAuthApprovalLoop(ctx context.Context, stop <-chan struct{}, interval time.Duration, ns *state.NetworkState, signer *dwn.Signer, encMgr *dwncrypto.EncryptionKeyManager, logger *slog.Logger) {
+func runPreAuthApprovalLoop(ctx context.Context, stop <-chan struct{}, interval time.Duration, ns *state.NetworkState, signer *dwn.Signer, encMgr *dwncrypto.EncryptionKeyManager, logger *slog.Logger, readGrantID, writeGrantID, deleteGrantID, keyDeliveryGrantID string, useContextEncryption bool) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
@@ -2856,7 +5541,7 @@ func runPreAuthApprovalLoop(ctx context.Context, stop <-chan struct{}, interval 
 		case <-stop:
 			return
 		case <-ticker.C:
-			approvePreAuthRequests(ctx, ns, signer, encMgr, logger)
+			approvePreAuthRequests(ctx, ns, signer, encMgr, logger, readGrantID, writeGrantID, deleteGrantID, keyDeliveryGrantID, useContextEncryption)
 		}
 	}
 }
@@ -2943,6 +5628,290 @@ func cmdAuthLogin(ctx context.Context, args []string) error {
 	return nil
 }
 
+type authConnectOptions struct {
+	profileName string
+	requestOut  string
+	responseIn  string
+	walletURL   string
+	noWait      bool
+	admin       bool
+}
+
+// cmdAuthConnect creates or imports a wallet connection for a CLI profile.
+//
+// Usage:
+//
+//	meshd auth connect [name] [--admin] [--request-out <file>] [--wallet <url>] [--no-wait]
+//	meshd auth connect [name] --response <file>
+func cmdAuthConnect(ctx context.Context, args []string, flagProfile string) error {
+	opts, err := parseAuthConnectArgs(args)
+	if err != nil {
+		return err
+	}
+	profileFlag := firstNonEmpty(opts.profileName, flagProfile)
+
+	if opts.responseIn != "" {
+		return importAuthConnectResponse(ctx, profileFlag, opts.responseIn)
+	}
+	return createAuthConnectRequest(ctx, profileFlag, opts)
+}
+
+func parseAuthConnectArgs(args []string) (authConnectOptions, error) {
+	opts := authConnectOptions{
+		walletURL: "https://wallet.enbox.id",
+	}
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--request-out":
+			if i+1 >= len(args) {
+				return opts, fmt.Errorf("--request-out requires a path")
+			}
+			opts.requestOut = args[i+1]
+			i++
+		case "--response":
+			if i+1 >= len(args) {
+				return opts, fmt.Errorf("--response requires a path")
+			}
+			opts.responseIn = args[i+1]
+			i++
+		case "--wallet":
+			if i+1 >= len(args) {
+				return opts, fmt.Errorf("--wallet requires a URL")
+			}
+			opts.walletURL = args[i+1]
+			i++
+		case "--no-wait":
+			opts.noWait = true
+		case "--admin":
+			opts.admin = true
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return opts, fmt.Errorf("unknown auth connect flag %q", args[i])
+			}
+			if opts.profileName == "" {
+				opts.profileName = args[i]
+			} else {
+				return opts, fmt.Errorf("unexpected argument %q", args[i])
+			}
+		}
+	}
+	return opts, nil
+}
+
+func createAuthConnectRequest(ctx context.Context, profileFlag string, opts authConnectOptions) error {
+	stateDir, identity, err := ensureIdentityForCommand(ctx, profileFlag, "")
+	if err != nil {
+		return err
+	}
+	var callback *walletResponseCallback
+	if shouldWaitForWalletResponse(opts.walletURL, opts.requestOut, opts.noWait) {
+		callback, err = startWalletResponseCallback()
+		if err != nil {
+			return err
+		}
+		defer callback.close()
+	}
+	var relay *walletResponseRelay
+	if shouldUseWalletResponseRelay(opts.walletURL, opts.requestOut, opts.noWait) {
+		relay, err = setupWalletResponseRelay(ctx, walletResponseEndpoint(""), identity)
+		if err != nil {
+			fmt.Printf("  Warning: wallet response handoff unavailable: %v\n", err)
+			relay = nil
+		}
+	}
+	profileName := profileNameForWrite(profileFlag)
+	delegateIdentity, err := ensureWalletDelegateIdentity(stateDir)
+	if err != nil {
+		return err
+	}
+	req, err := walletconnect.NewRequest(profileName, identity, delegateIdentity)
+	if err != nil {
+		return err
+	}
+	if opts.admin {
+		req.Permissions = appendUniqueStrings(req.Permissions, "mesh-admin")
+	}
+	if callback != nil {
+		req.CallbackURL = callback.url
+	}
+	if relay != nil {
+		req.ResponseEndpoint = relay.endpoint
+		req.ResponseToken = relay.token
+	}
+	if err := walletconnect.SignRequest(identity, &req); err != nil {
+		return err
+	}
+	requestURL, err := walletconnect.EncodeRequest(req)
+	if err != nil {
+		return err
+	}
+	if opts.requestOut != "" {
+		data, err := json.MarshalIndent(req, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal wallet request: %w", err)
+		}
+		if err := os.WriteFile(opts.requestOut, data, 0600); err != nil {
+			return fmt.Errorf("write wallet request: %w", err)
+		}
+	}
+
+	fmt.Println("Wallet connect request created.")
+	fmt.Printf("  Profile: %s\n", profileName)
+	fmt.Printf("  Node DID: %s\n", identity.URI)
+	fmt.Printf("  Delegate DID: %s\n", delegateIdentity.URI)
+	if opts.admin {
+		fmt.Printf("  Access: node runtime + admin control\n")
+	} else {
+		fmt.Printf("  Access: node runtime\n")
+	}
+	fmt.Printf("  State: %s\n", stateDir)
+	if opts.requestOut != "" {
+		fmt.Printf("  Request: %s\n", opts.requestOut)
+	}
+	if relay != nil {
+		fmt.Printf("  Response handoff: %s\n", relay.endpoint)
+	}
+	fmt.Printf("\nRequest URL:\n  %s\n", requestURL)
+	if opts.walletURL != "" {
+		walletURL := strings.TrimRight(opts.walletURL, "/") + "/meshd/connect?request=" + url.QueryEscape(requestURL)
+		printWalletURL(walletURL, callback != nil, relay != nil)
+	}
+	if callback == nil && relay == nil {
+		fmt.Printf("\nAfter wallet approval, save the response JSON and run:\n")
+		fmt.Printf("  meshd auth connect %s --response <response.json>\n", profileName)
+		return nil
+	}
+	fmt.Printf("\nWaiting for wallet approval...\n")
+	data, err := waitForWalletDelivery(ctx, callback, relay, identity)
+	if err != nil {
+		return err
+	}
+	return importAuthConnectResponseData(ctx, profileFlag, data)
+}
+
+func importAuthConnectResponse(ctx context.Context, profileFlag string, responsePath string) error {
+	var data []byte
+	var err error
+	if responsePath == "-" {
+		data, err = io.ReadAll(os.Stdin)
+	} else {
+		data, err = os.ReadFile(responsePath)
+	}
+	if err != nil {
+		return fmt.Errorf("read wallet response: %w", err)
+	}
+	return importAuthConnectResponseData(ctx, profileFlag, data)
+}
+
+func importAuthConnectResponseData(ctx context.Context, profileFlag string, data []byte) error {
+	var resp walletconnect.Response
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return fmt.Errorf("parse wallet response: %w", err)
+	}
+	if err := resp.Validate(); err != nil {
+		return err
+	}
+	resp.NormalizeOwnerDID()
+	ownerDID := resp.EffectiveOwnerDID()
+	profileFlag = firstNonEmpty(profileFlag, resp.ProfileName)
+	stateDir, identity, err := ensureIdentityForCommand(ctx, profileFlag, "")
+	if err != nil {
+		return err
+	}
+	if resp.NodeDID != identity.URI {
+		return fmt.Errorf("wallet response node DID %s does not match local node DID %s", resp.NodeDID, identity.URI)
+	}
+
+	password, err := vaultPasswordForUnlock(stateDir)
+	if err != nil {
+		return err
+	}
+	if _, err := requireWalletResponseDelegateIdentity(stateDir, resp.DelegateDID, resp.NodeDID, "wallet response"); err != nil {
+		return err
+	}
+	nodeContextKeys := resp.EffectiveNodeContextKeys()
+	nodeProtocols := resp.EffectiveNodeMultiPartyProtocols()
+	session := &state.WalletSession{
+		Version:                 1,
+		OwnerDID:                ownerDID,
+		ConnectedDID:            ownerDID,
+		DelegateDID:             resp.DelegateDID,
+		NodeDID:                 resp.NodeDID,
+		WalletOrigin:            resp.WalletOrigin,
+		ExpiresAt:               resp.ExpiresAt,
+		Grants:                  resp.Grants,
+		NodeContextKeys:         nodeContextKeys,
+		NodeMultiPartyProtocols: nodeProtocols,
+		DelegateDecryptionKeys:  resp.DelegateDecryptionKeys,
+	}
+	if err := state.StoreWalletSession(stateDir, password, session); err != nil {
+		return err
+	}
+	importedContextKeys, err := storeWalletNodeContextKeys(stateDir, password, nodeContextKeys)
+	if err != nil {
+		return err
+	}
+
+	if os.Getenv("MESHD_STATE_DIR") == "" {
+		profileName := profileNameForWrite(profileFlag)
+		if err := profile.UpsertProfileEntry(&profile.Entry{
+			Name:         profileName,
+			DID:          identity.URI,
+			AuthType:     profile.AuthTypeWalletAuthorizedNode,
+			OwnerDID:     ownerDID,
+			ConnectedDID: ownerDID,
+			DelegateDID:  resp.DelegateDID,
+			NodeDID:      identity.URI,
+			WalletOrigin: resp.WalletOrigin,
+			ExpiresAt:    resp.ExpiresAt,
+		}); err != nil {
+			return fmt.Errorf("saving wallet-connected profile: %w", err)
+		}
+	}
+
+	fmt.Println("Wallet connection imported.")
+	fmt.Printf("  Wallet Owner DID: %s\n", ownerDID)
+	if resp.DelegateDID != "" {
+		fmt.Printf("  Session Delegate DID: %s\n", resp.DelegateDID)
+	}
+	fmt.Printf("  Node DID: %s\n", resp.NodeDID)
+	fmt.Printf("  Session: encrypted\n")
+	if importedContextKeys > 0 {
+		fmt.Printf("  Context keys: %d imported\n", importedContextKeys)
+	}
+	return nil
+}
+
+func storeWalletNodeContextKeys(stateDir string, password string, rawKeys []json.RawMessage) (int, error) {
+	imported := 0
+	for _, raw := range rawKeys {
+		var entry struct {
+			Protocol          string          `json:"protocol"`
+			ContextID         string          `json:"contextId"`
+			DerivedPrivateKey json.RawMessage `json:"derivedPrivateKey"`
+		}
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			return imported, fmt.Errorf("parse node context key: %w", err)
+		}
+		if entry.Protocol != protocols.MeshProtocolURI || entry.ContextID == "" {
+			continue
+		}
+		contextKey, err := dwncrypto.ParseDerivedPrivateJwk(entry.DerivedPrivateKey)
+		if err != nil {
+			return imported, fmt.Errorf("parse mesh context key %s: %w", entry.ContextID, err)
+		}
+		privateKey, err := contextKey.PrivateKeyBytes()
+		if err != nil {
+			return imported, fmt.Errorf("decode mesh context key %s: %w", entry.ContextID, err)
+		}
+		if err := state.StoreContextKey(stateDir, password, entry.ContextID, privateKey); err != nil {
+			return imported, err
+		}
+		imported++
+	}
+	return imported, nil
+}
+
 // cmdAuthList lists all identity profiles.
 func cmdAuthList() error {
 	cfg, err := profile.ReadConfig()
@@ -2966,7 +5935,14 @@ func cmdAuthList() error {
 			suffix = " (default)"
 		}
 		fmt.Printf("%s%s%s\n", marker, entry.Name, suffix)
-		fmt.Printf("    DID:     %s\n", entry.DID)
+		fmt.Printf("    Node:    %s\n", entry.EffectiveNodeDID())
+		fmt.Printf("    Auth:    %s\n", authDisplayName(entry.EffectiveAuthType()))
+		if ownerDID := entry.EffectiveOwnerDID(); ownerDID != "" && ownerDID != entry.DID {
+			fmt.Printf("    Owner:   %s\n", ownerDID)
+		}
+		if entry.DelegateDID != "" {
+			fmt.Printf("    Session: %s\n", entry.DelegateDID)
+		}
 		fmt.Printf("    Created: %s\n", entry.CreatedAt)
 		fmt.Println()
 	}
@@ -3087,17 +6063,24 @@ func cmdACLSet(ctx context.Context, args []string, flagProfile string) error {
 		return fmt.Errorf("not in a network. Use 'meshd network create' first.")
 	}
 
-	// Verify this is the anchor node.
-	if identity.URI != ns.AnchorDID {
-		return fmt.Errorf("only the network anchor can set ACL policy (you: %s, anchor: %s)",
-			truncate(identity.URI, 40), truncate(ns.AnchorDID, 40))
+	meta, useContextEncryption, err := requireNetworkOwnerProfile(flagProfile, identity, ns)
+	if err != nil {
+		return err
 	}
 
-	signer := &dwn.Signer{
-		DID:        identity.URI,
-		PrivateKey: identity.SigningKey,
+	operationIdentity, err := loadDWNOperationIdentity(stateDir, meta, identity)
+	if err != nil {
+		return err
 	}
-	encMgr := newEncryptionKeyManager(identity)
+	signer := dwnSigner(operationIdentity)
+	encMgr, err := prepareNetworkCommandEncryption(stateDir, identity, ns, useContextEncryption)
+	if err != nil {
+		return err
+	}
+	writeGrantID, err := walletGrantIDForDWNOperation(stateDir, meta, dwn.InterfaceRecordsWrite, protocols.MeshProtocolURI, "", ns.NetworkRecordID, useContextEncryption)
+	if err != nil {
+		return err
+	}
 
 	if err := mesh.WriteACLPolicy(ctx, mesh.WriteACLPolicyParams{
 		AnchorEndpoint:       ns.AnchorEndpoint,
@@ -3105,6 +6088,8 @@ func cmdACLSet(ctx context.Context, args []string, flagProfile string) error {
 		NetworkRecordID:      ns.NetworkRecordID,
 		Signer:               signer,
 		EncryptionKeyManager: encMgr,
+		PermissionGrantID:    writeGrantID,
+		UseContextEncryption: useContextEncryption,
 		PolicyData:           policyBytes,
 	}); err != nil {
 		return err
@@ -3135,10 +6120,12 @@ func cmdACLShow(ctx context.Context, args []string, flagProfile string) error {
 		return fmt.Errorf("not in a network. Use 'meshd network join' first.")
 	}
 
-	signer := &dwn.Signer{
-		DID:        identity.URI,
-		PrivateKey: identity.SigningKey,
+	meta := resolveIdentityMetadata(flagProfile, identity.URI)
+	operationIdentity, err := loadDWNOperationIdentity(stateDir, meta, identity)
+	if err != nil {
+		return err
 	}
+	signer := dwnSigner(operationIdentity)
 	encMgr := newEncryptionKeyManager(identity)
 
 	// Load context key for decryption. Try cached key first, then DWN fetch.
@@ -3171,6 +6158,10 @@ func cmdACLShow(ctx context.Context, args []string, flagProfile string) error {
 	if ns.AnchorDID != identity.URI {
 		aclQueryRole = "network/node"
 	}
+	readGrantID, err := walletGrantIDForDWNOperation(stateDir, meta, dwn.InterfaceRecordsQuery, protocols.MeshProtocolURI, "", ns.NetworkRecordID, false)
+	if err != nil {
+		return err
+	}
 
 	client := control.NewDWNClient(
 		ns.AnchorEndpoint,
@@ -3180,6 +6171,7 @@ func cmdACLShow(ctx context.Context, args []string, flagProfile string) error {
 		signer,
 		control.WithEncryptionKeyManager(encMgr),
 		control.WithProtocolRole(aclQueryRole),
+		control.WithPermissionGrantID(readGrantID),
 	)
 
 	// Load state (which now includes ACL policy).
@@ -3212,4 +6204,33 @@ func truncate(s string, maxLen int) string {
 		return s[:maxLen]
 	}
 	return s[:maxLen-3] + "..."
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func appendUniqueStrings(values []string, next ...string) []string {
+	for _, candidate := range next {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		exists := false
+		for _, value := range values {
+			if value == candidate {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			values = append(values, candidate)
+		}
+	}
+	return values
 }

--- a/cmd/meshd/main_test.go
+++ b/cmd/meshd/main_test.go
@@ -1,23 +1,34 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/enboxorg/meshd/internal/control"
 	"github.com/enboxorg/meshd/internal/did"
+	"github.com/enboxorg/meshd/internal/dwn"
+	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
 	"github.com/enboxorg/meshd/internal/invite"
 	"github.com/enboxorg/meshd/internal/mesh"
 	"github.com/enboxorg/meshd/internal/profile"
 	"github.com/enboxorg/meshd/internal/state"
+	"github.com/enboxorg/meshd/internal/vault"
+	"github.com/enboxorg/meshd/internal/walletconnect"
+	"github.com/enboxorg/meshd/protocols"
 )
 
 func TestParseUpFlagsInviteURL(t *testing.T) {
@@ -26,12 +37,47 @@ func TestParseUpFlagsInviteURL(t *testing.T) {
 		t.Fatalf("Encode: %v", err)
 	}
 
-	flags := parseUpFlags([]string{u, "--no-tun"})
+	flags := parseUpFlags([]string{u, "--owner", "did:dht:wallet", "--no-tun"})
 	if flags.inviteURL != u {
 		t.Fatalf("inviteURL = %q, want %q", flags.inviteURL, u)
 	}
+	if flags.ownerDID != "did:dht:wallet" {
+		t.Fatalf("ownerDID = %q", flags.ownerDID)
+	}
 	if !flags.noTun {
 		t.Fatal("expected --no-tun to be parsed")
+	}
+}
+
+func TestPromptInteractiveJoinAcceptsInviteFirst(t *testing.T) {
+	u, err := invite.Encode(invite.New("https://dwn.example.com", "did:jwk:anchor", "net", "home", "", "", ""))
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	got, err := promptInteractiveJoin(bufio.NewScanner(strings.NewReader(u+"\n")), "")
+	if err != nil {
+		t.Fatalf("promptInteractiveJoin: %v", err)
+	}
+	if got.inviteURL != u {
+		t.Fatalf("inviteURL = %q, want %q", got.inviteURL, u)
+	}
+	if got.endpoint != "" || got.anchorDID != "" || got.networkID != "" {
+		t.Fatalf("manual fields should be empty for invite join: %+v", got)
+	}
+}
+
+func TestPromptInteractiveJoinFallsBackToManualDetails(t *testing.T) {
+	input := "\nhttps://dwn.example.com\ndid:jwk:anchor\nnetwork-1\n"
+	got, err := promptInteractiveJoin(bufio.NewScanner(strings.NewReader(input)), "")
+	if err != nil {
+		t.Fatalf("promptInteractiveJoin: %v", err)
+	}
+	if got.inviteURL != "" {
+		t.Fatalf("inviteURL = %q, want empty", got.inviteURL)
+	}
+	if got.endpoint != "https://dwn.example.com" || got.anchorDID != "did:jwk:anchor" || got.networkID != "network-1" {
+		t.Fatalf("manual join input = %+v", got)
 	}
 }
 
@@ -71,6 +117,522 @@ func TestPeerListDeviceLabelsSelf(t *testing.T) {
 	}
 	if got := peerListDevice("", selfDID); got != "peer" {
 		t.Fatalf("peerListDevice(empty) = %q, want peer", got)
+	}
+}
+
+func TestPeerListOwner(t *testing.T) {
+	const (
+		nodeDID  = "did:jwk:node"
+		ownerDID = "did:jwk:wallet"
+	)
+	if got := peerListOwner(nodeDID, "", nodeDID, ownerDID); got != ownerDID {
+		t.Fatalf("peerListOwner(self fallback) = %q, want %q", got, ownerDID)
+	}
+	if got := peerListOwner(nodeDID, ownerDID, "", ""); got != ownerDID {
+		t.Fatalf("peerListOwner(record owner) = %q, want %q", got, ownerDID)
+	}
+	if got := peerListOwner(nodeDID, "", "", ""); got != "node" {
+		t.Fatalf("peerListOwner(local-only) = %q, want node", got)
+	}
+	if got := peerListOwner(nodeDID, nodeDID, "", ""); got != "node" {
+		t.Fatalf("peerListOwner(same as node) = %q, want node", got)
+	}
+}
+
+func TestKeyDeliveryForNode(t *testing.T) {
+	selfKey := &dwncrypto.KeyDeliveryPublic{RootKeyID: "did:jwk:self#1"}
+	peerKey := &dwncrypto.KeyDeliveryPublic{RootKeyID: "did:jwk:peer#1"}
+	resp := &control.MapResponse{
+		Node: &control.Node{
+			DID:         "did:jwk:self",
+			KeyDelivery: selfKey,
+		},
+		Peers: []*control.Node{
+			{DID: "did:jwk:peer", KeyDelivery: peerKey},
+		},
+	}
+
+	if got := keyDeliveryForNode(resp, "did:jwk:self"); got != selfKey {
+		t.Fatalf("self key = %+v, want %+v", got, selfKey)
+	}
+	if got := keyDeliveryForNode(resp, "did:jwk:peer"); got != peerKey {
+		t.Fatalf("peer key = %+v, want %+v", got, peerKey)
+	}
+	if got := keyDeliveryForNode(resp, "did:jwk:missing"); got != nil {
+		t.Fatalf("missing key = %+v, want nil", got)
+	}
+	if got := keyDeliveryForNode(nil, "did:jwk:peer"); got != nil {
+		t.Fatalf("nil response key = %+v, want nil", got)
+	}
+}
+
+func TestRouteInterfaceParsesPlatformOutput(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{
+			name:   "linux ip route",
+			output: "10.200.43.197 dev meshd0 src 10.200.26.192 uid 1000\n    cache\n",
+			want:   "meshd0",
+		},
+		{
+			name: "darwin route get",
+			output: `   route to: 10.200.26.192
+destination: 10.200.26.192
+  interface: utun7
+`,
+			want: "utun7",
+		},
+		{
+			name:   "missing",
+			output: "default via 100.64.0.1\n",
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := routeInterface(tt.output); got != tt.want {
+				t.Fatalf("routeInterface() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+	if !routeUsesInterface("10.200.43.197 dev meshd0 src 10.200.26.192", "meshd0") {
+		t.Fatal("expected routeUsesInterface to match meshd0")
+	}
+	if routeUsesInterface("10.200.43.197 dev tailscale0 src 100.64.0.1", "meshd0") {
+		t.Fatal("expected routeUsesInterface to reject tailscale0")
+	}
+}
+
+func TestPrintDoctorCheck(t *testing.T) {
+	var buf bytes.Buffer
+	printDoctorCheck(&buf, doctorCheck{
+		Level:  doctorFail,
+		Title:  "Peer route does not use meshd TUN",
+		Detail: "10.200.26.192 routes via tailscale0, not meshd0",
+		Next:   "Run 'meshd down' and then 'meshd up'.",
+	})
+	got := buf.String()
+	for _, want := range []string{
+		"[fail] Peer route does not use meshd TUN",
+		"10.200.26.192 routes via tailscale0, not meshd0",
+		"Next: Run 'meshd down' and then 'meshd up'.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("doctor output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestBuildAdminURL(t *testing.T) {
+	rawURL := buildAdminURL("https://meshd-admin.pages.dev/", adminContext{
+		OwnerDID:        "did:dht:wallet",
+		NetworkRecordID: "network-1",
+	})
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := parsed.Scheme + "://" + parsed.Host + parsed.Path; got != "https://meshd-admin.pages.dev" {
+		t.Fatalf("admin URL base = %q", got)
+	}
+	if got := parsed.Query().Get("owner"); got != "did:dht:wallet" {
+		t.Fatalf("owner query = %q", got)
+	}
+	if got := parsed.Query().Get("network"); got != "network-1" {
+		t.Fatalf("network query = %q", got)
+	}
+	if got := buildAdminURL("", adminContext{}); got != "https://meshd-admin.pages.dev" {
+		t.Fatalf("default admin URL = %q", got)
+	}
+}
+
+func TestParseAdminArgs(t *testing.T) {
+	opts, err := parseAdminArgs([]string{"--dashboard", "http://127.0.0.1:5173", "--print"})
+	if err != nil {
+		t.Fatalf("parseAdminArgs: %v", err)
+	}
+	if opts.dashboardURL != "http://127.0.0.1:5173" || !opts.printOnly {
+		t.Fatalf("admin opts = %+v", opts)
+	}
+	if _, err := parseAdminArgs([]string{"--wallet"}); err == nil {
+		t.Fatal("expected missing wallet URL to fail")
+	}
+	if _, err := parseAdminArgs([]string{"--unknown"}); err == nil {
+		t.Fatal("expected unknown flag to fail")
+	}
+}
+
+func TestCollectDoctorChecksNoProfile(t *testing.T) {
+	t.Setenv("ENBOX_HOME", t.TempDir())
+	t.Setenv("ENBOX_PROFILE", "")
+	t.Setenv("MESHD_STATE_DIR", "")
+
+	checks := collectDoctorChecks(context.Background(), "")
+	if len(checks) == 0 {
+		t.Fatal("expected at least one doctor check")
+	}
+	if checks[0].Level != doctorFail || !strings.Contains(checks[0].Title, "identity profile") {
+		t.Fatalf("first check = %+v, want missing profile failure", checks[0])
+	}
+	if !doctorHasLevel(checks, doctorFail) {
+		t.Fatal("expected doctor failure level")
+	}
+}
+
+func TestPeerListRowsFromMapResponse(t *testing.T) {
+	ns := &state.NetworkState{MeshCIDR: "10.200.0.0/16"}
+	resp := &control.MapResponse{
+		Node: &control.Node{
+			DID:       "did:jwk:self",
+			MemberDID: "did:jwk:wallet",
+			Name:      "laptop",
+			MeshIP:    netip.MustParseAddr("10.200.0.5"),
+		},
+		Peers: []*control.Node{
+			{
+				DID:            "did:jwk:peer",
+				MemberDID:      "did:jwk:wallet",
+				MemberRecordID: "member-record",
+				Name:           "server",
+				MeshIP:         netip.MustParseAddr("10.200.0.8"),
+			},
+		},
+	}
+
+	rows := peerListRowsFromMapResponse(ns, resp, "did:jwk:self", "did:jwk:wallet")
+	if len(rows) != 2 {
+		t.Fatalf("rows len = %d, want 2", len(rows))
+	}
+	if rows[0].Device != "this device" || rows[0].Owner != "did:jwk:wallet" || rows[0].Path != "network/node" {
+		t.Fatalf("self row = %+v", rows[0])
+	}
+	if rows[1].Device != "peer" || rows[1].Owner != "did:jwk:wallet" || rows[1].Path != "network/member/node" {
+		t.Fatalf("peer row = %+v", rows[1])
+	}
+	if rows[1].MeshIP != "10.200.0.8" || rows[1].Label != "server" {
+		t.Fatalf("peer row data = %+v", rows[1])
+	}
+}
+
+func TestParsePeerAddOptions(t *testing.T) {
+	opts, err := parsePeerAddOptions([]string{
+		"did:jwk:node",
+		"--owner", "did:jwk:wallet",
+		"--label", "server",
+	})
+	if err != nil {
+		t.Fatalf("parsePeerAddOptions: %v", err)
+	}
+	if opts.nodeDID != "did:jwk:node" || opts.ownerDID != "did:jwk:wallet" || opts.label != "server" {
+		t.Fatalf("options = %+v", opts)
+	}
+
+	legacyOpts, err := parsePeerAddOptions([]string{"did:jwk:node", "--member", "did:jwk:wallet"})
+	if err != nil {
+		t.Fatalf("parsePeerAddOptions member alias: %v", err)
+	}
+	if legacyOpts.ownerDID != "did:jwk:wallet" {
+		t.Fatalf("member alias ownerDID = %q", legacyOpts.ownerDID)
+	}
+
+	if _, err := parsePeerAddOptions([]string{"--member", "did:jwk:wallet"}); err == nil {
+		t.Fatal("parsePeerAddOptions without node DID succeeded")
+	}
+}
+
+func TestParsePeerRemoveOptions(t *testing.T) {
+	opts, err := parsePeerRemoveOptions([]string{"did:jwk:node"})
+	if err != nil {
+		t.Fatalf("parsePeerRemoveOptions: %v", err)
+	}
+	if opts.nodeDID != "did:jwk:node" {
+		t.Fatalf("nodeDID = %q", opts.nodeDID)
+	}
+	if _, err := parsePeerRemoveOptions(nil); err == nil {
+		t.Fatal("parsePeerRemoveOptions without node DID succeeded")
+	}
+	if _, err := parsePeerRemoveOptions([]string{"did:jwk:node", "extra"}); err == nil {
+		t.Fatal("parsePeerRemoveOptions with extra argument succeeded")
+	}
+	if _, err := parsePeerRemoveOptions([]string{"--force", "did:jwk:node"}); err == nil {
+		t.Fatal("parsePeerRemoveOptions with unknown flag succeeded")
+	}
+}
+
+func TestPeerRemoveCandidateFromRecord(t *testing.T) {
+	candidate, ok := peerRemoveCandidateFromRecord(&dwn.Record{
+		ID:           "node-record",
+		ProtocolPath: "network/node",
+	}, "")
+	if !ok {
+		t.Fatal("top-level candidate not returned")
+	}
+	if candidate.RecordID != "node-record" || candidate.Path != "network/node" || candidate.MemberRecordID != "" {
+		t.Fatalf("top-level candidate = %+v", candidate)
+	}
+
+	memberCandidate, ok := peerRemoveCandidateFromRecord(&dwn.Record{
+		ID: "member-node-record",
+	}, "member-record")
+	if !ok {
+		t.Fatal("member candidate not returned")
+	}
+	if memberCandidate.Path != "network/member/node" || memberCandidate.MemberRecordID != "member-record" {
+		t.Fatalf("member candidate = %+v", memberCandidate)
+	}
+
+	if _, ok := peerRemoveCandidateFromRecord(&dwn.Record{}, ""); ok {
+		t.Fatal("empty record candidate returned")
+	}
+	if _, ok := peerRemoveCandidateFromRecord(nil, ""); ok {
+		t.Fatal("nil record candidate returned")
+	}
+}
+
+func TestDeliveredContextKeyMatchesNetwork(t *testing.T) {
+	record := &dwn.Record{
+		ID: "context-key-record",
+		Tags: map[string]any{
+			"protocol":  protocols.MeshProtocolURI,
+			"contextId": "network-1",
+		},
+	}
+	if !deliveredContextKeyMatchesNetwork(record, "network-1") {
+		t.Fatal("expected matching context key record")
+	}
+	if deliveredContextKeyMatchesNetwork(record, "network-2") {
+		t.Fatal("matched wrong network")
+	}
+	record.Tags["protocol"] = protocols.KeyDeliveryProtocolURI
+	if deliveredContextKeyMatchesNetwork(record, "network-1") {
+		t.Fatal("matched wrong source protocol")
+	}
+	if deliveredContextKeyMatchesNetwork(&dwn.Record{ID: "missing-tags"}, "network-1") {
+		t.Fatal("matched missing tags")
+	}
+	if deliveredContextKeyMatchesNetwork(nil, "network-1") {
+		t.Fatal("matched nil record")
+	}
+}
+
+func TestAuthDisplayName(t *testing.T) {
+	tests := []struct {
+		name     string
+		authType string
+		want     string
+	}{
+		{name: "default", authType: "", want: "local vault"},
+		{name: "local", authType: profile.AuthTypeLocalVault, want: "local vault"},
+		{name: "wallet", authType: profile.AuthTypeWalletAuthorizedNode, want: "wallet-authorized node"},
+		{name: "legacy wallet", authType: profile.AuthTypeWalletDelegate, want: "wallet-authorized node"},
+		{name: "unknown", authType: "custom", want: "custom"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := authDisplayName(tt.authType); got != tt.want {
+				t.Fatalf("authDisplayName(%q) = %q, want %q", tt.authType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadWalletSessionStatus(t *testing.T) {
+	resetVaultPasswordCache(t)
+
+	stateDir := t.TempDir()
+	t.Setenv(vaultPasswordEnv, "test-password")
+	if err := state.StoreWalletSession(stateDir, "test-password", &state.WalletSession{
+		Version:                 1,
+		OwnerDID:                "did:dht:wallet",
+		DelegateDID:             "did:jwk:control",
+		NodeDID:                 "did:jwk:node",
+		WalletOrigin:            "https://wallet.enbox.id",
+		ExpiresAt:               "2999-01-01T00:00:00Z",
+		Grants:                  []json.RawMessage{json.RawMessage(`{"id":"grant-1"}`), json.RawMessage(`{"id":"grant-2"}`)},
+		NodeContextKeys:         []json.RawMessage{json.RawMessage(`{"contextId":"network-1"}`)},
+		NodeMultiPartyProtocols: []string{protocols.MeshProtocolURI},
+	}); err != nil {
+		t.Fatalf("StoreWalletSession: %v", err)
+	}
+
+	status, err := loadWalletSessionStatus(stateDir, identityMetadata{
+		AuthType: profile.AuthTypeWalletAuthorizedNode,
+		OwnerDID: "did:dht:wallet",
+		NodeDID:  "did:jwk:node",
+	})
+	if err != nil {
+		t.Fatalf("loadWalletSessionStatus: %v", err)
+	}
+	if !status.Exists || status.GrantCount != 2 || status.NodeContextKeyCount != 1 || status.NodeProtocolCount != 1 {
+		t.Fatalf("wallet session status = %+v", status)
+	}
+	if status.DelegateDID != "did:jwk:control" || status.LegacyDelegateKeyFields {
+		t.Fatalf("wallet session metadata = %+v", status)
+	}
+	if status.OwnerDIDMismatch || status.NodeDIDMismatch {
+		t.Fatalf("unexpected mismatch = %+v", status)
+	}
+}
+
+func TestLoadWalletSessionStatusReportsRuntimeAndAdminAccess(t *testing.T) {
+	resetVaultPasswordCache(t)
+
+	stateDir := t.TempDir()
+	t.Setenv(vaultPasswordEnv, "test-password")
+	meta := identityMetadata{
+		AuthType: profile.AuthTypeWalletAuthorizedNode,
+		OwnerDID: "did:dht:wallet",
+		NodeDID:  "did:jwk:node",
+	}
+	runtimeGrants := []json.RawMessage{
+		testWalletPermissionGrant(t, "mesh-read", meta.OwnerDID, meta.NodeDID, map[string]any{
+			"interface": "Records",
+			"method":    "Read",
+			"protocol":  protocols.MeshProtocolURI,
+		}),
+		testWalletPermissionGrant(t, "node-info-write", meta.OwnerDID, meta.NodeDID, map[string]any{
+			"interface":    "Records",
+			"method":       "Write",
+			"protocol":     protocols.MeshProtocolURI,
+			"protocolPath": "network/node/nodeInfo",
+		}),
+		testWalletPermissionGrant(t, "node-endpoint-write", meta.OwnerDID, meta.NodeDID, map[string]any{
+			"interface":    "Records",
+			"method":       "Write",
+			"protocol":     protocols.MeshProtocolURI,
+			"protocolPath": "network/node/endpoint",
+		}),
+		testWalletPermissionGrant(t, "member-node-info-write", meta.OwnerDID, meta.NodeDID, map[string]any{
+			"interface":    "Records",
+			"method":       "Write",
+			"protocol":     protocols.MeshProtocolURI,
+			"protocolPath": "network/member/node/nodeInfo",
+		}),
+		testWalletPermissionGrant(t, "member-node-endpoint-write", meta.OwnerDID, meta.NodeDID, map[string]any{
+			"interface":    "Records",
+			"method":       "Write",
+			"protocol":     protocols.MeshProtocolURI,
+			"protocolPath": "network/member/node/endpoint",
+		}),
+		testWalletPermissionGrant(t, "key-delivery-read", meta.OwnerDID, meta.NodeDID, map[string]any{
+			"interface": "Records",
+			"method":    "Read",
+			"protocol":  protocols.KeyDeliveryProtocolURI,
+		}),
+	}
+
+	if err := state.StoreWalletSession(stateDir, "test-password", &state.WalletSession{
+		Version:  1,
+		OwnerDID: meta.OwnerDID,
+		NodeDID:  meta.NodeDID,
+		Grants:   runtimeGrants,
+	}); err != nil {
+		t.Fatalf("StoreWalletSession runtime: %v", err)
+	}
+	status, err := loadWalletSessionStatus(stateDir, meta)
+	if err != nil {
+		t.Fatalf("loadWalletSessionStatus runtime: %v", err)
+	}
+	if !status.NodeRuntimeAccess {
+		t.Fatalf("runtime access = false, status = %+v", status)
+	}
+	if status.AdminControlAccess {
+		t.Fatalf("admin access = true for runtime grants, status = %+v", status)
+	}
+
+	adminGrants := append([]json.RawMessage{}, runtimeGrants...)
+	adminGrants = append(adminGrants,
+		testWalletPermissionGrant(t, "mesh-write", meta.OwnerDID, meta.NodeDID, map[string]any{
+			"interface": "Records",
+			"method":    "Write",
+			"protocol":  protocols.MeshProtocolURI,
+		}),
+		testWalletPermissionGrant(t, "mesh-delete", meta.OwnerDID, meta.NodeDID, map[string]any{
+			"interface": "Records",
+			"method":    "Delete",
+			"protocol":  protocols.MeshProtocolURI,
+		}),
+		testWalletPermissionGrant(t, "key-delivery-write", meta.OwnerDID, meta.NodeDID, map[string]any{
+			"interface": "Records",
+			"method":    "Write",
+			"protocol":  protocols.KeyDeliveryProtocolURI,
+		}),
+		testWalletPermissionGrant(t, "key-delivery-delete", meta.OwnerDID, meta.NodeDID, map[string]any{
+			"interface": "Records",
+			"method":    "Delete",
+			"protocol":  protocols.KeyDeliveryProtocolURI,
+		}),
+	)
+	if err := state.StoreWalletSession(stateDir, "test-password", &state.WalletSession{
+		Version:  1,
+		OwnerDID: meta.OwnerDID,
+		NodeDID:  meta.NodeDID,
+		Grants:   adminGrants,
+	}); err != nil {
+		t.Fatalf("StoreWalletSession admin: %v", err)
+	}
+	status, err = loadWalletSessionStatus(stateDir, meta)
+	if err != nil {
+		t.Fatalf("loadWalletSessionStatus admin: %v", err)
+	}
+	if !status.NodeRuntimeAccess || !status.AdminControlAccess {
+		t.Fatalf("admin status = %+v, want runtime and admin access", status)
+	}
+}
+
+func TestLoadWalletSessionStatusLegacyDelegateContextKeys(t *testing.T) {
+	resetVaultPasswordCache(t)
+
+	stateDir := t.TempDir()
+	t.Setenv(vaultPasswordEnv, "test-password")
+	legacySession, err := json.Marshal(map[string]any{
+		"version":                     1,
+		"connectedDid":                "did:dht:wallet-a",
+		"nodeDid":                     "did:jwk:node-a",
+		"delegateContextKeys":         []json.RawMessage{json.RawMessage(`{"contextId":"network-1"}`)},
+		"delegateMultiPartyProtocols": []string{protocols.MeshProtocolURI},
+	})
+	if err != nil {
+		t.Fatalf("Marshal legacy session: %v", err)
+	}
+	sealed, err := vault.Seal(legacySession, "test-password")
+	if err != nil {
+		t.Fatalf("Seal legacy session: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "session.vault.json"), sealed, 0600); err != nil {
+		t.Fatalf("write legacy session: %v", err)
+	}
+
+	status, err := loadWalletSessionStatus(stateDir, identityMetadata{
+		AuthType: profile.AuthTypeWalletAuthorizedNode,
+		OwnerDID: "did:dht:wallet-b",
+		NodeDID:  "did:jwk:node-b",
+	})
+	if err != nil {
+		t.Fatalf("loadWalletSessionStatus: %v", err)
+	}
+	if !status.Exists || status.NodeContextKeyCount != 1 || status.NodeProtocolCount != 1 {
+		t.Fatalf("legacy wallet session status = %+v", status)
+	}
+	if !status.LegacyDelegateKeyFields || !status.OwnerDIDMismatch || !status.NodeDIDMismatch {
+		t.Fatalf("legacy/mismatch flags = %+v", status)
+	}
+}
+
+func TestLoadWalletSessionStatusMissing(t *testing.T) {
+	status, err := loadWalletSessionStatus(t.TempDir(), identityMetadata{
+		AuthType: profile.AuthTypeWalletAuthorizedNode,
+	})
+	if err != nil {
+		t.Fatalf("loadWalletSessionStatus: %v", err)
+	}
+	if status == nil || status.Exists {
+		t.Fatalf("missing session status = %+v", status)
 	}
 }
 
@@ -301,6 +863,205 @@ func TestParseNetworkCreateArgsUsesEndpointEnv(t *testing.T) {
 	}
 }
 
+func TestParseNetworkCreateOptionsWalletFlags(t *testing.T) {
+	t.Setenv("DWN_ENDPOINT", "")
+
+	opts, err := parseNetworkCreateOptions([]string{
+		"home",
+		"--endpoint", "https://dev.aws.dwn.enbox.id",
+		"--cidr", "10.201.0.0/16",
+		"--request-out", "request.json",
+		"--wallet", "https://wallet.enbox.id",
+	})
+	if err != nil {
+		t.Fatalf("parseNetworkCreateOptions: %v", err)
+	}
+	if opts.name != "home" || opts.endpoint != "https://dev.aws.dwn.enbox.id" {
+		t.Fatalf("name/endpoint = %q/%q", opts.name, opts.endpoint)
+	}
+	if opts.meshCIDR != "10.201.0.0/16" {
+		t.Fatalf("meshCIDR = %q", opts.meshCIDR)
+	}
+	if opts.requestOut != "request.json" {
+		t.Fatalf("requestOut = %q", opts.requestOut)
+	}
+	if opts.walletURL != "https://wallet.enbox.id" {
+		t.Fatalf("walletURL = %q", opts.walletURL)
+	}
+}
+
+func TestWalletResponseCallbackAcceptsPost(t *testing.T) {
+	cb, err := startWalletResponseCallback()
+	if err != nil {
+		t.Fatalf("startWalletResponseCallback: %v", err)
+	}
+	defer cb.close()
+
+	preflight, err := http.NewRequest(http.MethodOptions, cb.url, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	preflight.Header.Set("Access-Control-Request-Method", "POST")
+	preflight.Header.Set("Access-Control-Request-Private-Network", "true")
+	preflightResp, err := http.DefaultClient.Do(preflight)
+	if err != nil {
+		t.Fatalf("preflight: %v", err)
+	}
+	preflightResp.Body.Close()
+	if preflightResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("preflight status = %d, want %d", preflightResp.StatusCode, http.StatusNoContent)
+	}
+	if got := preflightResp.Header.Get("Access-Control-Allow-Private-Network"); got != "true" {
+		t.Fatalf("Access-Control-Allow-Private-Network = %q, want true", got)
+	}
+
+	postResp, err := http.Post(cb.url, "application/json", strings.NewReader(`{"ok":true}`))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	postResp.Body.Close()
+	if postResp.StatusCode != http.StatusAccepted {
+		t.Fatalf("post status = %d, want %d", postResp.StatusCode, http.StatusAccepted)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	data, err := cb.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	if string(data) != `{"ok":true}` {
+		t.Fatalf("callback data = %q", data)
+	}
+}
+
+func TestBrowserOpenCommand(t *testing.T) {
+	for _, tc := range []struct {
+		goos string
+		want string
+	}{
+		{goos: "darwin", want: "open"},
+		{goos: "linux", want: "xdg-open"},
+		{goos: "windows", want: "rundll32"},
+	} {
+		t.Run(tc.goos, func(t *testing.T) {
+			got, args, ok := browserOpenCommand(tc.goos, "https://wallet.enbox.id")
+			if !ok {
+				t.Fatal("browserOpenCommand returned !ok")
+			}
+			if got != tc.want {
+				t.Fatalf("command = %q, want %q", got, tc.want)
+			}
+			if len(args) == 0 {
+				t.Fatal("expected args")
+			}
+		})
+	}
+}
+
+func TestNetworkCreateWalletAuthorizedNodeAllowsMissingEndpoint(t *testing.T) {
+	resetVaultPasswordCache(t)
+
+	home := t.TempDir()
+	t.Setenv("ENBOX_HOME", home)
+	t.Setenv("ENBOX_PROFILE", "")
+	t.Setenv("MESHD_STATE_DIR", "")
+	t.Setenv("MESHD_VAULT_PASSWORD", "test-password")
+	t.Setenv("DWN_ENDPOINT", "")
+
+	_, identity, err := ensureIdentityForCommand(context.Background(), "walleted", "")
+	if err != nil {
+		t.Fatalf("ensureIdentityForCommand: %v", err)
+	}
+	if err := profile.UpsertProfileEntry(&profile.Entry{
+		Name:     "walleted",
+		DID:      identity.URI,
+		AuthType: profile.AuthTypeWalletAuthorizedNode,
+		OwnerDID: "did:dht:wallet",
+		NodeDID:  identity.URI,
+	}); err != nil {
+		t.Fatalf("UpsertProfileEntry: %v", err)
+	}
+
+	requestFile := filepath.Join(t.TempDir(), "request.json")
+	if err := cmdNetworkCreate(context.Background(), []string{
+		"home",
+		"--request-out", requestFile,
+		"--wallet", "",
+	}, "walleted"); err != nil {
+		t.Fatalf("cmdNetworkCreate: %v", err)
+	}
+
+	data, err := os.ReadFile(requestFile)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var req walletconnect.NetworkCreateRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if req.RequestedEndpoint != "" {
+		t.Fatalf("requested endpoint = %q, want empty", req.RequestedEndpoint)
+	}
+	if req.NetworkName != "home" || req.NodeDID != identity.URI {
+		t.Fatalf("request = %+v", req)
+	}
+}
+
+func TestSetupCreateNetworkWalletAuthorizedNodeRequiresInteractiveWithoutEndpoint(t *testing.T) {
+	resetVaultPasswordCache(t)
+
+	home := t.TempDir()
+	t.Setenv("ENBOX_HOME", home)
+	t.Setenv("ENBOX_PROFILE", "")
+	t.Setenv("MESHD_STATE_DIR", "")
+	t.Setenv("MESHD_VAULT_PASSWORD", "test-password")
+	t.Setenv("DWN_ENDPOINT", "")
+
+	stateDir, identity, err := ensureIdentityForCommand(context.Background(), "walleted", "")
+	if err != nil {
+		t.Fatalf("ensureIdentityForCommand: %v", err)
+	}
+	if err := profile.UpsertProfileEntry(&profile.Entry{
+		Name:     "walleted",
+		DID:      identity.URI,
+		AuthType: profile.AuthTypeWalletAuthorizedNode,
+		OwnerDID: "did:dht:wallet",
+		NodeDID:  identity.URI,
+	}); err != nil {
+		t.Fatalf("UpsertProfileEntry: %v", err)
+	}
+
+	_, err = setupCreateNetwork(context.Background(), upFlags{createNetwork: "home"}, stateDir, identity, "walleted")
+	if err == nil || !strings.Contains(err.Error(), "wallet-owned network creation requires an interactive terminal") {
+		t.Fatalf("setupCreateNetwork error = %v, want interactive wallet create error", err)
+	}
+}
+
+func TestNetworkCreateMissingEndpointDoesNotCreateLocalIdentity(t *testing.T) {
+	resetVaultPasswordCache(t)
+
+	home := t.TempDir()
+	t.Setenv("ENBOX_HOME", home)
+	t.Setenv("ENBOX_PROFILE", "")
+	t.Setenv("MESHD_STATE_DIR", "")
+	t.Setenv("MESHD_VAULT_PASSWORD", "test-password")
+	t.Setenv("DWN_ENDPOINT", "")
+
+	err := cmdNetworkCreate(context.Background(), []string{"home"}, "")
+	if err == nil || !strings.Contains(err.Error(), "usage: meshd network create") {
+		t.Fatalf("cmdNetworkCreate error = %v, want usage error", err)
+	}
+
+	cfg, err := profile.ReadConfig()
+	if err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+	if len(cfg.Profiles) != 0 {
+		t.Fatalf("profiles = %+v, want none", cfg.Profiles)
+	}
+}
+
 func TestParseNetworkJoinArgs(t *testing.T) {
 	t.Setenv("DWN_ENDPOINT", "")
 
@@ -343,6 +1104,269 @@ func TestParseNetworkJoinArgsUsesEndpointEnv(t *testing.T) {
 	if preauth {
 		t.Fatal("preauth = true, want false")
 	}
+}
+
+func TestParseOwnerDIDArg(t *testing.T) {
+	got := parseOwnerDIDArg([]string{
+		"--endpoint", "https://dwn.example.com",
+		"--owner", "did:dht:wallet",
+	})
+	if got != "did:dht:wallet" {
+		t.Fatalf("owner DID = %q", got)
+	}
+
+	got = parseOwnerDIDArg([]string{"--member", "did:dht:legacy"})
+	if got != "did:dht:legacy" {
+		t.Fatalf("legacy member alias owner DID = %q", got)
+	}
+}
+
+func TestParseJoinCommandArgsWithOwner(t *testing.T) {
+	inviteURL := "meshd://invite/test"
+	gotURL, ownerDID, noStartHint, err := parseJoinCommandArgs([]string{
+		inviteURL,
+		"--owner", "did:dht:wallet",
+		"--no-start-hint",
+	})
+	if err != nil {
+		t.Fatalf("parseJoinCommandArgs: %v", err)
+	}
+	if gotURL != inviteURL {
+		t.Fatalf("inviteURL = %q", gotURL)
+	}
+	if ownerDID != "did:dht:wallet" {
+		t.Fatalf("ownerDID = %q", ownerDID)
+	}
+	if !noStartHint {
+		t.Fatal("noStartHint = false, want true")
+	}
+}
+
+func TestParseNetworkJoinOptionsNoStartHint(t *testing.T) {
+	opts := parseNetworkJoinOptions([]string{
+		"--endpoint", "https://dwn.example.com",
+		"--anchor", "did:jwk:anchor",
+		"--network", "network-1",
+		"--preauth",
+		"--no-start-hint",
+	})
+	if opts.endpoint != "https://dwn.example.com" || opts.anchorDID != "did:jwk:anchor" || opts.networkID != "network-1" {
+		t.Fatalf("network join options = %+v", opts)
+	}
+	if !opts.preauthRequested || !opts.noStartHint {
+		t.Fatalf("network join flags = preauth %v noStartHint %v, want true/true", opts.preauthRequested, opts.noStartHint)
+	}
+}
+
+func TestNetworkIdentityFallbacks(t *testing.T) {
+	const fallback = "did:jwk:local"
+	if got := networkNodeDID(nil, fallback); got != fallback {
+		t.Fatalf("networkNodeDID nil = %q", got)
+	}
+	if got := networkOwnerDID(&state.NetworkState{}, fallback); got != fallback {
+		t.Fatalf("networkOwnerDID empty = %q", got)
+	}
+	ns := &state.NetworkState{NodeDID: "did:jwk:node", OwnerDID: "did:dht:wallet"}
+	if got := networkNodeDID(ns, fallback); got != "did:jwk:node" {
+		t.Fatalf("networkNodeDID = %q", got)
+	}
+	if got := networkOwnerDID(ns, fallback); got != "did:dht:wallet" {
+		t.Fatalf("networkOwnerDID = %q", got)
+	}
+}
+
+func TestIsNetworkOwnerProfile(t *testing.T) {
+	ns := &state.NetworkState{
+		AnchorDID: "did:dht:wallet",
+		NodeDID:   "did:jwk:node",
+		OwnerDID:  "did:dht:wallet",
+		MemberDID: "did:dht:wallet",
+	}
+
+	localAnchor := identityMetadata{
+		AuthType: profile.AuthTypeLocalVault,
+		OwnerDID: "did:dht:wallet",
+		NodeDID:  "did:dht:wallet",
+	}
+	if !isNetworkOwnerProfile(localAnchor, "did:dht:wallet", ns) {
+		t.Fatal("local anchor DID should be a network owner")
+	}
+
+	walletOwner := identityMetadata{
+		AuthType: profile.AuthTypeWalletAuthorizedNode,
+		OwnerDID: "did:dht:wallet",
+		NodeDID:  "did:jwk:node",
+	}
+	if !isNetworkOwnerProfile(walletOwner, "did:jwk:node", ns) {
+		t.Fatal("wallet-connected node owned by anchor DID should be a network owner")
+	}
+
+	otherWallet := identityMetadata{
+		AuthType: profile.AuthTypeWalletAuthorizedNode,
+		OwnerDID: "did:dht:other",
+		NodeDID:  "did:jwk:node",
+	}
+	if isNetworkOwnerProfile(otherWallet, "did:jwk:node", ns) {
+		t.Fatal("wallet-connected node for another member should not be network owner")
+	}
+}
+
+func TestWalletGrantIDForDWNOperation(t *testing.T) {
+	resetVaultPasswordCache(t)
+
+	stateDir := t.TempDir()
+	t.Setenv(vaultPasswordEnv, "test-password")
+
+	readGrant := testWalletPermissionGrant(t, "grant-read", "did:jwk:wallet", "did:jwk:node", map[string]any{
+		"interface": "Records",
+		"method":    "Read",
+		"protocol":  "https://enbox.id/protocols/wireguard-mesh",
+	})
+	endpointGrant := testWalletPermissionGrant(t, "grant-endpoint", "did:jwk:wallet", "did:jwk:node", map[string]any{
+		"interface":    "Records",
+		"method":       "Write",
+		"protocol":     "https://enbox.id/protocols/wireguard-mesh",
+		"protocolPath": "network/member/node/endpoint",
+	})
+	if err := state.StoreWalletSession(stateDir, "test-password", &state.WalletSession{
+		Version:  1,
+		OwnerDID: "did:jwk:wallet",
+		NodeDID:  "did:jwk:node",
+		Grants:   []json.RawMessage{readGrant, endpointGrant},
+	}); err != nil {
+		t.Fatalf("StoreWalletSession: %v", err)
+	}
+
+	grantID, err := walletGrantIDForDWNOperation(stateDir, identityMetadata{
+		AuthType: profile.AuthTypeWalletAuthorizedNode,
+		OwnerDID: "did:jwk:wallet",
+		NodeDID:  "did:jwk:node",
+	}, dwn.InterfaceRecordsQuery, "https://enbox.id/protocols/wireguard-mesh", "", "", true)
+	if err != nil {
+		t.Fatalf("walletGrantIDForDWNOperation: %v", err)
+	}
+	if grantID != "grant-read" {
+		t.Fatalf("grantID = %q, want grant-read", grantID)
+	}
+
+	grantID, err = walletGrantIDForDWNOperation(stateDir, identityMetadata{
+		AuthType: profile.AuthTypeWalletAuthorizedNode,
+		OwnerDID: "did:jwk:wallet",
+		NodeDID:  "did:jwk:node",
+	}, dwn.InterfaceRecordsWrite, "https://enbox.id/protocols/wireguard-mesh", "network/member/node/endpoint", "network-1", true)
+	if err != nil {
+		t.Fatalf("endpoint walletGrantIDForDWNOperation: %v", err)
+	}
+	if grantID != "grant-endpoint" {
+		t.Fatalf("endpoint grantID = %q, want grant-endpoint", grantID)
+	}
+
+	grantID, err = walletGrantIDForDWNOperation(stateDir, identityMetadata{
+		AuthType: profile.AuthTypeWalletAuthorizedNode,
+		OwnerDID: "did:jwk:wallet",
+		NodeDID:  "did:jwk:node",
+	}, dwn.InterfaceRecordsWrite, "https://enbox.id/protocols/wireguard-mesh", "network/preAuthKey", "network-1", false)
+	if err != nil {
+		t.Fatalf("preAuthKey walletGrantIDForDWNOperation: %v", err)
+	}
+	if grantID != "" {
+		t.Fatalf("preAuthKey grantID = %q, want none", grantID)
+	}
+
+	_, err = walletGrantIDForDWNOperation(stateDir, identityMetadata{
+		AuthType: profile.AuthTypeWalletAuthorizedNode,
+		OwnerDID: "did:jwk:wallet",
+		NodeDID:  "did:jwk:node",
+	}, dwn.InterfaceRecordsWrite, "https://enbox.id/protocols/wireguard-mesh", "network/preAuthKey", "network-1", true)
+	if err == nil || !strings.Contains(err.Error(), "meshd auth connect --admin") {
+		t.Fatalf("missing admin grant error = %v, want --admin guidance", err)
+	}
+
+	delegateReadGrant := testWalletPermissionGrant(t, "delegate-grant-read", "did:jwk:wallet", "did:jwk:delegate", map[string]any{
+		"interface": "Records",
+		"method":    "Read",
+		"protocol":  "https://enbox.id/protocols/wireguard-mesh",
+	})
+	if err := state.StoreWalletSession(stateDir, "test-password", &state.WalletSession{
+		Version:     1,
+		OwnerDID:    "did:jwk:wallet",
+		NodeDID:     "did:jwk:node",
+		DelegateDID: "did:jwk:delegate",
+		Grants:      []json.RawMessage{readGrant},
+	}); err != nil {
+		t.Fatalf("StoreWalletSession delegate with node grant: %v", err)
+	}
+	_, err = walletGrantIDForDWNOperation(stateDir, identityMetadata{
+		AuthType:    profile.AuthTypeWalletAuthorizedNode,
+		OwnerDID:    "did:jwk:wallet",
+		NodeDID:     "did:jwk:node",
+		DelegateDID: "did:jwk:delegate",
+	}, dwn.InterfaceRecordsQuery, "https://enbox.id/protocols/wireguard-mesh", "", "", true)
+	if err == nil || !strings.Contains(err.Error(), "no permission grant") {
+		t.Fatalf("delegate session used node-DID grant or returned wrong error: %v", err)
+	}
+
+	if err := state.StoreWalletSession(stateDir, "test-password", &state.WalletSession{
+		Version:     1,
+		OwnerDID:    "did:jwk:wallet",
+		NodeDID:     "did:jwk:node",
+		DelegateDID: "did:jwk:delegate",
+		Grants:      []json.RawMessage{delegateReadGrant},
+	}); err != nil {
+		t.Fatalf("StoreWalletSession delegate grant: %v", err)
+	}
+	grantID, err = walletGrantIDForDWNOperation(stateDir, identityMetadata{
+		AuthType:    profile.AuthTypeWalletAuthorizedNode,
+		OwnerDID:    "did:jwk:wallet",
+		NodeDID:     "did:jwk:node",
+		DelegateDID: "did:jwk:delegate",
+	}, dwn.InterfaceRecordsQuery, "https://enbox.id/protocols/wireguard-mesh", "", "", true)
+	if err != nil {
+		t.Fatalf("delegate walletGrantIDForDWNOperation: %v", err)
+	}
+	if grantID != "delegate-grant-read" {
+		t.Fatalf("delegate grantID = %q, want delegate-grant-read", grantID)
+	}
+}
+
+func testWalletPermissionGrant(t *testing.T, id string, grantor string, grantee string, scope map[string]any) json.RawMessage {
+	t.Helper()
+	header, err := json.Marshal(map[string]string{
+		"alg": "EdDSA",
+		"kid": grantor + "#0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(map[string]any{
+		"dateExpires": "2999-01-01T00:00:00Z",
+		"delegated":   true,
+		"scope":       scope,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg, err := json.Marshal(map[string]any{
+		"recordId":    id,
+		"encodedData": base64.RawURLEncoding.EncodeToString(data),
+		"descriptor": map[string]any{
+			"recipient":   grantee,
+			"dateCreated": "2026-06-23T00:00:00Z",
+		},
+		"authorization": map[string]any{
+			"signature": map[string]any{
+				"payload": "",
+				"signatures": []map[string]any{{
+					"protected": base64.RawURLEncoding.EncodeToString(header),
+					"signature": "",
+				}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return msg
 }
 
 func resetVaultPasswordCache(t *testing.T) {
@@ -472,6 +1496,403 @@ func TestEnsureIdentityForCommandUsesResolvedDefaultProfile(t *testing.T) {
 	}
 }
 
+func TestAuthConnectImportsWalletResponse(t *testing.T) {
+	resetVaultPasswordCache(t)
+
+	home := t.TempDir()
+	t.Setenv("ENBOX_HOME", home)
+	t.Setenv("ENBOX_PROFILE", "")
+	t.Setenv("MESHD_STATE_DIR", "")
+	t.Setenv("MESHD_VAULT_PASSWORD", "test-password")
+
+	stateDir, identity, err := ensureIdentityForCommand(context.Background(), "walleted", "")
+	if err != nil {
+		t.Fatalf("ensureIdentityForCommand: %v", err)
+	}
+	delegateIdentity, err := ensureWalletDelegateIdentity(stateDir)
+	if err != nil {
+		t.Fatalf("ensureWalletDelegateIdentity: %v", err)
+	}
+	resp := walletconnect.Response{
+		Version:      1,
+		Type:         walletconnect.ResponseType,
+		ProfileName:  "walleted",
+		OwnerDID:     "did:dht:wallet",
+		DelegateDID:  delegateIdentity.URI,
+		NodeDID:      identity.URI,
+		WalletOrigin: "https://wallet.enbox.id",
+		Grants:       []json.RawMessage{json.RawMessage(`{"id":"grant-1"}`)},
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	responseFile := filepath.Join(t.TempDir(), "response.json")
+	if err := os.WriteFile(responseFile, data, 0600); err != nil {
+		t.Fatalf("write response: %v", err)
+	}
+
+	if err := cmdAuthConnect(context.Background(), []string{"walleted", "--response", responseFile}, ""); err != nil {
+		t.Fatalf("cmdAuthConnect: %v", err)
+	}
+
+	cfg, err := profile.ReadConfig()
+	if err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+	entry := cfg.Profiles["walleted"]
+	if entry == nil {
+		t.Fatal("walleted profile missing")
+	}
+	if entry.EffectiveAuthType() != profile.AuthTypeWalletAuthorizedNode {
+		t.Fatalf("auth type = %q", entry.EffectiveAuthType())
+	}
+	if entry.EffectiveOwnerDID() != "did:dht:wallet" {
+		t.Fatalf("owner DID = %q", entry.EffectiveOwnerDID())
+	}
+	if entry.ConnectedDID != "did:dht:wallet" {
+		t.Fatalf("legacy connected DID = %q", entry.ConnectedDID)
+	}
+	if entry.EffectiveNodeDID() != identity.URI {
+		t.Fatalf("node DID = %q", entry.EffectiveNodeDID())
+	}
+	if entry.DelegateDID != delegateIdentity.URI {
+		t.Fatalf("delegate DID = %q", entry.DelegateDID)
+	}
+
+	session, err := state.LoadWalletSession(stateDir, "test-password")
+	if err != nil {
+		t.Fatalf("LoadWalletSession: %v", err)
+	}
+	if session == nil || session.EffectiveOwnerDID() != "did:dht:wallet" || session.ConnectedDID != "did:dht:wallet" || session.NodeDID != identity.URI || session.DelegateDID != delegateIdentity.URI {
+		t.Fatalf("wallet session = %+v", session)
+	}
+}
+
+func TestAuthConnectImportRequiresDistinctDelegate(t *testing.T) {
+	resetVaultPasswordCache(t)
+
+	home := t.TempDir()
+	t.Setenv("ENBOX_HOME", home)
+	t.Setenv("ENBOX_PROFILE", "")
+	t.Setenv("MESHD_STATE_DIR", "")
+	t.Setenv("MESHD_VAULT_PASSWORD", "test-password")
+
+	_, identity, err := ensureIdentityForCommand(context.Background(), "walleted", "")
+	if err != nil {
+		t.Fatalf("ensureIdentityForCommand: %v", err)
+	}
+	for _, tc := range []struct {
+		name        string
+		delegateDID string
+		want        string
+	}{
+		{name: "node DID", delegateDID: identity.URI, want: "distinct from node DID"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := walletconnect.Response{
+				Version:     1,
+				Type:        walletconnect.ResponseType,
+				ProfileName: "walleted",
+				OwnerDID:    "did:dht:wallet",
+				DelegateDID: tc.delegateDID,
+				NodeDID:     identity.URI,
+			}
+			data, err := json.Marshal(resp)
+			if err != nil {
+				t.Fatalf("marshal response: %v", err)
+			}
+			err = importAuthConnectResponseData(context.Background(), "walleted", data)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("importAuthConnectResponseData error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestAuthConnectAdminRequestIncludesExplicitAdminPermission(t *testing.T) {
+	resetVaultPasswordCache(t)
+
+	home := t.TempDir()
+	t.Setenv("ENBOX_HOME", home)
+	t.Setenv("ENBOX_PROFILE", "")
+	t.Setenv("MESHD_STATE_DIR", "")
+	t.Setenv("MESHD_VAULT_PASSWORD", "test-password")
+
+	requestFile := filepath.Join(t.TempDir(), "wallet-request.json")
+	if err := cmdAuthConnect(context.Background(), []string{
+		"walleted",
+		"--admin",
+		"--request-out", requestFile,
+		"--wallet", "",
+	}, ""); err != nil {
+		t.Fatalf("cmdAuthConnect admin request: %v", err)
+	}
+
+	data, err := os.ReadFile(requestFile)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var req walletconnect.Request
+	if err := json.Unmarshal(data, &req); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if req.ProfileName != "walleted" || req.NodeDID == "" {
+		t.Fatalf("request identity fields = %+v", req)
+	}
+	if req.DelegateDID == "" || req.DelegateDID == req.NodeDID {
+		t.Fatalf("delegate DID = %q, node DID = %q", req.DelegateDID, req.NodeDID)
+	}
+	if !slices.Contains(req.Permissions, "mesh-node") {
+		t.Fatalf("permissions = %v, missing mesh-node", req.Permissions)
+	}
+	if !slices.Contains(req.Permissions, "mesh-admin") {
+		t.Fatalf("permissions = %v, missing mesh-admin", req.Permissions)
+	}
+}
+
+func TestNetworkCreateImportsWalletResponse(t *testing.T) {
+	resetVaultPasswordCache(t)
+
+	home := t.TempDir()
+	t.Setenv("ENBOX_HOME", home)
+	t.Setenv("ENBOX_PROFILE", "")
+	t.Setenv("MESHD_STATE_DIR", "")
+	t.Setenv("MESHD_VAULT_PASSWORD", "test-password")
+
+	stateDir, identity, err := ensureIdentityForCommand(context.Background(), "walleted", "")
+	if err != nil {
+		t.Fatalf("ensureIdentityForCommand: %v", err)
+	}
+	delegateIdentity, err := ensureWalletDelegateIdentity(stateDir)
+	if err != nil {
+		t.Fatalf("ensureWalletDelegateIdentity: %v", err)
+	}
+
+	contextKeyBytes := bytes.Repeat([]byte{0x7a}, 32)
+	derived, err := dwncrypto.NewDerivedPrivateJwk(
+		"did:dht:wallet#enc",
+		dwncrypto.DerivationSchemeProtocolContext,
+		dwncrypto.BuildProtocolContextDerivation("network-1"),
+		contextKeyBytes,
+	)
+	if err != nil {
+		t.Fatalf("NewDerivedPrivateJwk: %v", err)
+	}
+	keyPayload, err := json.Marshal(map[string]any{
+		"protocol":          protocols.MeshProtocolURI,
+		"contextId":         "network-1",
+		"derivedPrivateKey": derived,
+	})
+	if err != nil {
+		t.Fatalf("marshal key payload: %v", err)
+	}
+
+	resp := walletconnect.NetworkCreateResponse{
+		Version:                 1,
+		Type:                    walletconnect.NetworkCreateResponseType,
+		ProfileName:             "walleted",
+		OwnerDID:                "did:dht:wallet",
+		DelegateDID:             delegateIdentity.URI,
+		NodeDID:                 identity.URI,
+		WalletOrigin:            "https://wallet.enbox.id",
+		ExpiresAt:               "2999-01-01T00:00:00Z",
+		AnchorEndpoint:          "https://dev.aws.dwn.enbox.id",
+		NetworkRecordID:         "network-1",
+		NetworkName:             "home",
+		MeshCIDR:                "10.200.0.0/16",
+		MeshIP:                  "10.200.4.5",
+		MemberRecordID:          "member-1",
+		MemberDateCreated:       "2026-06-23T00:00:00Z",
+		NodeRecordID:            "node-1",
+		NodeDateCreated:         "2026-06-23T00:00:00Z",
+		Grants:                  []json.RawMessage{json.RawMessage(`{"id":"grant-1"}`)},
+		NodeContextKeys:         []json.RawMessage{keyPayload},
+		NodeMultiPartyProtocols: []string{protocols.MeshProtocolURI},
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	responseFile := filepath.Join(t.TempDir(), "network-create-response.json")
+	if err := os.WriteFile(responseFile, data, 0600); err != nil {
+		t.Fatalf("write response: %v", err)
+	}
+
+	if err := cmdNetworkCreate(context.Background(), []string{"--response", responseFile}, ""); err != nil {
+		t.Fatalf("cmdNetworkCreate import: %v", err)
+	}
+
+	ns, err := state.LoadNetworkState(stateDir)
+	if err != nil {
+		t.Fatalf("LoadNetworkState: %v", err)
+	}
+	if ns == nil {
+		t.Fatal("network state missing")
+	}
+	if ns.AnchorDID != "did:dht:wallet" || ns.NodeDID != identity.URI || ns.OwnerDID != "did:dht:wallet" || ns.MemberDID != "did:dht:wallet" || ns.DelegateDID != delegateIdentity.URI {
+		t.Fatalf("network identities = anchor %q node %q owner %q member %q delegate %q", ns.AnchorDID, ns.NodeDID, ns.OwnerDID, ns.MemberDID, ns.DelegateDID)
+	}
+	if ns.NetworkRecordID != "network-1" || ns.NodeRecordID != "node-1" || ns.MeshIP != "10.200.4.5" {
+		t.Fatalf("network state = %+v", ns)
+	}
+	if ns.MemberRecordID != "member-1" {
+		t.Fatalf("member record ID = %q, want member-1", ns.MemberRecordID)
+	}
+
+	session, err := state.LoadWalletSession(stateDir, "test-password")
+	if err != nil {
+		t.Fatalf("LoadWalletSession: %v", err)
+	}
+	if session == nil || session.EffectiveOwnerDID() != "did:dht:wallet" || session.ConnectedDID != "did:dht:wallet" || session.NodeDID != identity.URI || session.DelegateDID != delegateIdentity.URI {
+		t.Fatalf("wallet session = %+v", session)
+	}
+	if len(session.Grants) != 1 || len(session.NodeContextKeys) != 1 {
+		t.Fatalf("wallet session grants/context keys = %d/%d", len(session.Grants), len(session.NodeContextKeys))
+	}
+
+	gotKey, ok, err := state.LoadContextKey(stateDir, "test-password", "network-1")
+	if err != nil {
+		t.Fatalf("LoadContextKey: %v", err)
+	}
+	if !ok || !bytes.Equal(gotKey, contextKeyBytes) {
+		t.Fatalf("stored context key mismatch: ok=%v got=%x", ok, gotKey)
+	}
+
+	cfg, err := profile.ReadConfig()
+	if err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+	entry := cfg.Profiles["walleted"]
+	if entry == nil {
+		t.Fatal("walleted profile missing")
+	}
+	if entry.EffectiveAuthType() != profile.AuthTypeWalletAuthorizedNode {
+		t.Fatalf("auth type = %q", entry.EffectiveAuthType())
+	}
+	if entry.EffectiveOwnerDID() != "did:dht:wallet" {
+		t.Fatalf("owner DID = %q", entry.EffectiveOwnerDID())
+	}
+	if entry.ConnectedDID != "did:dht:wallet" {
+		t.Fatalf("legacy connected DID = %q", entry.ConnectedDID)
+	}
+	if entry.EffectiveNodeDID() != identity.URI {
+		t.Fatalf("node DID = %q", entry.EffectiveNodeDID())
+	}
+	if entry.DelegateDID != delegateIdentity.URI {
+		t.Fatalf("delegate DID = %q", entry.DelegateDID)
+	}
+}
+
+func TestNetworkCreateImportRequiresDistinctDelegate(t *testing.T) {
+	resetVaultPasswordCache(t)
+
+	for _, tc := range []struct {
+		name        string
+		delegateDID string
+		want        string
+	}{
+		{name: "node DID", want: "distinct from node DID"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("ENBOX_HOME", home)
+			t.Setenv("ENBOX_PROFILE", "")
+			t.Setenv("MESHD_STATE_DIR", "")
+			t.Setenv("MESHD_VAULT_PASSWORD", "test-password")
+
+			_, identity, err := ensureIdentityForCommand(context.Background(), "walleted", "")
+			if err != nil {
+				t.Fatalf("ensureIdentityForCommand: %v", err)
+			}
+			delegateDID := tc.delegateDID
+			if tc.name == "node DID" {
+				delegateDID = identity.URI
+			}
+			resp := walletconnect.NetworkCreateResponse{
+				Version:         1,
+				Type:            walletconnect.NetworkCreateResponseType,
+				ProfileName:     "walleted",
+				OwnerDID:        "did:dht:wallet",
+				DelegateDID:     delegateDID,
+				NodeDID:         identity.URI,
+				AnchorEndpoint:  "https://dev.aws.dwn.enbox.id",
+				NetworkRecordID: "network-1",
+				NetworkName:     "home",
+				MeshCIDR:        "10.200.0.0/16",
+				MeshIP:          "10.200.4.5",
+			}
+			data, err := json.Marshal(resp)
+			if err != nil {
+				t.Fatalf("marshal response: %v", err)
+			}
+			err = importNetworkCreateResponseData(context.Background(), "walleted", data)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("importNetworkCreateResponseData error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestNetworkCreateImportRejectsMismatchedExistingWalletSession(t *testing.T) {
+	resetVaultPasswordCache(t)
+
+	home := t.TempDir()
+	t.Setenv("ENBOX_HOME", home)
+	t.Setenv("ENBOX_PROFILE", "")
+	t.Setenv("MESHD_STATE_DIR", "")
+	t.Setenv("MESHD_VAULT_PASSWORD", "test-password")
+
+	stateDir, identity, err := ensureIdentityForCommand(context.Background(), "walleted", "")
+	if err != nil {
+		t.Fatalf("ensureIdentityForCommand: %v", err)
+	}
+	delegateIdentity, err := ensureWalletDelegateIdentity(stateDir)
+	if err != nil {
+		t.Fatalf("ensureWalletDelegateIdentity: %v", err)
+	}
+	if err := state.StoreWalletSession(stateDir, "test-password", &state.WalletSession{
+		Version:  1,
+		OwnerDID: "did:dht:wallet-a",
+		NodeDID:  identity.URI,
+	}); err != nil {
+		t.Fatalf("StoreWalletSession: %v", err)
+	}
+
+	resp := walletconnect.NetworkCreateResponse{
+		Version:         1,
+		Type:            walletconnect.NetworkCreateResponseType,
+		ProfileName:     "walleted",
+		OwnerDID:        "did:dht:wallet-b",
+		DelegateDID:     delegateIdentity.URI,
+		NodeDID:         identity.URI,
+		AnchorEndpoint:  "https://dev.aws.dwn.enbox.id",
+		NetworkRecordID: "network-1",
+		NetworkName:     "home",
+		MeshCIDR:        "10.200.0.0/16",
+		MeshIP:          "10.200.4.5",
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	responseFile := filepath.Join(t.TempDir(), "network-create-response.json")
+	if err := os.WriteFile(responseFile, data, 0600); err != nil {
+		t.Fatalf("write response: %v", err)
+	}
+
+	err = cmdNetworkCreate(context.Background(), []string{"--response", responseFile}, "")
+	if err == nil {
+		t.Fatal("cmdNetworkCreate import succeeded with mismatched wallet session")
+	}
+	if !strings.Contains(err.Error(), "wallet session owner DID") {
+		t.Fatalf("error = %v, want owner DID mismatch", err)
+	}
+	if state.HasNetwork(stateDir) {
+		t.Fatal("network state should not be saved after session mismatch")
+	}
+}
+
 func TestLoadLocalContextKeyMigratesLegacyContextKey(t *testing.T) {
 	resetVaultPasswordCache(t)
 
@@ -519,5 +1940,85 @@ func TestLoadLocalContextKeyMigratesLegacyContextKey(t *testing.T) {
 	}
 	if reloaded.ContextKey != "" {
 		t.Fatalf("legacy ContextKey = %q, want empty", reloaded.ContextKey)
+	}
+}
+
+func TestStoreWalletNodeContextKeys(t *testing.T) {
+	resetVaultPasswordCache(t)
+
+	dir := t.TempDir()
+	t.Setenv("MESHD_VAULT_PASSWORD", "test-password")
+
+	contextKeyBytes := bytes.Repeat([]byte{0x24}, 32)
+	derived, err := dwncrypto.NewDerivedPrivateJwk(
+		"did:dht:wallet#enc",
+		dwncrypto.DerivationSchemeProtocolContext,
+		dwncrypto.BuildProtocolContextDerivation("network-1"),
+		contextKeyBytes,
+	)
+	if err != nil {
+		t.Fatalf("NewDerivedPrivateJwk: %v", err)
+	}
+	keyPayload, err := json.Marshal(map[string]any{
+		"protocol":          protocols.MeshProtocolURI,
+		"contextId":         "network-1",
+		"derivedPrivateKey": derived,
+	})
+	if err != nil {
+		t.Fatalf("marshal key payload: %v", err)
+	}
+
+	count, err := storeWalletNodeContextKeys(dir, "test-password", []json.RawMessage{keyPayload})
+	if err != nil {
+		t.Fatalf("storeWalletNodeContextKeys: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("count = %d, want 1", count)
+	}
+
+	got, ok, err := state.LoadContextKey(dir, "test-password", "network-1")
+	if err != nil {
+		t.Fatalf("LoadContextKey: %v", err)
+	}
+	if !ok || !bytes.Equal(got, contextKeyBytes) {
+		t.Fatalf("stored context key mismatch: ok=%v got=%x", ok, got)
+	}
+}
+
+func TestOwnerAutomationRequiresExplicitAdminGrantsForWalletOwnedNode(t *testing.T) {
+	ns := &state.NetworkState{
+		AnchorDID: "did:jwk:wallet",
+		NodeDID:   "did:jwk:node",
+	}
+
+	if !ownerAutomationEnabled(ns, "did:jwk:wallet", true, "", "", "", "") {
+		t.Fatal("local anchor should run owner automation without wallet grants")
+	}
+	if ownerAutomationEnabled(ns, "did:jwk:node", true, "read", "write", "", "") {
+		t.Fatal("wallet-owned node with runtime grants should not run owner automation")
+	}
+	if !ownerAutomationEnabled(ns, "did:jwk:node", true, "read", "write", "delete", "key-delivery-write") {
+		t.Fatal("wallet-owned node with explicit admin grants should run owner automation")
+	}
+	if ownerAutomationEnabled(ns, "did:jwk:node", false, "read", "write", "delete", "key-delivery-write") {
+		t.Fatal("non-owner profile should not run owner automation")
+	}
+}
+
+func TestNodeRuntimeProtocolPaths(t *testing.T) {
+	topLevel := &state.NetworkState{}
+	if got := nodeInfoProtocolPath(topLevel); got != "network/node/nodeInfo" {
+		t.Fatalf("top-level nodeInfo path = %q", got)
+	}
+	if got := endpointProtocolPath(topLevel); got != "network/node/endpoint" {
+		t.Fatalf("top-level endpoint path = %q", got)
+	}
+
+	memberNode := &state.NetworkState{MemberRecordID: "member-1"}
+	if got := nodeInfoProtocolPath(memberNode); got != "network/member/node/nodeInfo" {
+		t.Fatalf("member nodeInfo path = %q", got)
+	}
+	if got := endpointProtocolPath(memberNode); got != "network/member/node/endpoint" {
+		t.Fatalf("member endpoint path = %q", got)
 	}
 }

--- a/docs/smoke-test-mac-linux.md
+++ b/docs/smoke-test-mac-linux.md
@@ -1,0 +1,147 @@
+# Mac/Linux beta smoke test
+
+Use this runbook to validate the current wallet-owned, dashboard-approved flow
+before adding node membership expiry or edit controls.
+
+Assumptions:
+
+- The Mac is the owner/admin device.
+- The Linux server is the joining mesh node.
+- Both machines may already run Tailscale. meshd uses `10.200.0.0/16`, so it
+  should not overlap Tailscale's `100.64.0.0/10` address space.
+- The beta DWN endpoint is `https://dev.aws.dwn.enbox.id`.
+- You have the standalone meshd Admin dapp available locally or deployed.
+
+## 1. Start the admin dashboard on the Mac
+
+From the repository checkout:
+
+```bash
+cd ~/src/enboxorg/meshd/admin-dapp
+npm ci
+npm run dev -- --host 127.0.0.1
+```
+
+Open the printed Vite URL, usually:
+
+```text
+http://127.0.0.1:5173/
+```
+
+Connect the owner wallet and approve meshd Admin. Create a network if one does
+not already exist. Copy the owner DID from the wallet or dashboard header.
+
+## 2. Submit the Linux node request
+
+On the Linux server:
+
+```bash
+meshd down || true
+meshd up --owner '<OWNER_DID>' --endpoint https://dev.aws.dwn.enbox.id
+```
+
+Expected result:
+
+- If the node has no local identity, meshd creates one and asks for a vault
+  password.
+- meshd writes a signed owner-node request to the owner's DWN.
+- meshd exits cleanly or reports that it is waiting for dashboard approval.
+
+## 3. Approve from the dashboard
+
+On the Mac dashboard:
+
+1. Select the target network.
+2. Refresh if the pending request is not visible yet.
+3. Approve the Linux node.
+4. Confirm the node appears under `Nodes`.
+
+The dashboard should write the member/node record, deliver the network context
+key to the node, and write a node approval response.
+
+## 4. Start both mesh daemons
+
+On the Linux server:
+
+```bash
+meshd up
+meshd status
+meshd peer list
+```
+
+On the Mac:
+
+```bash
+meshd up
+meshd status
+meshd peer list
+```
+
+Expected result:
+
+- `meshd status` shows `Daemon: Running: yes`.
+- Both machines show the same network name.
+- `meshd peer list` shows both peers with `10.200.x.x` mesh IPs.
+
+## 5. Ping both directions
+
+From Linux, ping the Mac mesh IP:
+
+```bash
+ping -c 4 <MAC_MESH_IP>
+```
+
+From Mac, ping the Linux mesh IP:
+
+```bash
+ping -c 4 <LINUX_MESH_IP>
+```
+
+Expected result: both pings receive replies.
+
+## 6. Validate invite flow
+
+After the owner-request path works, validate invites.
+
+On the dashboard:
+
+1. Select the network.
+2. Create an invite.
+3. Copy the `meshd://invite/...` URL.
+
+On a fresh profile or another node:
+
+```bash
+meshd down || true
+meshd up '<meshd://invite/...>'
+meshd up
+meshd status
+meshd peer list
+```
+
+If the invite request appears pending in the dashboard, approve it and run
+`meshd up` again on the joining node.
+
+## Troubleshooting
+
+Run:
+
+```bash
+meshd doctor
+meshd status
+meshd peer list
+```
+
+Check these conditions first:
+
+- Both machines are in the same meshd network.
+- Both machines have a `10.200.x.x` mesh IP.
+- The daemon is running on both machines.
+- Routes for the peer mesh IP point to the meshd TUN device.
+- The dashboard shows the node under `Nodes`, not just under `Pending`.
+
+If `peer list` shows encrypted rows without mesh IPs, refresh the dashboard and
+run `meshd up` again on the joining node so it can consume the approval record.
+
+If pings fail but peers and routes look correct, run `meshd down` and then
+`meshd up` on both machines to force the daemon to rebuild the WireGuard state.

--- a/internal/control/control_test.go
+++ b/internal/control/control_test.go
@@ -127,6 +127,20 @@ func TestNewDWNClientProtocolRoleDefaults(t *testing.T) {
 			t.Fatalf("protocolRole = %q, want network/member", c.protocolRole)
 		}
 	})
+
+	t.Run("explicit permission grant is stored", func(t *testing.T) {
+		c := NewDWNClient(
+			"https://dwn.example",
+			"did:example:anchor",
+			"network",
+			"did:example:member",
+			nil,
+			WithPermissionGrantID("grant-123"),
+		)
+		if c.grantID != "grant-123" {
+			t.Fatalf("grantID = %q, want grant-123", c.grantID)
+		}
+	})
 }
 
 func TestBuildMapResponseFallsBackToDeterministicMeshIP(t *testing.T) {
@@ -177,9 +191,11 @@ func TestNodeRecordToNode(t *testing.T) {
 	didURI, wantKey := testDIDJWK(t)
 
 	rec := &NodeRecord{
-		MeshIP:     "10.200.0.5",
-		AllowedIPs: []string{"192.168.1.0/24"},
-		AddedAt:    "2026-01-01T00:00:00Z",
+		MeshIP:          "10.200.0.5",
+		AllowedIPs:      []string{"192.168.1.0/24"},
+		AddedAt:         "2026-01-01T00:00:00Z",
+		OwnerDID:        "did:jwk:wallet",
+		NodeKeyDelivery: &dwncrypto.KeyDeliveryPublic{RootKeyID: didURI + "#1"},
 		Info: &NodeInfoData{
 			Hostname:     "myhost",
 			OS:           "linux",
@@ -207,6 +223,7 @@ func TestNodeRecordToNode(t *testing.T) {
 		"DID":           {got: node.DID, want: didURI},
 		"Key":           {got: node.Key, want: wantKey},
 		"MeshIP":        {got: node.MeshIP, want: netip.MustParseAddr("10.200.0.5")},
+		"MemberDID":     {got: node.MemberDID, want: "did:jwk:wallet"},
 		"Name":          {got: node.Name, want: "myhost"},
 		"PreferredDERP": {got: node.PreferredDERP, want: 2},
 		"Online":        {got: node.Online, want: true},
@@ -246,6 +263,10 @@ func TestNodeRecordToNode(t *testing.T) {
 			t.Errorf("[1] = %q", node.Endpoints[1])
 		}
 	})
+
+	if node.KeyDelivery == nil || node.KeyDelivery.RootKeyID != didURI+"#1" {
+		t.Fatalf("KeyDelivery = %+v, want root %s", node.KeyDelivery, didURI+"#1")
+	}
 
 	t.Run("non-jwk DID yields empty key", func(t *testing.T) {
 		// nodeRecordToNode should not panic on a non-jwk DID.
@@ -376,6 +397,24 @@ func TestNodeOnlineStatus(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNodeRecordOwnerDIDCompatibility(t *testing.T) {
+	t.Run("owner alias populates legacy member", func(t *testing.T) {
+		rec := &NodeRecord{OwnerDID: "did:jwk:wallet"}
+		rec.NormalizeOwnerDID()
+		if rec.MemberDID != "did:jwk:wallet" || rec.EffectiveOwnerDID() != "did:jwk:wallet" {
+			t.Fatalf("record = %+v", rec)
+		}
+	})
+
+	t.Run("legacy member populates owner alias", func(t *testing.T) {
+		rec := &NodeRecord{MemberDID: "did:jwk:wallet"}
+		rec.NormalizeOwnerDID()
+		if rec.OwnerDID != "did:jwk:wallet" || rec.EffectiveOwnerDID() != "did:jwk:wallet" {
+			t.Fatalf("record = %+v", rec)
+		}
+	})
 }
 
 func TestDefaultPeerStaleThreshold(t *testing.T) {

--- a/internal/control/data.go
+++ b/internal/control/data.go
@@ -1,5 +1,7 @@
 package control
 
+import dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
+
 // NetworkConfig is the parsed network record data.
 type NetworkConfig struct {
 	Name           string   `json:"name"`
@@ -12,7 +14,7 @@ type NetworkConfig struct {
 // A member represents a person/entity that has been invited to the network.
 // Their DID comes from the recipient descriptor field.
 type MemberRecord struct {
-	DID      string `json:"-"`               // did:jwk from the recipient descriptor field
+	DID      string `json:"-"` // did:jwk from the recipient descriptor field
 	Label    string `json:"label,omitempty"`
 	AddedAt  string `json:"addedAt"`
 	RecordID string `json:"-"`
@@ -22,12 +24,16 @@ type MemberRecord struct {
 // The WireGuard public key is NOT stored here — it is derived from
 // the DID (did:jwk → X25519 birational map) at conversion time.
 type NodeRecord struct {
-	DID        string `json:"-"`                  // did:jwk from the recipient descriptor field
-	MeshIP     string `json:"meshIP"`
-	AllowedIPs []string `json:"allowedIPs,omitempty"`
-	AddedAt    string `json:"addedAt"`
-	Label      string `json:"label,omitempty"`
-	SourceDWN  string `json:"sourceDWN,omitempty"` // for cross-DWN member devices
+	DID             string                       `json:"-"` // did:jwk from the recipient descriptor field
+	MeshIP          string                       `json:"meshIP"`
+	AllowedIPs      []string                     `json:"allowedIPs,omitempty"`
+	AddedAt         string                       `json:"addedAt"`
+	Label           string                       `json:"label,omitempty"`
+	MemberDID       string                       `json:"memberDID,omitempty"`
+	OwnerDID        string                       `json:"ownerDID,omitempty"`
+	DelegateDID     string                       `json:"delegateDID,omitempty"`
+	SourceDWN       string                       `json:"sourceDWN,omitempty"` // for cross-DWN member devices
+	NodeKeyDelivery *dwncrypto.KeyDeliveryPublic `json:"nodeKeyDelivery,omitempty"`
 
 	// Fields populated from child records (not from this record's data).
 	Info      *NodeInfoData  `json:"-"`
@@ -38,6 +44,30 @@ type NodeRecord struct {
 	// under a member (network/member/node path). Empty for owner-provisioned
 	// top-level nodes (network/node path).
 	MemberRecordID string `json:"-"`
+}
+
+// NormalizeOwnerDID keeps the newer ownerDID field and the older memberDID
+// field interchangeable while records transition.
+func (n *NodeRecord) NormalizeOwnerDID() {
+	if n == nil {
+		return
+	}
+	if n.OwnerDID == "" {
+		n.OwnerDID = n.MemberDID
+	}
+	if n.MemberDID == "" {
+		n.MemberDID = n.OwnerDID
+	}
+}
+
+func (n *NodeRecord) EffectiveOwnerDID() string {
+	if n == nil {
+		return ""
+	}
+	if n.OwnerDID != "" {
+		return n.OwnerDID
+	}
+	return n.MemberDID
 }
 
 // NodeInfoData is the parsed nodeInfo record data (device-controlled).
@@ -75,10 +105,10 @@ type RelayData struct {
 
 // ACLPolicyData is the parsed ACL policy record data.
 type ACLPolicyData struct {
-	Version       int                `json:"version"`
-	DefaultAction string             `json:"defaultAction,omitempty"`
+	Version       int                 `json:"version"`
+	DefaultAction string              `json:"defaultAction,omitempty"`
 	Groups        map[string][]string `json:"groups,omitempty"`
-	Rules         []ACLRule          `json:"rules"`
+	Rules         []ACLRule           `json:"rules"`
 }
 
 // ACLRule is a single ACL rule.

--- a/internal/control/dwnclient.go
+++ b/internal/control/dwnclient.go
@@ -37,6 +37,7 @@ type dwnClientOptions struct {
 	resolver     Resolver
 	encManager   *dwncrypto.EncryptionKeyManager
 	protocolRole string
+	grantID      string
 }
 
 // Option configures a DWNClient.
@@ -74,6 +75,13 @@ func WithProtocolRole(role string) Option {
 	}
 }
 
+// WithPermissionGrantID sets the DWN permission grant used for read queries.
+func WithPermissionGrantID(grantID string) Option {
+	return func(o *dwnClientOptions) {
+		o.grantID = grantID
+	}
+}
+
 // DWNClient reads mesh state from DWN records and produces MapResponse
 // snapshots for the networking engine.
 type DWNClient struct {
@@ -90,6 +98,9 @@ type DWNClient struct {
 	// The anchor (network author) leaves this empty (reads as author).
 	// Non-anchor nodes default to "network/node" unless explicitly set.
 	protocolRole string
+
+	// grantID is an optional DWN permission grant invoked for read queries.
+	grantID string
 
 	mu      sync.RWMutex
 	network *NetworkConfig
@@ -133,6 +144,7 @@ func NewDWNClient(
 		resolver:        options.resolver,
 		encManager:      options.encManager,
 		protocolRole:    protocolRole,
+		grantID:         options.grantID,
 		members:         make(map[string]*MemberRecord),
 		nodes:           make(map[string]*NodeRecord),
 		peerEndpoints:   make(map[string]*PeerEndpointInfo),
@@ -163,7 +175,7 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 
 	netResp, err := c.anchorDWN.RecordsRead(ctx, c.anchorTenant, dwn.RecordsFilter{
 		RecordID: c.networkRecordID,
-	}, role)
+	}, role, c.grantID)
 	if err != nil {
 		return nil, fmt.Errorf("reading network: %w", err)
 	}
@@ -193,7 +205,7 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 		Protocol:     protocols.MeshProtocolURI,
 		ProtocolPath: "network/node",
 		ContextID:    c.networkRecordID,
-	}, "createdAscending", nil, role)
+	}, "createdAscending", nil, role, c.grantID)
 	if err != nil {
 		return nil, fmt.Errorf("querying nodes: %w", err)
 	}
@@ -220,7 +232,7 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 		Protocol:     protocols.MeshProtocolURI,
 		ProtocolPath: "network/member",
 		ContextID:    c.networkRecordID,
-	}, "createdAscending", nil, role)
+	}, "createdAscending", nil, role, c.grantID)
 	if err != nil {
 		// Non-fatal: members are optional (a simple personal mesh may have none).
 		c.logger.DebugContext(ctx, "querying members failed", slog.Any("error", err))
@@ -271,7 +283,7 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 			Protocol:     protocols.MeshProtocolURI,
 			ProtocolPath: "network/member/node",
 			ContextID:    query.ParentContextID,
-		}, "createdAscending", nil, role)
+		}, "createdAscending", nil, role, c.grantID)
 		if err != nil {
 			// Non-fatal: member nodes are optional.
 			c.logger.DebugContext(ctx, "querying member nodes failed",
@@ -305,7 +317,7 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 		Protocol:     protocols.MeshProtocolURI,
 		ProtocolPath: "network/relay",
 		ContextID:    c.networkRecordID,
-	}, "createdAscending", nil, role)
+	}, "createdAscending", nil, role, c.grantID)
 	if err != nil {
 		return nil, fmt.Errorf("querying relays: %w", err)
 	}
@@ -333,7 +345,7 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 		Protocol:     protocols.MeshProtocolURI,
 		ProtocolPath: "network/aclPolicy",
 		ContextID:    c.networkRecordID,
-	}, "createdDescending", nil, role)
+	}, "createdDescending", nil, role, c.grantID)
 	if err != nil {
 		// Non-fatal: ACL policy is optional. Default to allow-all.
 		c.logger.DebugContext(ctx, "querying ACL policy failed", slog.Any("error", err))
@@ -430,6 +442,7 @@ func (c *DWNClient) loadNodeEntry(ctx context.Context, entry json.RawMessage, de
 		}
 		return
 	}
+	node.NormalizeOwnerDID()
 	node.DID = nodeDID
 	node.RecordID = meta.RecordID
 	node.MemberRecordID = memberRecordID
@@ -493,7 +506,7 @@ func (c *DWNClient) loadChildRecords(ctx context.Context, protocolPath string, p
 		Protocol:     protocols.MeshProtocolURI,
 		ProtocolPath: protocolPath,
 		ContextID:    parentContextID,
-	}, "createdDescending", nil, role)
+	}, "createdDescending", nil, role, c.grantID)
 	if err != nil {
 		c.logger.DebugContext(ctx, "querying child records failed",
 			slog.String("path", protocolPath),
@@ -727,8 +740,11 @@ func nodeRecordToNode(id int64, did string, rec *NodeRecord) *Node {
 // the Key field is left empty and logged.
 func nodeRecordToNodeWithThreshold(id int64, nodeDID string, rec *NodeRecord, staleThreshold time.Duration, now time.Time) *Node {
 	node := &Node{
-		ID:  id,
-		DID: nodeDID,
+		ID:             id,
+		DID:            nodeDID,
+		MemberDID:      rec.EffectiveOwnerDID(),
+		MemberRecordID: rec.MemberRecordID,
+		KeyDelivery:    rec.NodeKeyDelivery,
 	}
 
 	// Populate operational fields from the nodeInfo child record if available.

--- a/internal/control/types.go
+++ b/internal/control/types.go
@@ -12,6 +12,8 @@ package control
 import (
 	"net/netip"
 	"time"
+
+	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
 )
 
 // Node represents a peer in the mesh network.
@@ -25,6 +27,14 @@ type Node struct {
 
 	// DID is the node's DID URI.
 	DID string
+
+	// MemberDID is the wallet/member DID that owns this node, when distinct
+	// from the node DID.
+	MemberDID string
+
+	// MemberRecordID is the parent member record when this node is stored
+	// under network/member/node.
+	MemberRecordID string
 
 	// Key is the WireGuard public key (Curve25519, base64).
 	// Derived from the node's did:jwk identity (Ed25519 → X25519 birational map),
@@ -61,6 +71,11 @@ type Node struct {
 
 	// Capabilities advertised by this node.
 	Capabilities []string
+
+	// KeyDelivery is the node's key-delivery ProtocolPath public key, when
+	// supplied during wallet/preauth joins. Anchors use it to encrypt context
+	// keys to this device.
+	KeyDelivery *dwncrypto.KeyDeliveryPublic
 }
 
 // DERPRegion represents a DERP relay region.

--- a/internal/did/vault.go
+++ b/internal/did/vault.go
@@ -14,10 +14,20 @@ const encryptedStateFile = "identity.vault.json"
 
 // StoreEncrypted persists the DID private key in a password-encrypted vault.
 func (d *DID) StoreEncrypted(stateDir string, password string) error {
-	return d.storeEncryptedWithParams(stateDir, password, vault.DefaultArgon2idParams)
+	return d.StoreEncryptedAs(stateDir, encryptedStateFile, password)
 }
 
 func (d *DID) storeEncryptedWithParams(stateDir string, password string, params vault.Argon2idParams) error {
+	return d.storeEncryptedFileWithParams(stateDir, encryptedStateFile, password, params)
+}
+
+// StoreEncryptedAs persists the DID private key in a named password-encrypted
+// vault file under stateDir. The filename must be controlled by the caller.
+func (d *DID) StoreEncryptedAs(stateDir string, filename string, password string) error {
+	return d.storeEncryptedFileWithParams(stateDir, filename, password, vault.DefaultArgon2idParams)
+}
+
+func (d *DID) storeEncryptedFileWithParams(stateDir string, filename string, password string, params vault.Argon2idParams) error {
 	if err := os.MkdirAll(stateDir, 0700); err != nil {
 		return fmt.Errorf("create state dir: %w", err)
 	}
@@ -36,7 +46,7 @@ func (d *DID) storeEncryptedWithParams(stateDir string, password string, params 
 		return err
 	}
 
-	target := filepath.Join(stateDir, encryptedStateFile)
+	target := filepath.Join(stateDir, filename)
 	tmp := target + ".tmp"
 	if err := os.WriteFile(tmp, sealed, 0600); err != nil {
 		return fmt.Errorf("write encrypted identity: %w", err)
@@ -50,7 +60,13 @@ func (d *DID) storeEncryptedWithParams(stateDir string, password string, params 
 
 // LoadEncrypted reads a password-encrypted DID identity.
 func LoadEncrypted(stateDir string, password string) (*DID, error) {
-	target := filepath.Join(stateDir, encryptedStateFile)
+	return LoadEncryptedAs(stateDir, encryptedStateFile, password)
+}
+
+// LoadEncryptedAs reads a password-encrypted DID identity from a named vault
+// file under stateDir. The filename must be controlled by the caller.
+func LoadEncryptedAs(stateDir string, filename string, password string) (*DID, error) {
+	target := filepath.Join(stateDir, filename)
 	data, err := os.ReadFile(target)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -81,7 +97,12 @@ func LoadEncrypted(stateDir string, password string) (*DID, error) {
 
 // EncryptedExists checks whether an encrypted DID identity file exists.
 func EncryptedExists(stateDir string) bool {
-	target := filepath.Join(stateDir, encryptedStateFile)
+	return EncryptedExistsAs(stateDir, encryptedStateFile)
+}
+
+// EncryptedExistsAs checks whether a named encrypted DID vault file exists.
+func EncryptedExistsAs(stateDir string, filename string) bool {
+	target := filepath.Join(stateDir, filename)
 	_, err := os.Stat(target)
 	return err == nil
 }

--- a/internal/dwn/agent.go
+++ b/internal/dwn/agent.go
@@ -70,6 +70,10 @@ type DwnRequest struct {
 	// ProtocolRole for role-based authorization.
 	ProtocolRole string
 
+	// PermissionGrantID invokes a DWN permission grant for delegated
+	// authorization.
+	PermissionGrantID string
+
 	// Store controls whether to persist the result locally.
 	Store bool
 }
@@ -100,13 +104,14 @@ type DwnResponse struct {
 
 // WriteParams configures a RecordsWrite operation.
 type WriteParams struct {
-	Protocol     string
-	ProtocolPath string
-	Schema       string
-	Recipient    string
-	Tags         map[string]any
-	DataFormat   string
-	Published    *bool
+	Protocol          string
+	ProtocolPath      string
+	Schema            string
+	Recipient         string
+	Tags              map[string]any
+	DataFormat        string
+	Published         *bool
+	PermissionGrantID string
 
 	// Data is the record payload. For the DwnRequest, this should also
 	// be set on DwnRequest.DataStream for large payloads.
@@ -143,20 +148,23 @@ type WriteParams struct {
 
 // ReadParams configures a RecordsRead operation.
 type ReadParams struct {
-	Filter RecordsFilter
+	Filter            RecordsFilter
+	PermissionGrantID string
 }
 
 // QueryParams configures a RecordsQuery operation.
 type QueryParams struct {
-	Filter     RecordsFilter
-	DateSort   string
-	Pagination *Pagination
+	Filter            RecordsFilter
+	DateSort          string
+	Pagination        *Pagination
+	PermissionGrantID string
 }
 
 // DeleteParams configures a RecordsDelete operation.
 type DeleteParams struct {
-	RecordID string
-	Prune    bool
+	RecordID          string
+	Prune             bool
+	PermissionGrantID string
 }
 
 // SubscribeParams configures a RecordsSubscribe operation.
@@ -258,13 +266,14 @@ func (a *SimpleAgent) sendRecordsWrite(ctx context.Context, target string, req D
 		ProtocolPath:         params.ProtocolPath,
 		Schema:               params.Schema,
 		Recipient:            params.Recipient,
-		ParentContextID:     params.ParentContextID,
+		ParentContextID:      params.ParentContextID,
 		Tags:                 params.Tags,
 		DataFormat:           params.DataFormat,
 		Published:            params.Published,
+		PermissionGrantID:    firstNonEmpty(params.PermissionGrantID, req.PermissionGrantID),
 		Data:                 data,
 		RecordID:             params.RecordID,
-		DateCreated:         params.DateCreated,
+		DateCreated:          params.DateCreated,
 		ProtocolRole:         req.ProtocolRole,
 		Squash:               params.Squash,
 		EncryptionRecipients: params.EncryptionRecipients,
@@ -286,7 +295,7 @@ func (a *SimpleAgent) sendRecordsRead(ctx context.Context, target string, req Dw
 		return nil, fmt.Errorf("RecordsRead requires *ReadParams, got %T", req.MessageParams)
 	}
 
-	result, err := a.client.RecordsRead(ctx, target, params.Filter, req.ProtocolRole)
+	result, err := a.client.RecordsRead(ctx, target, params.Filter, req.ProtocolRole, firstNonEmpty(params.PermissionGrantID, req.PermissionGrantID))
 	if err != nil {
 		return nil, err
 	}
@@ -304,7 +313,7 @@ func (a *SimpleAgent) sendRecordsQuery(ctx context.Context, target string, req D
 		return nil, fmt.Errorf("RecordsQuery requires *QueryParams, got %T", req.MessageParams)
 	}
 
-	reply, err := a.client.RecordsQuery(ctx, target, params.Filter, params.DateSort, params.Pagination, req.ProtocolRole)
+	reply, err := a.client.RecordsQuery(ctx, target, params.Filter, params.DateSort, params.Pagination, req.ProtocolRole, firstNonEmpty(params.PermissionGrantID, req.PermissionGrantID))
 	if err != nil {
 		return nil, err
 	}
@@ -321,7 +330,7 @@ func (a *SimpleAgent) sendRecordsDelete(ctx context.Context, target string, req 
 		return nil, fmt.Errorf("RecordsDelete requires *DeleteParams, got %T", req.MessageParams)
 	}
 
-	reply, err := a.client.RecordsDelete(ctx, target, params.RecordID, params.Prune, req.ProtocolRole)
+	reply, err := a.client.RecordsDelete(ctx, target, params.RecordID, params.Prune, req.ProtocolRole, firstNonEmpty(params.PermissionGrantID, req.PermissionGrantID))
 	if err != nil {
 		return nil, err
 	}
@@ -364,4 +373,13 @@ func (a *SimpleAgent) sendProtocolsQuery(ctx context.Context, target string, req
 		Status: reply.Status,
 		Reply:  reply,
 	}, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }

--- a/internal/dwn/client.go
+++ b/internal/dwn/client.go
@@ -112,8 +112,8 @@ type RecordsReadResult struct {
 }
 
 // RecordsRead reads a single record from the target DWN.
-func (c *Client) RecordsRead(ctx context.Context, target string, filter RecordsFilter, protocolRole string) (*RecordsReadResult, error) {
-	msg, err := BuildRecordsRead(c.signer, filter, protocolRole)
+func (c *Client) RecordsRead(ctx context.Context, target string, filter RecordsFilter, protocolRole string, permissionGrantID ...string) (*RecordsReadResult, error) {
+	msg, err := BuildRecordsRead(c.signer, filter, protocolRole, optionalString(permissionGrantID))
 	if err != nil {
 		return nil, fmt.Errorf("building RecordsRead: %w", err)
 	}
@@ -130,8 +130,8 @@ func (c *Client) RecordsRead(ctx context.Context, target string, filter RecordsF
 }
 
 // RecordsQuery queries records on the target DWN.
-func (c *Client) RecordsQuery(ctx context.Context, target string, filter RecordsFilter, dateSort string, pagination *Pagination, protocolRole string) (*DwnReply, error) {
-	msg, err := BuildRecordsQuery(c.signer, filter, dateSort, pagination, protocolRole)
+func (c *Client) RecordsQuery(ctx context.Context, target string, filter RecordsFilter, dateSort string, pagination *Pagination, protocolRole string, permissionGrantID ...string) (*DwnReply, error) {
+	msg, err := BuildRecordsQuery(c.signer, filter, dateSort, pagination, protocolRole, optionalString(permissionGrantID))
 	if err != nil {
 		return nil, fmt.Errorf("building RecordsQuery: %w", err)
 	}
@@ -145,8 +145,8 @@ func (c *Client) RecordsQuery(ctx context.Context, target string, filter Records
 }
 
 // RecordsDelete deletes a record on the target DWN.
-func (c *Client) RecordsDelete(ctx context.Context, target string, recordID string, prune bool, protocolRole string) (*DwnReply, error) {
-	msg, err := BuildRecordsDelete(c.signer, recordID, prune, protocolRole)
+func (c *Client) RecordsDelete(ctx context.Context, target string, recordID string, prune bool, protocolRole string, permissionGrantID ...string) (*DwnReply, error) {
+	msg, err := BuildRecordsDelete(c.signer, recordID, prune, protocolRole, optionalString(permissionGrantID))
 	if err != nil {
 		return nil, fmt.Errorf("building RecordsDelete: %w", err)
 	}
@@ -218,5 +218,3 @@ func ReadEntry(reply *DwnReply) (json.RawMessage, error) {
 	}
 	return reply.Entry, nil
 }
-
-

--- a/internal/dwn/crypto/keydelivery.go
+++ b/internal/dwn/crypto/keydelivery.go
@@ -35,6 +35,13 @@ type PrivateKeyJWK struct {
 	D   string `json:"d"`   // base64url private key
 }
 
+// KeyDeliveryPublic is the recipient public-key material needed to encrypt a
+// contextKey record to the recipient's key-delivery ProtocolPath key.
+type KeyDeliveryPublic struct {
+	RootKeyID    string       `json:"rootKeyId"`
+	PublicKeyJWK PublicKeyJWK `json:"publicKeyJwk"`
+}
+
 // NewDerivedPrivateJwk creates a DerivedPrivateJwk from raw key bytes
 // and derivation metadata.
 func NewDerivedPrivateJwk(
@@ -142,4 +149,33 @@ func DeriveKeyDeliveryDecryptionKey(
 		return nil, fmt.Errorf("deriving key-delivery decryption key: %w", err)
 	}
 	return privKey, nil
+}
+
+// DeriveKeyDeliveryPublicJWK derives the recipient-side ProtocolPath public
+// key used by owners to encrypt future contextKey records to this identity.
+func DeriveKeyDeliveryPublicJWK(rootPrivateKey []byte, rootKeyID string, keyDeliveryProtocolURI string) (PublicKeyJWK, error) {
+	fullPath := BuildProtocolPathDerivation(keyDeliveryProtocolURI, "contextKey")
+	_, publicKey, err := DerivePrivateKey(rootPrivateKey, fullPath)
+	if err != nil {
+		return PublicKeyJWK{}, fmt.Errorf("deriving key-delivery public key: %w", err)
+	}
+	return PublicKeyJWK{
+		KTY: "OKP",
+		CRV: "X25519",
+		X:   base64.RawURLEncoding.EncodeToString(publicKey),
+		KID: rootKeyID,
+	}, nil
+}
+
+// NewKeyDeliveryPublic derives the public key descriptor that another party
+// can use to encrypt contextKey records to this identity.
+func NewKeyDeliveryPublic(rootPrivateKey []byte, rootKeyID string, keyDeliveryProtocolURI string) (*KeyDeliveryPublic, error) {
+	publicJWK, err := DeriveKeyDeliveryPublicJWK(rootPrivateKey, rootKeyID, keyDeliveryProtocolURI)
+	if err != nil {
+		return nil, err
+	}
+	return &KeyDeliveryPublic{
+		RootKeyID:    rootKeyID,
+		PublicKeyJWK: publicJWK,
+	}, nil
 }

--- a/internal/dwn/crypto/keydelivery_test.go
+++ b/internal/dwn/crypto/keydelivery_test.go
@@ -470,7 +470,7 @@ func TestKeyDeliveryProtocolEncryptionInjection(t *testing.T) {
 		}
 
 		protoJSON := []byte(`{
-			"protocol": "https://enbox.id/protocols/key-delivery",
+			"protocol": "https://identity.foundation/protocols/key-delivery",
 			"published": false,
 			"types": {
 				"contextKey": {

--- a/internal/dwn/dwn_test.go
+++ b/internal/dwn/dwn_test.go
@@ -290,6 +290,29 @@ func TestBuildRecordsWrite(t *testing.T) {
 		}
 	})
 
+	t.Run("permissionGrantId in descriptor and signature payload", func(t *testing.T) {
+		result, err := BuildRecordsWrite(s, RecordsWriteOptions{
+			Protocol:          "https://example.com/test",
+			ProtocolPath:      "root",
+			DataFormat:        "application/json",
+			Data:              []byte(`{}`),
+			PermissionGrantID: "grant-123",
+		})
+		if err != nil {
+			t.Fatalf("BuildRecordsWrite: %v", err)
+		}
+
+		if result.Message.Descriptor["permissionGrantId"] != "grant-123" {
+			t.Fatalf("descriptor permissionGrantId = %v", result.Message.Descriptor["permissionGrantId"])
+		}
+		payloadBytes, _ := base64.RawURLEncoding.DecodeString(result.Message.Authorization.Signature.Payload)
+		var payload map[string]any
+		json.Unmarshal(payloadBytes, &payload)
+		if payload["permissionGrantId"] != "grant-123" {
+			t.Fatalf("signature permissionGrantId = %v", payload["permissionGrantId"])
+		}
+	})
+
 	t.Run("missing protocol returns error", func(t *testing.T) {
 		_, err := BuildRecordsWrite(s, RecordsWriteOptions{
 			DataFormat: "application/json",
@@ -357,6 +380,26 @@ func TestBuildRecordsWrite(t *testing.T) {
 			t.Errorf("parentId = %q, want %q", parentID, rootID)
 		}
 	})
+}
+
+func TestBuildRecordsQueryWithPermissionGrant(t *testing.T) {
+	s := newTestSigner(t)
+	msg, err := BuildRecordsQuery(s, RecordsFilter{
+		Protocol: "https://example.com/test",
+	}, "", nil, "", "grant-123")
+	if err != nil {
+		t.Fatalf("BuildRecordsQuery: %v", err)
+	}
+
+	if msg.Descriptor["permissionGrantId"] != "grant-123" {
+		t.Fatalf("descriptor permissionGrantId = %v", msg.Descriptor["permissionGrantId"])
+	}
+	payloadBytes, _ := base64.RawURLEncoding.DecodeString(msg.Authorization.Signature.Payload)
+	var payload map[string]any
+	json.Unmarshal(payloadBytes, &payload)
+	if payload["permissionGrantId"] != "grant-123" {
+		t.Fatalf("signature permissionGrantId = %v", payload["permissionGrantId"])
+	}
 }
 
 func TestBuildRecordsQuery(t *testing.T) {

--- a/internal/dwn/dwnapi.go
+++ b/internal/dwn/dwnapi.go
@@ -40,10 +40,11 @@ func (api *DwnAPI) Agent() Agent {
 // Protocol Path of the role (e.g., "network/node").
 func (api *DwnAPI) Write(ctx context.Context, target string, params WriteParams) (*Record, *Status, error) {
 	resp, err := api.agent.SendDwnRequest(ctx, DwnRequest{
-		Target:       target,
-		MessageType:  InterfaceRecordsWrite,
-		MessageParams: &params,
-		ProtocolRole: params.ProtocolRole,
+		Target:            target,
+		MessageType:       InterfaceRecordsWrite,
+		MessageParams:     &params,
+		ProtocolRole:      params.ProtocolRole,
+		PermissionGrantID: params.PermissionGrantID,
 	})
 	if err != nil {
 		return nil, nil, err
@@ -94,12 +95,13 @@ func (api *DwnAPI) Write(ctx context.Context, target string, params WriteParams)
 // Read reads a single record by filter.
 //
 // Returns the Record with its data available via record.Data().
-func (api *DwnAPI) Read(ctx context.Context, target string, filter RecordsFilter, protocolRole string) (*Record, *Status, error) {
+func (api *DwnAPI) Read(ctx context.Context, target string, filter RecordsFilter, protocolRole string, permissionGrantID ...string) (*Record, *Status, error) {
 	resp, err := api.agent.SendDwnRequest(ctx, DwnRequest{
-		Target:       target,
-		MessageType:  InterfaceRecordsRead,
-		MessageParams: &ReadParams{Filter: filter},
-		ProtocolRole: protocolRole,
+		Target:            target,
+		MessageType:       InterfaceRecordsRead,
+		MessageParams:     &ReadParams{Filter: filter},
+		ProtocolRole:      protocolRole,
+		PermissionGrantID: optionalString(permissionGrantID),
 	})
 	if err != nil {
 		return nil, nil, err
@@ -124,10 +126,11 @@ func (api *DwnAPI) Read(ctx context.Context, target string, filter RecordsFilter
 // call record.Data() on each to fetch data lazily.
 func (api *DwnAPI) Query(ctx context.Context, target string, params QueryParams, protocolRole string) ([]*Record, *Status, error) {
 	resp, err := api.agent.SendDwnRequest(ctx, DwnRequest{
-		Target:       target,
-		MessageType:  InterfaceRecordsQuery,
-		MessageParams: &params,
-		ProtocolRole: protocolRole,
+		Target:            target,
+		MessageType:       InterfaceRecordsQuery,
+		MessageParams:     &params,
+		ProtocolRole:      protocolRole,
+		PermissionGrantID: params.PermissionGrantID,
 	})
 	if err != nil {
 		return nil, nil, err
@@ -156,15 +159,16 @@ func (api *DwnAPI) Query(ctx context.Context, target string, params QueryParams,
 }
 
 // Delete deletes a record.
-func (api *DwnAPI) Delete(ctx context.Context, target string, recordID string, prune bool, protocolRole string) (*Status, error) {
+func (api *DwnAPI) Delete(ctx context.Context, target string, recordID string, prune bool, protocolRole string, permissionGrantID ...string) (*Status, error) {
 	resp, err := api.agent.SendDwnRequest(ctx, DwnRequest{
-		Target:       target,
-		MessageType:  InterfaceRecordsDelete,
+		Target:      target,
+		MessageType: InterfaceRecordsDelete,
 		MessageParams: &DeleteParams{
 			RecordID: recordID,
 			Prune:    prune,
 		},
-		ProtocolRole: protocolRole,
+		ProtocolRole:      protocolRole,
+		PermissionGrantID: optionalString(permissionGrantID),
 	})
 	if err != nil {
 		return nil, err

--- a/internal/dwn/message.go
+++ b/internal/dwn/message.go
@@ -143,10 +143,14 @@ type RecordsWriteOptions struct {
 	ProtocolPath string
 	Schema       string
 	Recipient    string
-	Tags       map[string]any
-	Data       []byte
-	DataFormat string
-	Published  *bool
+	Tags         map[string]any
+	Data         []byte
+	DataFormat   string
+	Published    *bool
+
+	// PermissionGrantID invokes a DWN permission grant for delegated
+	// authorization. It is included in both the descriptor and signed payload.
+	PermissionGrantID string
 
 	// For updates: set RecordID to the existing record's ID.
 	// Leave empty for initial writes.
@@ -279,6 +283,9 @@ func BuildRecordsWrite(s *Signer, opts RecordsWriteOptions) (*BuildRecordsWriteR
 	if opts.Squash {
 		desc["squash"] = true
 	}
+	if opts.PermissionGrantID != "" {
+		desc["permissionGrantId"] = opts.PermissionGrantID
+	}
 
 	// Compute record ID.
 	recordID := opts.RecordID
@@ -316,10 +323,11 @@ func BuildRecordsWrite(s *Signer, opts RecordsWriteOptions) (*BuildRecordsWriteR
 
 	// RecordsWrite uses the extended signature payload.
 	sigPayload := recordsWriteSignaturePayload{
-		DescriptorCID: descriptorCID,
-		RecordID:      recordID,
-		ContextID:     contextID,
-		ProtocolRole:  opts.ProtocolRole,
+		DescriptorCID:     descriptorCID,
+		RecordID:          recordID,
+		ContextID:         contextID,
+		PermissionGrantID: opts.PermissionGrantID,
+		ProtocolRole:      opts.ProtocolRole,
 	}
 
 	// If encryption is present, compute its CID for the signature payload.
@@ -376,24 +384,32 @@ func structToMap(v any) (map[string]any, error) {
 }
 
 // BuildRecordsRead constructs and signs a RecordsRead message.
-func BuildRecordsRead(s *Signer, filter RecordsFilter, protocolRole string) (*Message, error) {
+func BuildRecordsRead(s *Signer, filter RecordsFilter, protocolRole string, permissionGrantID ...string) (*Message, error) {
+	grantID := optionalString(permissionGrantID)
 	desc := map[string]any{
 		"interface":        "Records",
 		"method":           "Read",
 		"messageTimestamp": Now(),
 		"filter":           filterToMap(filter),
 	}
+	if grantID != "" {
+		desc["permissionGrantId"] = grantID
+	}
 
-	return signGenericMessage(s, desc, protocolRole)
+	return signGenericMessage(s, desc, protocolRole, grantID)
 }
 
 // BuildRecordsQuery constructs and signs a RecordsQuery message.
-func BuildRecordsQuery(s *Signer, filter RecordsFilter, dateSort string, pagination *Pagination, protocolRole string) (*Message, error) {
+func BuildRecordsQuery(s *Signer, filter RecordsFilter, dateSort string, pagination *Pagination, protocolRole string, permissionGrantID ...string) (*Message, error) {
+	grantID := optionalString(permissionGrantID)
 	desc := map[string]any{
 		"interface":        "Records",
 		"method":           "Query",
 		"messageTimestamp": Now(),
 		"filter":           filterToMap(filter),
+	}
+	if grantID != "" {
+		desc["permissionGrantId"] = grantID
 	}
 	if dateSort != "" {
 		desc["dateSort"] = dateSort
@@ -409,11 +425,12 @@ func BuildRecordsQuery(s *Signer, filter RecordsFilter, dateSort string, paginat
 		desc["pagination"] = p
 	}
 
-	return signGenericMessage(s, desc, protocolRole)
+	return signGenericMessage(s, desc, protocolRole, grantID)
 }
 
 // BuildRecordsDelete constructs and signs a RecordsDelete message.
-func BuildRecordsDelete(s *Signer, recordID string, prune bool, protocolRole string) (*Message, error) {
+func BuildRecordsDelete(s *Signer, recordID string, prune bool, protocolRole string, permissionGrantID ...string) (*Message, error) {
+	grantID := optionalString(permissionGrantID)
 	desc := map[string]any{
 		"interface":        "Records",
 		"method":           "Delete",
@@ -421,8 +438,11 @@ func BuildRecordsDelete(s *Signer, recordID string, prune bool, protocolRole str
 		"recordId":         recordID,
 		"prune":            prune, // required field per SDK
 	}
+	if grantID != "" {
+		desc["permissionGrantId"] = grantID
+	}
 
-	return signGenericMessage(s, desc, protocolRole)
+	return signGenericMessage(s, desc, protocolRole, grantID)
 }
 
 // BuildProtocolsConfigure constructs and signs a ProtocolsConfigure message.
@@ -459,15 +479,16 @@ func BuildProtocolsQuery(s *Signer, protocolURI string) (*Message, error) {
 
 // signGenericMessage signs a non-RecordsWrite message with the generic
 // signature payload (descriptorCid only, no recordId/contextId).
-func signGenericMessage(s *Signer, desc map[string]any, protocolRole string) (*Message, error) {
+func signGenericMessage(s *Signer, desc map[string]any, protocolRole string, permissionGrantID ...string) (*Message, error) {
 	descriptorCID, err := ComputeCID(desc)
 	if err != nil {
 		return nil, fmt.Errorf("computing descriptor CID: %w", err)
 	}
 
 	sigPayload := genericSignaturePayload{
-		DescriptorCID: descriptorCID,
-		ProtocolRole:  protocolRole,
+		DescriptorCID:     descriptorCID,
+		PermissionGrantID: optionalString(permissionGrantID),
+		ProtocolRole:      protocolRole,
 	}
 
 	jws, err := SignJWS(sigPayload, s.KeyID(), s.PrivateKey)
@@ -481,6 +502,13 @@ func signGenericMessage(s *Signer, desc map[string]any, protocolRole string) (*M
 			Signature: jws,
 		},
 	}, nil
+}
+
+func optionalString(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
 }
 
 // filterToMap converts a RecordsFilter to a map, omitting zero-value fields.

--- a/internal/dwn/permission_grants.go
+++ b/internal/dwn/permission_grants.go
@@ -1,0 +1,208 @@
+package dwn
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	DwnScopeInterfaceRecords   = "Records"
+	DwnScopeInterfaceProtocols = "Protocols"
+
+	DwnScopeMethodRead      = "Read"
+	DwnScopeMethodWrite     = "Write"
+	DwnScopeMethodDelete    = "Delete"
+	DwnScopeMethodConfigure = "Configure"
+	DwnScopeMethodQuery     = "Query"
+)
+
+type PermissionScope struct {
+	Interface    string `json:"interface"`
+	Method       string `json:"method"`
+	Protocol     string `json:"protocol,omitempty"`
+	ProtocolPath string `json:"protocolPath,omitempty"`
+	ContextID    string `json:"contextId,omitempty"`
+}
+
+type PermissionGrant struct {
+	ID          string
+	Grantor     string
+	Grantee     string
+	DateGranted string
+	DateExpires string
+	Delegated   bool
+	Scope       PermissionScope
+}
+
+type PermissionGrantMatch struct {
+	Grantor      string
+	Grantee      string
+	MessageType  DwnInterface
+	Protocol     string
+	ProtocolPath string
+	ContextID    string
+	Now          time.Time
+}
+
+func ParsePermissionGrant(raw json.RawMessage) (*PermissionGrant, error) {
+	var msg struct {
+		RecordID    string `json:"recordId"`
+		EncodedData string `json:"encodedData"`
+		Descriptor  struct {
+			Recipient   string `json:"recipient"`
+			DateCreated string `json:"dateCreated"`
+		} `json:"descriptor"`
+		Authorization struct {
+			Signature *GeneralJWS `json:"signature"`
+		} `json:"authorization"`
+	}
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		return nil, fmt.Errorf("parse permission grant message: %w", err)
+	}
+	if msg.RecordID == "" {
+		return nil, fmt.Errorf("permission grant missing recordId")
+	}
+	if msg.EncodedData == "" {
+		return nil, fmt.Errorf("permission grant %s missing encodedData", msg.RecordID)
+	}
+	if msg.Descriptor.Recipient == "" {
+		return nil, fmt.Errorf("permission grant %s missing descriptor.recipient", msg.RecordID)
+	}
+	grantor, err := signerDIDFromJWS(msg.Authorization.Signature)
+	if err != nil {
+		return nil, fmt.Errorf("permission grant %s: %w", msg.RecordID, err)
+	}
+	data, err := base64.RawURLEncoding.DecodeString(msg.EncodedData)
+	if err != nil {
+		return nil, fmt.Errorf("decode permission grant %s data: %w", msg.RecordID, err)
+	}
+	var grantData struct {
+		DateExpires string          `json:"dateExpires"`
+		Delegated   bool            `json:"delegated,omitempty"`
+		Scope       PermissionScope `json:"scope"`
+	}
+	if err := json.Unmarshal(data, &grantData); err != nil {
+		return nil, fmt.Errorf("parse permission grant %s data: %w", msg.RecordID, err)
+	}
+	if grantData.DateExpires == "" {
+		return nil, fmt.Errorf("permission grant %s missing dateExpires", msg.RecordID)
+	}
+	if grantData.Scope.Interface == "" || grantData.Scope.Method == "" {
+		return nil, fmt.Errorf("permission grant %s missing scope interface or method", msg.RecordID)
+	}
+	return &PermissionGrant{
+		ID:          msg.RecordID,
+		Grantor:     grantor,
+		Grantee:     msg.Descriptor.Recipient,
+		DateGranted: msg.Descriptor.DateCreated,
+		DateExpires: grantData.DateExpires,
+		Delegated:   grantData.Delegated,
+		Scope:       grantData.Scope,
+	}, nil
+}
+
+func FindPermissionGrantID(rawGrants []json.RawMessage, match PermissionGrantMatch) (string, error) {
+	var fallback string
+	for _, raw := range rawGrants {
+		grant, err := ParsePermissionGrant(raw)
+		if err != nil {
+			continue
+		}
+		if !permissionGrantMatches(grant, match) {
+			continue
+		}
+		if grant.Scope.Interface+grant.Scope.Method == string(match.MessageType) {
+			return grant.ID, nil
+		}
+		if fallback == "" {
+			fallback = grant.ID
+		}
+	}
+	return fallback, nil
+}
+
+func permissionGrantMatches(grant *PermissionGrant, match PermissionGrantMatch) bool {
+	if grant == nil {
+		return false
+	}
+	if match.Grantor != "" && grant.Grantor != match.Grantor {
+		return false
+	}
+	if match.Grantee != "" && grant.Grantee != match.Grantee {
+		return false
+	}
+	if !permissionGrantActive(grant, match.Now) {
+		return false
+	}
+	if !scopeInterfaceMethodMatches(grant.Scope, match.MessageType) {
+		return false
+	}
+	return scopeTargetMatches(grant.Scope, match.Protocol, match.ProtocolPath, match.ContextID)
+}
+
+func permissionGrantActive(grant *PermissionGrant, now time.Time) bool {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	expiresAt, err := time.Parse(time.RFC3339, grant.DateExpires)
+	if err != nil {
+		return false
+	}
+	return now.Before(expiresAt)
+}
+
+func scopeInterfaceMethodMatches(scope PermissionScope, messageType DwnInterface) bool {
+	switch messageType {
+	case InterfaceRecordsRead, InterfaceRecordsQuery:
+		return scope.Interface == DwnScopeInterfaceRecords && scope.Method == DwnScopeMethodRead
+	case InterfaceRecordsWrite:
+		return scope.Interface == DwnScopeInterfaceRecords && scope.Method == DwnScopeMethodWrite
+	case InterfaceRecordsDelete:
+		return scope.Interface == DwnScopeInterfaceRecords && scope.Method == DwnScopeMethodDelete
+	case InterfaceProtocolsQuery:
+		return scope.Interface == DwnScopeInterfaceProtocols && scope.Method == DwnScopeMethodQuery
+	case InterfaceProtocolsConfigure:
+		return scope.Interface == DwnScopeInterfaceProtocols && scope.Method == DwnScopeMethodConfigure
+	default:
+		return false
+	}
+}
+
+func scopeTargetMatches(scope PermissionScope, protocol, protocolPath, contextID string) bool {
+	if scope.Protocol != "" && scope.Protocol != protocol {
+		return false
+	}
+	if scope.ProtocolPath != "" && scope.ProtocolPath != protocolPath {
+		return false
+	}
+	if scope.ContextID != "" && scope.ContextID != contextID {
+		return false
+	}
+	return true
+}
+
+func signerDIDFromJWS(jws *GeneralJWS) (string, error) {
+	if jws == nil || len(jws.Signatures) == 0 {
+		return "", fmt.Errorf("permission grant missing authorization signature")
+	}
+	headerData, err := base64.RawURLEncoding.DecodeString(jws.Signatures[0].Protected)
+	if err != nil {
+		return "", fmt.Errorf("decode permission grant protected header: %w", err)
+	}
+	var header struct {
+		KID string `json:"kid"`
+	}
+	if err := json.Unmarshal(headerData, &header); err != nil {
+		return "", fmt.Errorf("parse permission grant protected header: %w", err)
+	}
+	if header.KID == "" {
+		return "", fmt.Errorf("permission grant protected header missing kid")
+	}
+	if i := strings.LastIndex(header.KID, "#"); i > 0 {
+		return header.KID[:i], nil
+	}
+	return header.KID, nil
+}

--- a/internal/dwn/permission_grants_test.go
+++ b/internal/dwn/permission_grants_test.go
@@ -1,0 +1,221 @@
+package dwn
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func testPermissionGrantMessage(t *testing.T, id string, grantor string, grantee string, scope PermissionScope, expires string) json.RawMessage {
+	t.Helper()
+	header, err := json.Marshal(map[string]string{
+		"alg": "EdDSA",
+		"kid": grantor + "#0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(map[string]any{
+		"dateExpires": expires,
+		"delegated":   true,
+		"scope":       scope,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg, err := json.Marshal(map[string]any{
+		"recordId":    id,
+		"encodedData": base64.RawURLEncoding.EncodeToString(data),
+		"descriptor": map[string]any{
+			"recipient":   grantee,
+			"dateCreated": "2026-06-23T00:00:00Z",
+		},
+		"authorization": map[string]any{
+			"signature": map[string]any{
+				"payload": "",
+				"signatures": []map[string]any{{
+					"protected": base64.RawURLEncoding.EncodeToString(header),
+					"signature": "",
+				}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return msg
+}
+
+func TestParsePermissionGrant(t *testing.T) {
+	raw := testPermissionGrantMessage(t, "grant-read", "did:jwk:wallet", "did:jwk:node", PermissionScope{
+		Interface: DwnScopeInterfaceRecords,
+		Method:    DwnScopeMethodRead,
+		Protocol:  "https://enbox.id/protocols/wireguard-mesh",
+	}, "2026-06-24T00:00:00Z")
+
+	grant, err := ParsePermissionGrant(raw)
+	if err != nil {
+		t.Fatalf("ParsePermissionGrant: %v", err)
+	}
+	if grant.ID != "grant-read" || grant.Grantor != "did:jwk:wallet" || grant.Grantee != "did:jwk:node" {
+		t.Fatalf("grant identity fields = %+v", grant)
+	}
+	if grant.Scope.Interface != DwnScopeInterfaceRecords || grant.Scope.Method != DwnScopeMethodRead {
+		t.Fatalf("scope = %+v", grant.Scope)
+	}
+}
+
+func TestFindPermissionGrantID(t *testing.T) {
+	grants := []json.RawMessage{
+		testPermissionGrantMessage(t, "grant-read", "did:jwk:wallet", "did:jwk:node", PermissionScope{
+			Interface: DwnScopeInterfaceRecords,
+			Method:    DwnScopeMethodRead,
+			Protocol:  "https://enbox.id/protocols/wireguard-mesh",
+		}, "2026-06-24T00:00:00Z"),
+		testPermissionGrantMessage(t, "grant-write", "did:jwk:wallet", "did:jwk:node", PermissionScope{
+			Interface: DwnScopeInterfaceRecords,
+			Method:    DwnScopeMethodWrite,
+			Protocol:  "https://enbox.id/protocols/wireguard-mesh",
+		}, "2026-06-24T00:00:00Z"),
+		testPermissionGrantMessage(t, "grant-key-delivery-write", "did:jwk:wallet", "did:jwk:node", PermissionScope{
+			Interface: DwnScopeInterfaceRecords,
+			Method:    DwnScopeMethodWrite,
+			Protocol:  "https://identity.foundation/protocols/key-delivery",
+		}, "2026-06-24T00:00:00Z"),
+	}
+
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	got, err := FindPermissionGrantID(grants, PermissionGrantMatch{
+		Grantor:     "did:jwk:wallet",
+		Grantee:     "did:jwk:node",
+		MessageType: InterfaceRecordsQuery,
+		Protocol:    "https://enbox.id/protocols/wireguard-mesh",
+		Now:         now,
+	})
+	if err != nil {
+		t.Fatalf("FindPermissionGrantID: %v", err)
+	}
+	if got != "grant-read" {
+		t.Fatalf("query grant = %q, want grant-read", got)
+	}
+
+	got, err = FindPermissionGrantID(grants, PermissionGrantMatch{
+		Grantor:     "did:jwk:wallet",
+		Grantee:     "did:jwk:node",
+		MessageType: InterfaceRecordsWrite,
+		Protocol:    "https://enbox.id/protocols/wireguard-mesh",
+		Now:         now,
+	})
+	if err != nil {
+		t.Fatalf("FindPermissionGrantID: %v", err)
+	}
+	if got != "grant-write" {
+		t.Fatalf("write grant = %q, want grant-write", got)
+	}
+
+	got, err = FindPermissionGrantID(grants, PermissionGrantMatch{
+		Grantor:     "did:jwk:wallet",
+		Grantee:     "did:jwk:node",
+		MessageType: InterfaceRecordsWrite,
+		Protocol:    "https://identity.foundation/protocols/key-delivery",
+		Now:         now,
+	})
+	if err != nil {
+		t.Fatalf("FindPermissionGrantID: %v", err)
+	}
+	if got != "grant-key-delivery-write" {
+		t.Fatalf("key-delivery write grant = %q, want grant-key-delivery-write", got)
+	}
+}
+
+func TestFindPermissionGrantIDMatchesProtocolPathSpecificGrants(t *testing.T) {
+	grants := []json.RawMessage{
+		testPermissionGrantMessage(t, "grant-endpoint", "did:jwk:wallet", "did:jwk:node", PermissionScope{
+			Interface:    DwnScopeInterfaceRecords,
+			Method:       DwnScopeMethodWrite,
+			Protocol:     "https://enbox.id/protocols/wireguard-mesh",
+			ProtocolPath: "network/member/node/endpoint",
+		}, "2026-06-24T00:00:00Z"),
+		testPermissionGrantMessage(t, "grant-broad", "did:jwk:wallet", "did:jwk:node", PermissionScope{
+			Interface: DwnScopeInterfaceRecords,
+			Method:    DwnScopeMethodWrite,
+			Protocol:  "https://enbox.id/protocols/wireguard-mesh",
+		}, "2026-06-24T00:00:00Z"),
+	}
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+
+	got, err := FindPermissionGrantID(grants, PermissionGrantMatch{
+		Grantor:      "did:jwk:wallet",
+		Grantee:      "did:jwk:node",
+		MessageType:  InterfaceRecordsWrite,
+		Protocol:     "https://enbox.id/protocols/wireguard-mesh",
+		ProtocolPath: "network/member/node/endpoint",
+		Now:          now,
+	})
+	if err != nil {
+		t.Fatalf("FindPermissionGrantID endpoint: %v", err)
+	}
+	if got != "grant-endpoint" {
+		t.Fatalf("endpoint grant = %q, want grant-endpoint", got)
+	}
+
+	got, err = FindPermissionGrantID(grants[:1], PermissionGrantMatch{
+		Grantor:      "did:jwk:wallet",
+		Grantee:      "did:jwk:node",
+		MessageType:  InterfaceRecordsWrite,
+		Protocol:     "https://enbox.id/protocols/wireguard-mesh",
+		ProtocolPath: "network/preAuthKey",
+		Now:          now,
+	})
+	if err != nil {
+		t.Fatalf("FindPermissionGrantID preAuthKey: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("preAuthKey grant = %q, want none", got)
+	}
+
+	got, err = FindPermissionGrantID(grants[1:], PermissionGrantMatch{
+		Grantor:      "did:jwk:wallet",
+		Grantee:      "did:jwk:node",
+		MessageType:  InterfaceRecordsWrite,
+		Protocol:     "https://enbox.id/protocols/wireguard-mesh",
+		ProtocolPath: "network/member/node/endpoint",
+		Now:          now,
+	})
+	if err != nil {
+		t.Fatalf("FindPermissionGrantID broad fallback: %v", err)
+	}
+	if got != "grant-broad" {
+		t.Fatalf("broad fallback grant = %q, want grant-broad", got)
+	}
+}
+
+func TestFindPermissionGrantIDRejectsExpiredAndWrongGrantee(t *testing.T) {
+	grants := []json.RawMessage{
+		testPermissionGrantMessage(t, "grant-expired", "did:jwk:wallet", "did:jwk:node", PermissionScope{
+			Interface: DwnScopeInterfaceRecords,
+			Method:    DwnScopeMethodRead,
+			Protocol:  "https://enbox.id/protocols/wireguard-mesh",
+		}, "2026-06-22T00:00:00Z"),
+		testPermissionGrantMessage(t, "grant-other-node", "did:jwk:wallet", "did:jwk:other", PermissionScope{
+			Interface: DwnScopeInterfaceRecords,
+			Method:    DwnScopeMethodRead,
+			Protocol:  "https://enbox.id/protocols/wireguard-mesh",
+		}, "2026-06-24T00:00:00Z"),
+	}
+
+	got, err := FindPermissionGrantID(grants, PermissionGrantMatch{
+		Grantor:     "did:jwk:wallet",
+		Grantee:     "did:jwk:node",
+		MessageType: InterfaceRecordsQuery,
+		Protocol:    "https://enbox.id/protocols/wireguard-mesh",
+		Now:         time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("FindPermissionGrantID: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("grant = %q, want none", got)
+	}
+}

--- a/internal/engine/autodeliver.go
+++ b/internal/engine/autodeliver.go
@@ -14,8 +14,8 @@ import (
 )
 
 // AutoKeyDelivery monitors the mesh node list and automatically delivers
-// context keys to new nodes. This is only active on the anchor node
-// (the network owner who holds the root private key).
+// context keys to new nodes. This is active on a local anchor node or a
+// wallet-authorized owner node that has a cached network context key.
 //
 // When the engine polls DWN state and discovers nodes that don't yet have
 // a context key, it delivers one to each of them. This removes the need for
@@ -39,14 +39,25 @@ type AutoKeyDelivery struct {
 	// Logger for output.
 	Logger *slog.Logger
 
+	// PermissionGrantID invokes a wallet/member grant for contextKey writes.
+	PermissionGrantID string
+
 	mu        sync.Mutex
 	delivered map[string]bool // DID → true if context key already delivered
 }
 
+// KeyDeliveryRecipient identifies a node that may need a delivered context key.
+type KeyDeliveryRecipient struct {
+	DID         string
+	KeyDelivery *dwncrypto.KeyDeliveryPublic
+}
+
 // NewAutoKeyDelivery creates a new auto key delivery instance.
-// Returns nil if the EncryptionKeyManager is not an owner (doesn't have root private key).
+// Returns nil if the EncryptionKeyManager cannot resolve this network's
+// context key.
 func NewAutoKeyDelivery(cfg AutoKeyDeliveryConfig) *AutoKeyDelivery {
-	if cfg.EncryptionKeyManager == nil || !cfg.EncryptionKeyManager.IsOwner() {
+	if cfg.EncryptionKeyManager == nil ||
+		(!cfg.EncryptionKeyManager.IsOwner() && !cfg.EncryptionKeyManager.HasContextKey(cfg.NetworkRecordID)) {
 		return nil
 	}
 
@@ -62,6 +73,7 @@ func NewAutoKeyDelivery(cfg AutoKeyDeliveryConfig) *AutoKeyDelivery {
 		Signer:               cfg.Signer,
 		EncryptionKeyManager: cfg.EncryptionKeyManager,
 		Logger:               l,
+		PermissionGrantID:    cfg.PermissionGrantID,
 		delivered:            make(map[string]bool),
 	}
 }
@@ -74,6 +86,7 @@ type AutoKeyDeliveryConfig struct {
 	Signer               *dwn.Signer
 	EncryptionKeyManager *dwncrypto.EncryptionKeyManager
 	Logger               *slog.Logger
+	PermissionGrantID    string
 }
 
 // OnNodesUpdated should be called after each poll that discovers node DIDs.
@@ -83,15 +96,29 @@ type AutoKeyDeliveryConfig struct {
 // nodeDIDs is the full set of node DIDs from the current mesh state.
 // It is safe to call concurrently.
 func (a *AutoKeyDelivery) OnNodesUpdated(ctx context.Context, nodeDIDs []string) {
+	recipients := make([]KeyDeliveryRecipient, 0, len(nodeDIDs))
+	for _, did := range nodeDIDs {
+		recipients = append(recipients, KeyDeliveryRecipient{DID: did})
+	}
+	a.OnRecipientsUpdated(ctx, recipients)
+}
+
+// OnRecipientsUpdated should be called after each poll that discovers nodes.
+// It delivers context keys to nodes that have not yet received them, using
+// recipient key-delivery public keys when available.
+func (a *AutoKeyDelivery) OnRecipientsUpdated(ctx context.Context, recipients []KeyDeliveryRecipient) {
 	if a == nil {
 		return
 	}
 
 	a.mu.Lock()
-	var pending []string
-	for _, did := range nodeDIDs {
-		if !a.delivered[did] {
-			pending = append(pending, did)
+	var pending []KeyDeliveryRecipient
+	for _, recipient := range recipients {
+		if recipient.DID == "" {
+			continue
+		}
+		if !a.delivered[recipient.DID] {
+			pending = append(pending, recipient)
 		}
 	}
 	a.mu.Unlock()
@@ -107,27 +134,29 @@ func (a *AutoKeyDelivery) OnNodesUpdated(ctx context.Context, nodeDIDs []string)
 		Logger:               a.Logger,
 	}
 
-	for _, did := range pending {
+	for _, recipient := range pending {
 		err := kdm.DeliverContextKey(ctx, mesh.DeliverContextKeyParams{
-			AnchorDID:      a.AnchorDID,
-			RecipientDID:   did,
-			SourceProtocol: protocols.MeshProtocolURI,
-			ContextID:      a.NetworkRecordID,
+			AnchorDID:            a.AnchorDID,
+			RecipientDID:         recipient.DID,
+			SourceProtocol:       protocols.MeshProtocolURI,
+			ContextID:            a.NetworkRecordID,
+			PermissionGrantID:    a.PermissionGrantID,
+			RecipientKeyDelivery: recipient.KeyDelivery,
 		})
 		if err != nil {
 			a.Logger.Warn("auto key delivery failed",
-				slog.String("recipient", did),
+				slog.String("recipient", recipient.DID),
 				slog.Any("error", err),
 			)
 			continue
 		}
 
 		a.mu.Lock()
-		a.delivered[did] = true
+		a.delivered[recipient.DID] = true
 		a.mu.Unlock()
 
 		a.Logger.Info("auto-delivered context key",
-			slog.String("recipient", did),
+			slog.String("recipient", recipient.DID),
 		)
 	}
 }

--- a/internal/engine/connectivity_test.go
+++ b/internal/engine/connectivity_test.go
@@ -298,11 +298,12 @@ func TestTwoNodeConnectivity(t *testing.T) {
 	t.Log("Step 6b: Node B fetches context key and re-registers with context encryption")
 
 	contextKeyJwk, err := mesh.FetchContextKey(ctx, mesh.FetchContextKeyParams{
-		AnchorEndpoint: endpoint,
-		AnchorDID:      nodeA.identity.URI,
-		SelfDID:        nodeB.identity.URI,
-		ContextID:      networkRecordID,
-		Signer:         nodeB.signer,
+		AnchorEndpoint:       endpoint,
+		AnchorDID:            nodeA.identity.URI,
+		SelfDID:              nodeB.identity.URI,
+		ContextID:            networkRecordID,
+		Signer:               nodeB.signer,
+		EncryptionKeyManager: nodeB.encMgr,
 	})
 	if err != nil {
 		t.Fatalf("fetching context key for B: %v", err)
@@ -775,11 +776,12 @@ func TestTwoNodeNetworkMapDiscovery(t *testing.T) {
 
 	// Node B fetches and stores context key.
 	contextKeyJwk, err := mesh.FetchContextKey(ctx, mesh.FetchContextKeyParams{
-		AnchorEndpoint: endpoint,
-		AnchorDID:      nodeA.identity.URI,
-		SelfDID:        nodeB.identity.URI,
-		ContextID:      networkRecordID,
-		Signer:         nodeB.signer,
+		AnchorEndpoint:       endpoint,
+		AnchorDID:            nodeA.identity.URI,
+		SelfDID:              nodeB.identity.URI,
+		ContextID:            networkRecordID,
+		Signer:               nodeB.signer,
+		EncryptionKeyManager: nodeB.encMgr,
 	})
 	if err != nil {
 		t.Fatalf("fetching context key: %v", err)

--- a/internal/engine/convert.go
+++ b/internal/engine/convert.go
@@ -375,14 +375,20 @@ func MapResponseFunc(client *control.DWNClient, converter *Converter, autoDelive
 		// If auto key delivery is active, extract node DIDs from
 		// the response and deliver context keys to any new nodes.
 		if autoDelivery != nil && resp != nil {
-			var nodeDIDs []string
+			var recipients []KeyDeliveryRecipient
 			if resp.Node != nil {
-				nodeDIDs = append(nodeDIDs, resp.Node.DID)
+				recipients = append(recipients, KeyDeliveryRecipient{
+					DID:         resp.Node.DID,
+					KeyDelivery: resp.Node.KeyDelivery,
+				})
 			}
 			for _, p := range resp.Peers {
-				nodeDIDs = append(nodeDIDs, p.DID)
+				recipients = append(recipients, KeyDeliveryRecipient{
+					DID:         p.DID,
+					KeyDelivery: p.KeyDelivery,
+				})
 			}
-			autoDelivery.OnNodesUpdated(ctx, nodeDIDs)
+			autoDelivery.OnRecipientsUpdated(ctx, recipients)
 		}
 
 		return converter.Convert(resp)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -112,6 +112,14 @@ type Config struct {
 	// Non-anchor nodes use "network/node".
 	ProtocolRole string
 
+	// PermissionGrantID invokes a DWN permission grant for control-plane
+	// read/query operations.
+	PermissionGrantID string
+
+	// WritePermissionGrantID invokes a DWN permission grant for this node's
+	// runtime endpoint writes.
+	WritePermissionGrantID string
+
 	// AutoKeyDelivery enables automatic context key delivery to new nodes.
 	// Only active when this node is the anchor and has the root private key.
 	// If nil, auto delivery is disabled.
@@ -205,6 +213,9 @@ func New(cfg Config) (*Engine, error) {
 	}
 	if cfg.ProtocolRole != "" {
 		controlOpts = append(controlOpts, control.WithProtocolRole(cfg.ProtocolRole))
+	}
+	if cfg.PermissionGrantID != "" {
+		controlOpts = append(controlOpts, control.WithPermissionGrantID(cfg.PermissionGrantID))
 	}
 	dwnClient := control.NewDWNClient(
 		cfg.AnchorEndpoint,
@@ -632,6 +643,7 @@ func makeEndpointUpdateFunc(cfg Config, l *slog.Logger) func(context.Context, []
 			DiscoKey:             discoKeyB64,
 			NATType:              "unknown",
 			UseContextEncryption: cfg.UseContextEncryption,
+			PermissionGrantID:    cfg.WritePermissionGrantID,
 		})
 		if err != nil {
 			l.Warn("failed to publish endpoints to DWN",

--- a/internal/mesh/keydelivery.go
+++ b/internal/mesh/keydelivery.go
@@ -2,6 +2,8 @@ package mesh
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 
@@ -44,19 +46,31 @@ type DeliverContextKeyParams struct {
 
 	// ContextID is the root context ID (typically the network record ID).
 	ContextID string
+
+	// PermissionGrantID invokes a wallet/member grant when a local node DID
+	// writes the contextKey record on behalf of the wallet owner.
+	PermissionGrantID string
+
+	// RecipientKeyDelivery is the recipient's key-delivery ProtocolPath
+	// public key. When present, the contextKey payload is encrypted to it.
+	RecipientKeyDelivery *dwncrypto.KeyDeliveryPublic
 }
 
 // DeliverContextKey derives the Protocol Context key for a context and
 // writes a contextKey record to the anchor's DWN.
 //
-// The contextKey record payload is plaintext JSON, but protocol authorization
-// only allows the addressed recipient to read it. It is not Protocol Context
+// The contextKey record payload is encrypted to the recipient's key-delivery
+// ProtocolPath public key when it is available. It is never Protocol Context
 // encrypted, because that would create a circular key exchange dependency.
+// For older/manual flows that only have a recipient DID, meshd falls back to
+// plaintext JSON with key-delivery protocol authorization controlling reads.
 //
-// This MUST be called by the DWN owner (anchor) who has the root private key.
+// This can be called by the DWN owner (who can derive the context key from the
+// root key) or by a wallet-authorized node that already holds the delivered
+// context key locally.
 func (m *KeyDeliveryManager) DeliverContextKey(ctx context.Context, params DeliverContextKeyParams) error {
-	if !m.EncryptionKeyManager.IsOwner() {
-		return fmt.Errorf("context key delivery requires the DWN owner's root private key")
+	if m.EncryptionKeyManager == nil {
+		return fmt.Errorf("EncryptionKeyManager is required")
 	}
 
 	logger := m.Logger
@@ -64,10 +78,10 @@ func (m *KeyDeliveryManager) DeliverContextKey(ctx context.Context, params Deliv
 		logger = slog.Default()
 	}
 
-	// 1. Derive the context key payload.
-	contextKeyJwk, err := m.EncryptionKeyManager.DeriveContextKeyJwk(params.ContextID)
+	// 1. Derive or reuse the context key payload.
+	contextKeyJwk, err := deliverableContextKeyJwk(m.EncryptionKeyManager, params.ContextID)
 	if err != nil {
-		return fmt.Errorf("deriving context key: %w", err)
+		return fmt.Errorf("resolving context key: %w", err)
 	}
 
 	payload, err := contextKeyJwk.MarshalPayload()
@@ -75,21 +89,26 @@ func (m *KeyDeliveryManager) DeliverContextKey(ctx context.Context, params Deliv
 		return fmt.Errorf("marshaling context key payload: %w", err)
 	}
 
-	// 2. Write the contextKey record unencrypted. The key-delivery protocol
-	//    does not require encryption ($encryption is not set). Access is
-	//    controlled by $actions authorization — only the recipient can read.
-	//    This avoids the circular key exchange problem.
+	// 2. Prefer standard key-delivery encryption when the recipient's public
+	//    ProtocolPath key is available. Manual peer-add flows that only have a
+	//    DID fall back to authorization-controlled plaintext.
+	recipients, err := keyDeliveryEncryptionRecipients(params.RecipientKeyDelivery)
+	if err != nil {
+		return err
+	}
 
 	agent := dwn.NewSimpleAgent(m.Endpoint, m.Signer)
 	api := dwn.NewDwnAPI(agent)
 
-	// 3. Write the contextKey record (unencrypted — access controlled by $actions).
+	// 3. Write the contextKey record.
 	_, status, err := api.Write(ctx, params.AnchorDID, dwn.WriteParams{
-		Protocol:     protocols.KeyDeliveryProtocolURI,
-		ProtocolPath: "contextKey",
-		DataFormat:   "application/json",
-		Recipient:    params.RecipientDID,
-		Data:         payload,
+		Protocol:             protocols.KeyDeliveryProtocolURI,
+		ProtocolPath:         "contextKey",
+		DataFormat:           "application/json",
+		Recipient:            params.RecipientDID,
+		Data:                 payload,
+		EncryptionRecipients: recipients,
+		PermissionGrantID:    params.PermissionGrantID,
 		Tags: map[string]any{
 			"protocol":  params.SourceProtocol,
 			"contextId": params.ContextID,
@@ -111,6 +130,55 @@ func (m *KeyDeliveryManager) DeliverContextKey(ctx context.Context, params Deliv
 	return nil
 }
 
+func keyDeliveryEncryptionRecipients(public *dwncrypto.KeyDeliveryPublic) ([]dwncrypto.KeyEncryptionInput, error) {
+	if public == nil {
+		return nil, nil
+	}
+	rootKeyID := public.RootKeyID
+	if rootKeyID == "" {
+		rootKeyID = public.PublicKeyJWK.KID
+	}
+	if rootKeyID == "" {
+		return nil, fmt.Errorf("recipient key-delivery rootKeyId is required")
+	}
+	if public.PublicKeyJWK.X == "" {
+		return nil, fmt.Errorf("recipient key-delivery publicKeyJwk.x is required")
+	}
+	publicKey, err := base64.RawURLEncoding.DecodeString(public.PublicKeyJWK.X)
+	if err != nil {
+		return nil, fmt.Errorf("decoding recipient key-delivery public key: %w", err)
+	}
+	if len(publicKey) != 32 {
+		return nil, fmt.Errorf("recipient key-delivery public key is %d bytes, want 32", len(publicKey))
+	}
+	return []dwncrypto.KeyEncryptionInput{
+		{
+			PublicKeyID:      rootKeyID,
+			PublicKey:        publicKey,
+			DerivationScheme: dwncrypto.DerivationSchemeProtocolPath,
+		},
+	}, nil
+}
+
+func deliverableContextKeyJwk(encMgr *dwncrypto.EncryptionKeyManager, contextID string) (*dwncrypto.DerivedPrivateJwk, error) {
+	if encMgr == nil {
+		return nil, fmt.Errorf("EncryptionKeyManager is required")
+	}
+	contextKey := encMgr.GetContextKey(contextID)
+	if len(contextKey) > 0 {
+		return dwncrypto.NewDerivedPrivateJwk(
+			encMgr.RootKeyID,
+			dwncrypto.DerivationSchemeProtocolContext,
+			dwncrypto.BuildProtocolContextDerivation(contextID),
+			contextKey,
+		)
+	}
+	if encMgr.IsOwner() {
+		return encMgr.DeriveContextKeyJwk(contextID)
+	}
+	return nil, fmt.Errorf("context key delivery requires the owner root key or a cached context key for %s", contextID)
+}
+
 // FetchContextKeyParams configures a context key fetch.
 type FetchContextKeyParams struct {
 	// AnchorEndpoint is the DWN server URL of the anchor (key owner).
@@ -128,6 +196,10 @@ type FetchContextKeyParams struct {
 
 	// Signer signs query/read messages.
 	Signer *dwn.Signer
+
+	// EncryptionKeyManager holds this node's encryption root and is used to
+	// decrypt wallet-authored contextKey records encrypted to the node.
+	EncryptionKeyManager *dwncrypto.EncryptionKeyManager
 }
 
 // FetchContextKey queries the anchor DWN for a contextKey record addressed
@@ -135,7 +207,8 @@ type FetchContextKeyParams struct {
 //
 // The query relies on the DWN's implicit recipient authorization — any
 // authenticated party can query for records where they are the recipient.
-// contextKey records are written unencrypted (access controlled by $actions).
+// contextKey records may be written unencrypted by meshd or encrypted by a
+// wallet to the node's key-delivery ProtocolPath public key.
 //
 // Returns nil (no error) if no matching contextKey record is found.
 func FetchContextKey(ctx context.Context, params FetchContextKeyParams) (*dwncrypto.DerivedPrivateJwk, error) {
@@ -178,14 +251,14 @@ func FetchContextKey(ctx context.Context, params FetchContextKeyParams) (*dwncry
 
 		// Get the record data. For RecordsRead, data comes from the HTTP body
 		// (stored as rawData) or from encodedData (for small inline payloads).
-		// contextKey records are written unencrypted (access controlled by $actions),
-		// so the data is plaintext JSON.
+		// The bytes may be plaintext JSON (CLI-authored) or ciphertext
+		// (wallet-authored with JWE metadata in RawEntry).
 		dataBytes, err := record.Data().Bytes(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("reading contextKey data: %w", err)
 		}
 
-		key, err := dwncrypto.ParseDerivedPrivateJwk(dataBytes)
+		key, err := parseContextKeyRecordData(record.RawEntry, dataBytes, params.EncryptionKeyManager)
 		if err != nil {
 			return nil, err
 		}
@@ -196,6 +269,57 @@ func FetchContextKey(ctx context.Context, params FetchContextKeyParams) (*dwncry
 	}
 
 	return nil, nil // No matching record found.
+}
+
+func parseContextKeyRecordData(rawEntry json.RawMessage, dataBytes []byte, encMgr *dwncrypto.EncryptionKeyManager) (*dwncrypto.DerivedPrivateJwk, error) {
+	key, parseErr := dwncrypto.ParseDerivedPrivateJwk(dataBytes)
+	if parseErr == nil {
+		return key, nil
+	}
+
+	enc := contextKeyRecordEncryption(rawEntry)
+	if enc == nil {
+		return nil, parseErr
+	}
+	if encMgr == nil || len(encMgr.RootPrivateKey) == 0 || encMgr.RootKeyID == "" {
+		return nil, fmt.Errorf("decrypting encrypted contextKey requires this node's encryption key manager")
+	}
+
+	privKey, err := dwncrypto.DeriveKeyDeliveryDecryptionKey(encMgr.RootPrivateKey, protocols.KeyDeliveryProtocolURI)
+	if err != nil {
+		return nil, err
+	}
+
+	plaintext, err := dwncrypto.DecryptData(dataBytes, enc, privKey, encMgr.RootKeyID)
+	if err != nil {
+		return nil, fmt.Errorf("decrypting contextKey data: %w", err)
+	}
+
+	key, err = dwncrypto.ParseDerivedPrivateJwk(plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("parsing decrypted contextKey data: %w", err)
+	}
+	return key, nil
+}
+
+func contextKeyRecordEncryption(rawEntry json.RawMessage) *dwncrypto.Encryption {
+	if len(rawEntry) == 0 {
+		return nil
+	}
+
+	var entry struct {
+		RecordsWrite struct {
+			Encryption *dwncrypto.Encryption `json:"encryption"`
+		} `json:"recordsWrite"`
+		Encryption *dwncrypto.Encryption `json:"encryption"`
+	}
+	if err := json.Unmarshal(rawEntry, &entry); err != nil {
+		return nil
+	}
+	if entry.Encryption != nil {
+		return entry.Encryption
+	}
+	return entry.RecordsWrite.Encryption
 }
 
 func contextKeyMatchesContext(key *dwncrypto.DerivedPrivateJwk, contextID string) bool {

--- a/internal/mesh/keydelivery_test.go
+++ b/internal/mesh/keydelivery_test.go
@@ -1,9 +1,13 @@
 package mesh
 
 import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
 	"testing"
 
 	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
+	"github.com/enboxorg/meshd/protocols"
 )
 
 func TestContextKeyMatchesContext(t *testing.T) {
@@ -59,5 +63,206 @@ func TestContextKeyMatchesContext(t *testing.T) {
 				t.Fatalf("contextKeyMatchesContext() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDeliverableContextKeyJwkUsesCachedContextKey(t *testing.T) {
+	contextID := "network-1"
+	contextKey := bytes.Repeat([]byte{0x7a}, 32)
+	mgr := &dwncrypto.EncryptionKeyManager{
+		RootKeyID:   "did:jwk:node#enc",
+		ProtocolURI: "https://enbox.id/protocols/wireguard-mesh",
+	}
+	mgr.StoreContextKey(contextID, contextKey)
+
+	got, err := deliverableContextKeyJwk(mgr, contextID)
+	if err != nil {
+		t.Fatalf("deliverableContextKeyJwk: %v", err)
+	}
+	if got.RootKeyID != mgr.RootKeyID {
+		t.Fatalf("root key id = %q, want %q", got.RootKeyID, mgr.RootKeyID)
+	}
+	if got.DerivationScheme != dwncrypto.DerivationSchemeProtocolContext {
+		t.Fatalf("derivation scheme = %q", got.DerivationScheme)
+	}
+	gotKey, err := got.PrivateKeyBytes()
+	if err != nil {
+		t.Fatalf("PrivateKeyBytes: %v", err)
+	}
+	if !bytes.Equal(gotKey, contextKey) {
+		t.Fatalf("context key mismatch")
+	}
+}
+
+func TestDeliverableContextKeyJwkPrefersCachedContextKeyOverLocalRoot(t *testing.T) {
+	contextID := "network-1"
+	contextKey := bytes.Repeat([]byte{0x5c}, 32)
+	rootKey, _, err := dwncrypto.GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("GenerateX25519KeyPair: %v", err)
+	}
+	mgr := &dwncrypto.EncryptionKeyManager{
+		RootPrivateKey: rootKey,
+		RootKeyID:      "did:jwk:node#enc",
+		ProtocolURI:    "https://enbox.id/protocols/wireguard-mesh",
+	}
+	mgr.StoreContextKey(contextID, contextKey)
+
+	got, err := deliverableContextKeyJwk(mgr, contextID)
+	if err != nil {
+		t.Fatalf("deliverableContextKeyJwk: %v", err)
+	}
+	gotKey, err := got.PrivateKeyBytes()
+	if err != nil {
+		t.Fatalf("PrivateKeyBytes: %v", err)
+	}
+	if !bytes.Equal(gotKey, contextKey) {
+		t.Fatalf("derived from local root instead of cached context key")
+	}
+}
+
+func TestDeliverableContextKeyJwkRequiresOwnerOrCachedKey(t *testing.T) {
+	mgr := &dwncrypto.EncryptionKeyManager{
+		RootKeyID:   "did:jwk:node#enc",
+		ProtocolURI: "https://enbox.id/protocols/wireguard-mesh",
+	}
+	if _, err := deliverableContextKeyJwk(mgr, "network-1"); err == nil {
+		t.Fatal("expected missing cached context key to fail")
+	}
+}
+
+func TestKeyDeliveryEncryptionRecipients(t *testing.T) {
+	rootKeyID := "did:jwk:node#enc"
+	rootKey, _, err := dwncrypto.GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("GenerateX25519KeyPair: %v", err)
+	}
+	public, err := dwncrypto.NewKeyDeliveryPublic(rootKey, rootKeyID, protocols.KeyDeliveryProtocolURI)
+	if err != nil {
+		t.Fatalf("NewKeyDeliveryPublic: %v", err)
+	}
+
+	recipients, err := keyDeliveryEncryptionRecipients(public)
+	if err != nil {
+		t.Fatalf("keyDeliveryEncryptionRecipients: %v", err)
+	}
+	if len(recipients) != 1 {
+		t.Fatalf("recipients len = %d, want 1", len(recipients))
+	}
+	if recipients[0].PublicKeyID != rootKeyID {
+		t.Fatalf("PublicKeyID = %q, want %q", recipients[0].PublicKeyID, rootKeyID)
+	}
+	if recipients[0].DerivationScheme != dwncrypto.DerivationSchemeProtocolPath {
+		t.Fatalf("DerivationScheme = %q", recipients[0].DerivationScheme)
+	}
+	if len(recipients[0].PublicKey) == 0 {
+		t.Fatal("PublicKey is empty")
+	}
+
+	recipients, err = keyDeliveryEncryptionRecipients(nil)
+	if err != nil {
+		t.Fatalf("nil key delivery should not fail: %v", err)
+	}
+	if recipients != nil {
+		t.Fatalf("nil key delivery recipients = %+v, want nil", recipients)
+	}
+}
+
+func TestParseContextKeyRecordDataPlaintext(t *testing.T) {
+	contextID := "network-1"
+	contextKey := bytes.Repeat([]byte{0x3a}, 32)
+	want, err := dwncrypto.NewDerivedPrivateJwk(
+		"did:jwk:wallet#enc",
+		dwncrypto.DerivationSchemeProtocolContext,
+		dwncrypto.BuildProtocolContextDerivation(contextID),
+		contextKey,
+	)
+	if err != nil {
+		t.Fatalf("NewDerivedPrivateJwk: %v", err)
+	}
+	payload, err := want.MarshalPayload()
+	if err != nil {
+		t.Fatalf("MarshalPayload: %v", err)
+	}
+
+	got, err := parseContextKeyRecordData(nil, payload, nil)
+	if err != nil {
+		t.Fatalf("parseContextKeyRecordData: %v", err)
+	}
+	if !contextKeyMatchesContext(got, contextID) {
+		t.Fatal("parsed key does not match context")
+	}
+}
+
+func TestParseContextKeyRecordDataDecryptsWalletEncryptedRecord(t *testing.T) {
+	contextID := "network-1"
+	nodeRootKeyID := "did:jwk:node#enc"
+	nodeRootKey, _, err := dwncrypto.GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("GenerateX25519KeyPair: %v", err)
+	}
+	nodeEncMgr := &dwncrypto.EncryptionKeyManager{
+		RootPrivateKey: nodeRootKey,
+		RootKeyID:      nodeRootKeyID,
+		ProtocolURI:    protocols.MeshProtocolURI,
+	}
+
+	contextKey := bytes.Repeat([]byte{0x4b}, 32)
+	delivered, err := dwncrypto.NewDerivedPrivateJwk(
+		"did:jwk:wallet#enc",
+		dwncrypto.DerivationSchemeProtocolContext,
+		dwncrypto.BuildProtocolContextDerivation(contextID),
+		contextKey,
+	)
+	if err != nil {
+		t.Fatalf("NewDerivedPrivateJwk: %v", err)
+	}
+	plaintext, err := delivered.MarshalPayload()
+	if err != nil {
+		t.Fatalf("MarshalPayload: %v", err)
+	}
+
+	publicJWK, err := dwncrypto.DeriveKeyDeliveryPublicJWK(nodeRootKey, nodeRootKeyID, protocols.KeyDeliveryProtocolURI)
+	if err != nil {
+		t.Fatalf("DeriveKeyDeliveryPublicJWK: %v", err)
+	}
+	publicKey, err := base64.RawURLEncoding.DecodeString(publicJWK.X)
+	if err != nil {
+		t.Fatalf("DecodeString: %v", err)
+	}
+	ciphertext, enc, err := dwncrypto.EncryptData(plaintext, []dwncrypto.KeyEncryptionInput{
+		{
+			PublicKeyID:      nodeRootKeyID,
+			PublicKey:        publicKey,
+			DerivationScheme: dwncrypto.DerivationSchemeProtocolPath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("EncryptData: %v", err)
+	}
+	rawEntry, err := json.Marshal(map[string]any{
+		"recordsWrite": map[string]any{"encryption": enc},
+	})
+	if err != nil {
+		t.Fatalf("Marshal rawEntry: %v", err)
+	}
+
+	got, err := parseContextKeyRecordData(rawEntry, ciphertext, nodeEncMgr)
+	if err != nil {
+		t.Fatalf("parseContextKeyRecordData: %v", err)
+	}
+	gotKey, err := got.PrivateKeyBytes()
+	if err != nil {
+		t.Fatalf("PrivateKeyBytes: %v", err)
+	}
+	if !bytes.Equal(gotKey, contextKey) {
+		t.Fatal("decrypted context key mismatch")
+	}
+	if !contextKeyMatchesContext(got, contextID) {
+		t.Fatal("decrypted key does not match context")
+	}
+
+	if _, err := parseContextKeyRecordData(rawEntry, ciphertext, nil); err == nil {
+		t.Fatal("expected encrypted contextKey to require an encryption key manager")
 	}
 }

--- a/internal/mesh/mesh_test.go
+++ b/internal/mesh/mesh_test.go
@@ -6,7 +6,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/enboxorg/meshd/internal/did"
+	"github.com/enboxorg/meshd/internal/dwn"
+	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
+	"github.com/enboxorg/meshd/internal/invite"
 	"github.com/enboxorg/meshd/pkg/dids/didjwk"
+	"github.com/enboxorg/meshd/protocols"
 )
 
 // =============================================================================
@@ -120,6 +125,111 @@ func TestWireGuardKeyFromIdentity_Deterministic(t *testing.T) {
 
 	if kp1.PublicKey != kp2.PublicKey {
 		t.Fatal("same identity should produce same WG key pair")
+	}
+}
+
+func TestNodeJoinProofRoundTrip(t *testing.T) {
+	node, err := did.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	signer := &dwn.Signer{DID: node.URI, PrivateKey: node.SigningKey}
+
+	proof := SignNodeJoinProof(signer, "network-record", node.URI, "did:dht:member", "preauth-record")
+	if proof == "" {
+		t.Fatal("proof is empty")
+	}
+	if !VerifyNodeJoinProof(node.URI, proof, "network-record", "did:dht:member", "preauth-record") {
+		t.Fatal("proof did not verify")
+	}
+	if VerifyNodeJoinProof(node.URI, proof, "other-network", "did:dht:member", "preauth-record") {
+		t.Fatal("proof verified for a different network")
+	}
+}
+
+func TestPreAuthNodeRequestDataIncludesSignedNodeKeyDelivery(t *testing.T) {
+	node, err := did.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	signer := &dwn.Signer{DID: node.URI, PrivateKey: node.SigningKey}
+	keyDelivery, err := dwncrypto.NewKeyDeliveryPublic(
+		node.EncryptionPrivateKey,
+		node.EncryptionKeyID(),
+		protocols.KeyDeliveryProtocolURI,
+	)
+	if err != nil {
+		t.Fatalf("NewKeyDeliveryPublic: %v", err)
+	}
+	payload := invite.New(
+		"https://dwn.example",
+		"did:jwk:anchor",
+		"network-record",
+		"test-net",
+		"preauth-record",
+		"preauth-secret",
+		"",
+	)
+
+	got, err := preAuthNodeRequestData(WritePreAuthNodeRequestParams{
+		Invite:          payload,
+		NodeDID:         node.URI,
+		MemberDID:       "did:jwk:wallet",
+		RequestedBy:     node.URI,
+		Signer:          signer,
+		Label:           "laptop",
+		NodeKeyDelivery: keyDelivery,
+	})
+	if err != nil {
+		t.Fatalf("preAuthNodeRequestData: %v", err)
+	}
+	if got.NodeDID != node.URI {
+		t.Fatalf("node DID = %q, want %q", got.NodeDID, node.URI)
+	}
+	if got.MemberDID != "did:jwk:wallet" {
+		t.Fatalf("member DID = %q", got.MemberDID)
+	}
+	if got.OwnerDID != "did:jwk:wallet" {
+		t.Fatalf("owner DID = %q", got.OwnerDID)
+	}
+	if got.NodeKeyDelivery == nil || got.NodeKeyDelivery.RootKeyID != node.EncryptionKeyID() {
+		t.Fatalf("node key delivery = %+v, want root %s", got.NodeKeyDelivery, node.EncryptionKeyID())
+	}
+	if !VerifyNodeJoinProof(got.NodeDID, got.NodeProof, payload.NetworkID, got.MemberDID, payload.TokenID) {
+		t.Fatal("node proof did not verify")
+	}
+	if !invite.VerifyProof(payload.Secret, payload.NetworkID, got.NodeDID, got.PreAuthProof) {
+		t.Fatal("preauth proof did not verify")
+	}
+	if got.RequestedAt == "" {
+		t.Fatal("requestedAt is empty")
+	}
+}
+
+func TestValidateNodeKeyDeliveryRejectsMismatchedRoot(t *testing.T) {
+	node, err := did.Generate()
+	if err != nil {
+		t.Fatalf("Generate node: %v", err)
+	}
+	other, err := did.Generate()
+	if err != nil {
+		t.Fatalf("Generate other: %v", err)
+	}
+	keyDelivery, err := dwncrypto.NewKeyDeliveryPublic(
+		other.EncryptionPrivateKey,
+		other.EncryptionKeyID(),
+		protocols.KeyDeliveryProtocolURI,
+	)
+	if err != nil {
+		t.Fatalf("NewKeyDeliveryPublic: %v", err)
+	}
+
+	err = validateNodeKeyDelivery(node.URI, keyDelivery)
+	if err == nil {
+		t.Fatal("expected mismatched key delivery root to fail")
+	}
+	if !strings.Contains(err.Error(), "does not match node DID") {
+		t.Fatalf("error = %v", err)
 	}
 }
 

--- a/internal/mesh/owner_request.go
+++ b/internal/mesh/owner_request.go
@@ -1,0 +1,198 @@
+package mesh
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/enboxorg/meshd/internal/did"
+	"github.com/enboxorg/meshd/internal/dwn"
+	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
+	"github.com/enboxorg/meshd/protocols"
+)
+
+// OwnerNodeRequestParams configures a root nodeRequest sent to an owner's DWN.
+type OwnerNodeRequestParams struct {
+	OwnerEndpoint   string
+	OwnerDID        string
+	NodeDID         string
+	Signer          *dwn.Signer
+	Label           string
+	SourceDWN       string
+	NodeKeyDelivery *dwncrypto.KeyDeliveryPublic
+}
+
+// NodeApprovalData is the root nodeApproval payload written by the owner
+// dashboard after accepting a node into a network.
+type NodeApprovalData struct {
+	OwnerDID          string `json:"ownerDID"`
+	NodeDID           string `json:"nodeDID"`
+	NetworkRecordID   string `json:"networkRecordId"`
+	NetworkName       string `json:"networkName,omitempty"`
+	MeshCIDR          string `json:"meshCIDR,omitempty"`
+	MeshIP            string `json:"meshIP"`
+	AnchorEndpoint    string `json:"anchorEndpoint,omitempty"`
+	MemberRecordID    string `json:"memberRecordId,omitempty"`
+	MemberDateCreated string `json:"memberDateCreated,omitempty"`
+	NodeRecordID      string `json:"nodeRecordId"`
+	NodeDateCreated   string `json:"nodeDateCreated,omitempty"`
+	Label             string `json:"label,omitempty"`
+	ExpiresAt         string `json:"expiresAt,omitempty"`
+	ApprovedAt        string `json:"approvedAt"`
+	RequestRecordID   string `json:"requestRecordId,omitempty"`
+}
+
+// WriteOwnerNodeRequest writes a root nodeRequest to the owner DWN. This is the
+// default enrollment request used when a CLI node asks a wallet/account owner to
+// approve it from the dashboard.
+func WriteOwnerNodeRequest(ctx context.Context, params OwnerNodeRequestParams) (string, error) {
+	data, err := ownerNodeRequestData(params)
+	if err != nil {
+		return "", err
+	}
+	dataBytes, err := json.Marshal(data)
+	if err != nil {
+		return "", fmt.Errorf("marshaling owner node request: %w", err)
+	}
+
+	agent := dwn.NewSimpleAgent(params.OwnerEndpoint, params.Signer)
+	api := dwn.NewDwnAPI(agent)
+	record, status, err := api.Write(ctx, params.OwnerDID, dwn.WriteParams{
+		Protocol:     protocols.MeshProtocolURI,
+		ProtocolPath: "nodeRequest",
+		Schema:       schemaNodeRequest,
+		DataFormat:   "application/json",
+		Recipient:    params.OwnerDID,
+		Data:         dataBytes,
+	})
+	if err != nil {
+		return "", fmt.Errorf("writing owner node request: %w", err)
+	}
+	if status.Code >= 300 {
+		return "", fmt.Errorf("owner node request write failed: %d %s", status.Code, status.Detail)
+	}
+	return record.ID, nil
+}
+
+func ownerNodeRequestData(params OwnerNodeRequestParams) (NodeRequestData, error) {
+	if params.OwnerEndpoint == "" {
+		return NodeRequestData{}, fmt.Errorf("owner DWN endpoint is required")
+	}
+	if params.OwnerDID == "" {
+		return NodeRequestData{}, fmt.Errorf("owner DID is required")
+	}
+	if params.NodeDID == "" {
+		return NodeRequestData{}, fmt.Errorf("node DID is required")
+	}
+	if params.Signer == nil || params.Signer.DID == "" || len(params.Signer.PrivateKey) != ed25519.PrivateKeySize {
+		return NodeRequestData{}, fmt.Errorf("node signer is required")
+	}
+	if params.Signer.DID != params.NodeDID {
+		return NodeRequestData{}, fmt.Errorf("node signer DID %s does not match node DID %s", params.Signer.DID, params.NodeDID)
+	}
+	if err := validateNodeKeyDelivery(params.NodeDID, params.NodeKeyDelivery); err != nil {
+		return NodeRequestData{}, err
+	}
+
+	requestedAt := time.Now().UTC().Format(time.RFC3339)
+	return NodeRequestData{
+		NodeDID:         params.NodeDID,
+		MemberDID:       params.OwnerDID,
+		OwnerDID:        params.OwnerDID,
+		RequestedBy:     params.NodeDID,
+		NodeProof:       SignOwnerNodeRequestProof(params.Signer, params.OwnerDID, params.NodeDID, params.SourceDWN, requestedAt),
+		RequestKind:     "owner-node",
+		SourceDWN:       params.SourceDWN,
+		Label:           params.Label,
+		NodeKeyDelivery: params.NodeKeyDelivery,
+		RequestedAt:     requestedAt,
+	}, nil
+}
+
+// OwnerNodeRequestProofMessage returns the stable message signed by a node DID
+// when it asks an owner DID to approve the device from the dashboard.
+func OwnerNodeRequestProofMessage(ownerDID, nodeDID, sourceDWN, requestedAt string) []byte {
+	return []byte(
+		"meshd owner node request v1\n" +
+			"owner=" + ownerDID + "\n" +
+			"node=" + nodeDID + "\n" +
+			"sourceDWN=" + sourceDWN + "\n" +
+			"requestedAt=" + requestedAt + "\n",
+	)
+}
+
+// SignOwnerNodeRequestProof signs an owner-scoped node request with the node DID.
+func SignOwnerNodeRequestProof(signer *dwn.Signer, ownerDID, nodeDID, sourceDWN, requestedAt string) string {
+	if signer == nil || signer.DID == "" || len(signer.PrivateKey) != ed25519.PrivateKeySize {
+		return ""
+	}
+	msg := OwnerNodeRequestProofMessage(ownerDID, nodeDID, sourceDWN, requestedAt)
+	sig := ed25519.Sign(signer.PrivateKey, msg)
+	return base64.RawURLEncoding.EncodeToString(sig)
+}
+
+// VerifyOwnerNodeRequestProof verifies an owner-scoped request proof from a
+// did:jwk node DID.
+func VerifyOwnerNodeRequestProof(request NodeRequestData) bool {
+	if request.NodeDID == "" || request.OwnerDID == "" || request.NodeProof == "" || request.RequestedAt == "" {
+		return false
+	}
+	pub, err := did.ParseURI(request.NodeDID)
+	if err != nil {
+		return false
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(request.NodeProof)
+	if err != nil {
+		return false
+	}
+	msg := OwnerNodeRequestProofMessage(request.OwnerDID, request.NodeDID, request.SourceDWN, request.RequestedAt)
+	return did.VerifyWith(pub, msg, sig)
+}
+
+// FindOwnerNodeApproval returns the newest owner approval addressed to nodeDID.
+func FindOwnerNodeApproval(ctx context.Context, ownerEndpoint, ownerDID, nodeDID string, signer *dwn.Signer) (*NodeApprovalData, string, error) {
+	if ownerEndpoint == "" {
+		return nil, "", fmt.Errorf("owner DWN endpoint is required")
+	}
+	if ownerDID == "" {
+		return nil, "", fmt.Errorf("owner DID is required")
+	}
+	if nodeDID == "" {
+		return nil, "", fmt.Errorf("node DID is required")
+	}
+
+	agent := dwn.NewSimpleAgent(ownerEndpoint, signer)
+	api := dwn.NewDwnAPI(agent)
+	records, status, err := api.Query(ctx, ownerDID, dwn.QueryParams{
+		Filter: dwn.RecordsFilter{
+			Protocol:     protocols.MeshProtocolURI,
+			ProtocolPath: "nodeApproval",
+			Recipient:    nodeDID,
+		},
+		DateSort: "createdDescending",
+	}, "")
+	if err != nil {
+		return nil, "", fmt.Errorf("querying owner node approvals: %w", err)
+	}
+	if status.Code != 200 {
+		return nil, "", fmt.Errorf("querying owner node approvals failed: %d %s", status.Code, status.Detail)
+	}
+
+	for _, record := range records {
+		var approval NodeApprovalData
+		if err := record.Data().JSON(ctx, &approval); err != nil {
+			continue
+		}
+		if approval.OwnerDID != ownerDID || approval.NodeDID != nodeDID {
+			continue
+		}
+		if approval.NetworkRecordID == "" || approval.NodeRecordID == "" || approval.MeshIP == "" {
+			continue
+		}
+		return &approval, record.ID, nil
+	}
+	return nil, "", nil
+}

--- a/internal/mesh/preauth.go
+++ b/internal/mesh/preauth.go
@@ -2,11 +2,14 @@ package mesh
 
 import (
 	"context"
+	"crypto/ed25519"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/enboxorg/meshd/internal/control"
+	"github.com/enboxorg/meshd/internal/did"
 	"github.com/enboxorg/meshd/internal/dwn"
 	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
 	"github.com/enboxorg/meshd/internal/invite"
@@ -27,12 +30,32 @@ type PreAuthKeyData struct {
 // NodeRequestData is the network/nodeRequest record payload written by a
 // joining node that holds a preauth invite.
 type NodeRequestData struct {
-	NodeDID      string `json:"nodeDID"`
-	SourceDWN    string `json:"sourceDWN,omitempty"`
-	Label        string `json:"label,omitempty"`
-	PreAuthKeyID string `json:"preAuthKeyId,omitempty"`
-	PreAuthProof string `json:"preAuthProof,omitempty"`
-	RequestedAt  string `json:"requestedAt,omitempty"`
+	NodeDID         string                       `json:"nodeDID"`
+	MemberDID       string                       `json:"memberDID,omitempty"`
+	OwnerDID        string                       `json:"ownerDID,omitempty"`
+	DelegateDID     string                       `json:"delegateDID,omitempty"`
+	RequestedBy     string                       `json:"requestedBy,omitempty"`
+	NodeProof       string                       `json:"nodeProof,omitempty"`
+	RequestKind     string                       `json:"requestKind,omitempty"`
+	NetworkRecordID string                       `json:"networkRecordId,omitempty"`
+	NetworkName     string                       `json:"networkName,omitempty"`
+	SourceDWN       string                       `json:"sourceDWN,omitempty"`
+	Label           string                       `json:"label,omitempty"`
+	NodeKeyDelivery *dwncrypto.KeyDeliveryPublic `json:"nodeKeyDelivery,omitempty"`
+	PreAuthKeyID    string                       `json:"preAuthKeyId,omitempty"`
+	PreAuthProof    string                       `json:"preAuthProof,omitempty"`
+	RequestedAt     string                       `json:"requestedAt,omitempty"`
+	ExpiresAt       string                       `json:"expiresAt,omitempty"`
+}
+
+func (r NodeRequestData) EffectiveOwnerDID() string {
+	if r.OwnerDID != "" {
+		return r.OwnerDID
+	}
+	if r.MemberDID != "" {
+		return r.MemberDID
+	}
+	return r.NodeDID
 }
 
 // CreatePreAuthKeyParams configures preauth token creation.
@@ -47,6 +70,8 @@ type CreatePreAuthKeyParams struct {
 	ExpiresAt            time.Time
 	Reusable             bool
 	Ephemeral            bool
+	PermissionGrantID    string
+	UseContextEncryption bool
 }
 
 // PreAuthInvite is a created preauth key and its corresponding invite URL.
@@ -86,9 +111,17 @@ func CreatePreAuthKey(ctx context.Context, params CreatePreAuthKeyParams) (*PreA
 		return nil, fmt.Errorf("marshaling preauth key: %w", err)
 	}
 
-	recipients, err := params.EncryptionKeyManager.DeriveWriteEncryption("network/preAuthKey")
-	if err != nil {
-		return nil, fmt.Errorf("deriving preauth encryption: %w", err)
+	var recipients []dwncrypto.KeyEncryptionInput
+	if params.UseContextEncryption {
+		recipients, err = params.EncryptionKeyManager.DeriveContextWriteEncryption(params.NetworkRecordID)
+		if err != nil {
+			return nil, fmt.Errorf("deriving preauth context encryption: %w", err)
+		}
+	} else {
+		recipients, err = params.EncryptionKeyManager.DeriveWriteEncryption("network/preAuthKey")
+		if err != nil {
+			return nil, fmt.Errorf("deriving preauth encryption: %w", err)
+		}
 	}
 
 	agent := dwn.NewSimpleAgent(params.AnchorEndpoint, params.Signer)
@@ -101,6 +134,7 @@ func CreatePreAuthKey(ctx context.Context, params CreatePreAuthKeyParams) (*PreA
 		ParentContextID:      params.NetworkRecordID,
 		Data:                 dataBytes,
 		EncryptionRecipients: recipients,
+		PermissionGrantID:    params.PermissionGrantID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("writing preauth key: %w", err)
@@ -133,11 +167,15 @@ func CreatePreAuthKey(ctx context.Context, params CreatePreAuthKeyParams) (*PreA
 
 // WritePreAuthNodeRequestParams configures a preauth join request.
 type WritePreAuthNodeRequestParams struct {
-	Invite    invite.Payload
-	NodeDID   string
-	Signer    *dwn.Signer
-	Label     string
-	SourceDWN string
+	Invite          invite.Payload
+	NodeDID         string
+	MemberDID       string
+	DelegateDID     string
+	RequestedBy     string
+	Signer          *dwn.Signer
+	Label           string
+	SourceDWN       string
+	NodeKeyDelivery *dwncrypto.KeyDeliveryPublic
 }
 
 // WritePreAuthNodeRequest writes a network/nodeRequest claim to the anchor DWN.
@@ -145,17 +183,9 @@ func WritePreAuthNodeRequest(ctx context.Context, params WritePreAuthNodeRequest
 	if err := params.Invite.ValidatePreAuth(); err != nil {
 		return err
 	}
-	if params.NodeDID == "" {
-		return fmt.Errorf("node DID is required")
-	}
-
-	data := NodeRequestData{
-		NodeDID:      params.NodeDID,
-		SourceDWN:    params.SourceDWN,
-		Label:        params.Label,
-		PreAuthKeyID: params.Invite.TokenID,
-		PreAuthProof: invite.Proof(params.Invite.Secret, params.Invite.NetworkID, params.NodeDID),
-		RequestedAt:  time.Now().UTC().Format(time.RFC3339),
+	data, err := preAuthNodeRequestData(params)
+	if err != nil {
+		return err
 	}
 	dataBytes, err := json.Marshal(data)
 	if err != nil {
@@ -182,14 +212,100 @@ func WritePreAuthNodeRequest(ctx context.Context, params WritePreAuthNodeRequest
 	return nil
 }
 
+func preAuthNodeRequestData(params WritePreAuthNodeRequestParams) (NodeRequestData, error) {
+	if params.NodeDID == "" {
+		return NodeRequestData{}, fmt.Errorf("node DID is required")
+	}
+	if err := validateNodeKeyDelivery(params.NodeDID, params.NodeKeyDelivery); err != nil {
+		return NodeRequestData{}, err
+	}
+
+	memberDID := params.MemberDID
+	if memberDID == "" {
+		memberDID = params.NodeDID
+	}
+	requestedBy := params.RequestedBy
+	if requestedBy == "" && params.Signer != nil {
+		requestedBy = params.Signer.DID
+	}
+
+	nodeProof := ""
+	if params.Signer != nil && params.Signer.DID == params.NodeDID && len(params.Signer.PrivateKey) == ed25519.PrivateKeySize {
+		nodeProof = SignNodeJoinProof(params.Signer, params.Invite.NetworkID, params.NodeDID, memberDID, params.Invite.TokenID)
+	}
+
+	return NodeRequestData{
+		NodeDID:         params.NodeDID,
+		MemberDID:       memberDID,
+		OwnerDID:        memberDID,
+		DelegateDID:     params.DelegateDID,
+		RequestedBy:     requestedBy,
+		NodeProof:       nodeProof,
+		RequestKind:     "network-preauth",
+		NetworkRecordID: params.Invite.NetworkID,
+		NetworkName:     params.Invite.NetworkName,
+		SourceDWN:       params.SourceDWN,
+		Label:           params.Label,
+		NodeKeyDelivery: params.NodeKeyDelivery,
+		PreAuthKeyID:    params.Invite.TokenID,
+		PreAuthProof:    invite.Proof(params.Invite.Secret, params.Invite.NetworkID, params.NodeDID),
+		RequestedAt:     time.Now().UTC().Format(time.RFC3339),
+	}, nil
+}
+
+func validateNodeKeyDelivery(nodeDID string, key *dwncrypto.KeyDeliveryPublic) error {
+	if key == nil {
+		return nil
+	}
+	if nodeDID == "" {
+		return fmt.Errorf("node DID is required for key delivery validation")
+	}
+	rootKeyID := key.RootKeyID
+	if rootKeyID == "" {
+		rootKeyID = key.PublicKeyJWK.KID
+	}
+	if rootKeyID == "" {
+		return fmt.Errorf("node key delivery rootKeyId is required")
+	}
+	expectedRootKeyID := nodeDID + "#1"
+	if rootKeyID != expectedRootKeyID {
+		return fmt.Errorf("node key delivery rootKeyId %q does not match node DID %q", rootKeyID, nodeDID)
+	}
+	if key.PublicKeyJWK.KID != "" && key.PublicKeyJWK.KID != rootKeyID {
+		return fmt.Errorf("node key delivery publicKeyJwk.kid %q does not match rootKeyId %q", key.PublicKeyJWK.KID, rootKeyID)
+	}
+	if key.PublicKeyJWK.KTY != "OKP" {
+		return fmt.Errorf("node key delivery publicKeyJwk.kty must be OKP")
+	}
+	if key.PublicKeyJWK.CRV != "X25519" {
+		return fmt.Errorf("node key delivery publicKeyJwk.crv must be X25519")
+	}
+	if key.PublicKeyJWK.X == "" {
+		return fmt.Errorf("node key delivery publicKeyJwk.x is required")
+	}
+	publicKey, err := base64.RawURLEncoding.DecodeString(key.PublicKeyJWK.X)
+	if err != nil {
+		return fmt.Errorf("decoding node key delivery public key: %w", err)
+	}
+	if len(publicKey) != 32 {
+		return fmt.Errorf("node key delivery public key is %d bytes, want 32", len(publicKey))
+	}
+	return nil
+}
+
 // ApprovePreAuthRequestsParams configures anchor-side request approval.
 type ApprovePreAuthRequestsParams struct {
-	AnchorEndpoint       string
-	AnchorDID            string
-	NetworkRecordID      string
-	MeshCIDR             string
-	Signer               *dwn.Signer
-	EncryptionKeyManager *dwncrypto.EncryptionKeyManager
+	AnchorEndpoint          string
+	AnchorDID               string
+	NetworkRecordID         string
+	MeshCIDR                string
+	Signer                  *dwn.Signer
+	EncryptionKeyManager    *dwncrypto.EncryptionKeyManager
+	ReadPermissionGrantID   string
+	WritePermissionGrantID  string
+	DeletePermissionGrantID string
+	KeyDeliveryGrantID      string
+	UseContextEncryption    bool
 }
 
 // ApprovePreAuthResult summarizes processed preauth requests.
@@ -215,7 +331,8 @@ func ApprovePreAuthRequests(ctx context.Context, params ApprovePreAuthRequestsPa
 			ProtocolPath: "network/nodeRequest",
 			ContextID:    params.NetworkRecordID,
 		},
-		DateSort: "createdAscending",
+		DateSort:          "createdAscending",
+		PermissionGrantID: params.ReadPermissionGrantID,
 	}, "")
 	if err != nil {
 		return nil, fmt.Errorf("querying node requests: %w", err)
@@ -228,7 +345,12 @@ func ApprovePreAuthRequests(ctx context.Context, params ApprovePreAuthRequestsPa
 		var req NodeRequestData
 		if err := request.Data().JSON(ctx, &req); err != nil {
 			result.Rejected++
-			_ = deleteRecord(ctx, api, params.AnchorDID, request.ID)
+			_ = deleteRecord(ctx, api, params.AnchorDID, request.ID, params.DeletePermissionGrantID)
+			continue
+		}
+		if err := validateNodeKeyDelivery(req.NodeDID, req.NodeKeyDelivery); err != nil {
+			result.Rejected++
+			_ = deleteRecord(ctx, api, params.AnchorDID, request.ID, params.DeletePermissionGrantID)
 			continue
 		}
 
@@ -239,32 +361,56 @@ func ApprovePreAuthRequests(ctx context.Context, params ApprovePreAuthRequestsPa
 		}
 		if !preAuthKeyAllows(key, req.NodeDID) || !invite.VerifyProof(key.Key, params.NetworkRecordID, req.NodeDID, req.PreAuthProof) {
 			result.Rejected++
-			_ = deleteRecord(ctx, api, params.AnchorDID, request.ID)
+			_ = deleteRecord(ctx, api, params.AnchorDID, request.ID, params.DeletePermissionGrantID)
+			continue
+		}
+		ownerDID := req.EffectiveOwnerDID()
+		if req.NodeProof != "" && !VerifyNodeJoinProof(req.NodeDID, req.NodeProof, params.NetworkRecordID, ownerDID, req.PreAuthKeyID) {
+			result.Rejected++
+			_ = deleteRecord(ctx, api, params.AnchorDID, request.ID, params.DeletePermissionGrantID)
 			continue
 		}
 
-		exists, err := nodeRecordExists(ctx, api, params.AnchorDID, params.NetworkRecordID, req.NodeDID)
+		exists, err := nodeRecordExists(ctx, api, params.AnchorDID, params.NetworkRecordID, req.NodeDID, params.ReadPermissionGrantID)
 		if err != nil {
 			result.Pending++
 			continue
 		}
 		if !exists {
+			memberDID := ownerDID
+			memberRecordID := ""
+			if memberDID != "" && memberDID != req.NodeDID {
+				memberRecordID, err = ensureMemberRecord(ctx, api, params, memberDID, firstNonEmpty(req.Label, key.Label))
+				if err != nil {
+					result.Pending++
+					continue
+				}
+			}
+			if memberDID == "" {
+				memberDID = req.NodeDID
+			}
+
 			meshIP, err := AllocateMeshIP(params.MeshCIDR, req.NodeDID)
 			if err != nil {
 				result.Rejected++
-				_ = deleteRecord(ctx, api, params.AnchorDID, request.ID)
+				_ = deleteRecord(ctx, api, params.AnchorDID, request.ID, params.DeletePermissionGrantID)
 				continue
 			}
 			_, err = RegisterNode(ctx, RegisterNodeParams{
 				AnchorEndpoint:       params.AnchorEndpoint,
 				AnchorDID:            params.AnchorDID,
 				NetworkRecordID:      params.NetworkRecordID,
+				MemberRecordID:       memberRecordID,
 				NodeDID:              req.NodeDID,
 				Signer:               params.Signer,
 				EncryptionKeyManager: params.EncryptionKeyManager,
 				MeshIP:               meshIP.String(),
 				Label:                firstNonEmpty(req.Label, key.Label),
+				OwnerDID:             memberDID,
+				DelegateDID:          req.DelegateDID,
+				NodeKeyDelivery:      req.NodeKeyDelivery,
 				UseContextEncryption: true,
+				PermissionGrantID:    params.WritePermissionGrantID,
 			})
 			if err != nil {
 				result.Pending++
@@ -278,10 +424,12 @@ func ApprovePreAuthRequests(ctx context.Context, params ApprovePreAuthRequestsPa
 			EncryptionKeyManager: params.EncryptionKeyManager,
 		}
 		if err := kdm.DeliverContextKey(ctx, DeliverContextKeyParams{
-			AnchorDID:      params.AnchorDID,
-			RecipientDID:   req.NodeDID,
-			SourceProtocol: protocols.MeshProtocolURI,
-			ContextID:      params.NetworkRecordID,
+			AnchorDID:            params.AnchorDID,
+			RecipientDID:         req.NodeDID,
+			SourceProtocol:       protocols.MeshProtocolURI,
+			ContextID:            params.NetworkRecordID,
+			PermissionGrantID:    params.KeyDeliveryGrantID,
+			RecipientKeyDelivery: req.NodeKeyDelivery,
 		}); err != nil {
 			result.Pending++
 			continue
@@ -291,7 +439,7 @@ func ApprovePreAuthRequests(ctx context.Context, params ApprovePreAuthRequestsPa
 			result.Pending++
 			continue
 		}
-		if err := deleteRecord(ctx, api, params.AnchorDID, request.ID); err != nil {
+		if err := deleteRecord(ctx, api, params.AnchorDID, request.ID, params.DeletePermissionGrantID); err != nil {
 			result.Pending++
 			continue
 		}
@@ -299,6 +447,45 @@ func ApprovePreAuthRequests(ctx context.Context, params ApprovePreAuthRequestsPa
 	}
 
 	return result, nil
+}
+
+// NodeJoinProofMessage returns the stable message signed by a node DID when it
+// asks to join a network on behalf of a member DID.
+func NodeJoinProofMessage(networkID, nodeDID, memberDID, preAuthKeyID string) []byte {
+	if memberDID == "" {
+		memberDID = nodeDID
+	}
+	return []byte(
+		"meshd node join v1\n" +
+			"network=" + networkID + "\n" +
+			"node=" + nodeDID + "\n" +
+			"member=" + memberDID + "\n" +
+			"preauth=" + preAuthKeyID + "\n",
+	)
+}
+
+// SignNodeJoinProof signs a node join proof with the node DID signer.
+func SignNodeJoinProof(signer *dwn.Signer, networkID, nodeDID, memberDID, preAuthKeyID string) string {
+	if signer == nil || signer.DID == "" || len(signer.PrivateKey) != ed25519.PrivateKeySize {
+		return ""
+	}
+	msg := NodeJoinProofMessage(networkID, nodeDID, memberDID, preAuthKeyID)
+	sig := ed25519.Sign(signer.PrivateKey, msg)
+	return base64.RawURLEncoding.EncodeToString(sig)
+}
+
+// VerifyNodeJoinProof verifies a node join proof from a did:jwk node DID.
+func VerifyNodeJoinProof(nodeDID, proof, networkID, memberDID, preAuthKeyID string) bool {
+	pub, err := did.ParseURI(nodeDID)
+	if err != nil {
+		return false
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(proof)
+	if err != nil {
+		return false
+	}
+	msg := NodeJoinProofMessage(networkID, nodeDID, memberDID, preAuthKeyID)
+	return did.VerifyWith(pub, msg, sig)
 }
 
 func readPreAuthKey(ctx context.Context, api *dwn.DwnAPI, params ApprovePreAuthRequestsParams, recordID string) (*dwn.Record, *PreAuthKeyData, error) {
@@ -312,7 +499,8 @@ func readPreAuthKey(ctx context.Context, api *dwn.DwnAPI, params ApprovePreAuthR
 			ProtocolPath: "network/preAuthKey",
 			ContextID:    params.NetworkRecordID,
 		},
-		DateSort: "createdDescending",
+		DateSort:          "createdDescending",
+		PermissionGrantID: params.ReadPermissionGrantID,
 	}, "")
 	if err != nil {
 		return nil, nil, err
@@ -333,21 +521,40 @@ func readPreAuthKey(ctx context.Context, api *dwn.DwnAPI, params ApprovePreAuthR
 	}
 
 	var key PreAuthKeyData
-	decryptor := preAuthDecryptor(params.EncryptionKeyManager)
+	decryptor := preAuthDecryptor(params.EncryptionKeyManager, params.NetworkRecordID)
 	if err := control.ParseEntryData(record.RawEntry, &key, decryptor); err != nil {
 		return nil, nil, err
 	}
 	return record, &key, nil
 }
 
-func preAuthDecryptor(encMgr *dwncrypto.EncryptionKeyManager) control.EntryDecryptor {
+func preAuthDecryptor(encMgr *dwncrypto.EncryptionKeyManager, contextID string) control.EntryDecryptor {
 	return func(ciphertext []byte, enc *dwncrypto.Encryption) ([]byte, error) {
+		if encryptedDerivationScheme(enc) == dwncrypto.DerivationSchemeProtocolContext {
+			privKey, err := encMgr.DeriveContextDecryptionKey(contextID)
+			if err != nil {
+				return nil, err
+			}
+			return dwncrypto.DecryptDataWithScheme(ciphertext, enc, privKey, dwncrypto.DerivationSchemeProtocolContext)
+		}
 		privKey, err := encMgr.DeriveDecryptionKey("network/preAuthKey")
 		if err != nil {
 			return nil, err
 		}
 		return dwncrypto.DecryptData(ciphertext, enc, privKey, encMgr.RootKeyID)
 	}
+}
+
+func encryptedDerivationScheme(enc *dwncrypto.Encryption) string {
+	if enc == nil {
+		return dwncrypto.DerivationSchemeProtocolPath
+	}
+	for _, recipient := range enc.Recipients {
+		if recipient.Header.DerivationScheme != "" {
+			return recipient.Header.DerivationScheme
+		}
+	}
+	return dwncrypto.DerivationSchemeProtocolPath
 }
 
 func preAuthKeyAllows(key *PreAuthKeyData, nodeDID string) bool {
@@ -380,9 +587,17 @@ func markPreAuthKeyUsed(ctx context.Context, api *dwn.DwnAPI, params ApprovePreA
 	if err != nil {
 		return fmt.Errorf("marshaling used preauth key: %w", err)
 	}
-	recipients, err := params.EncryptionKeyManager.DeriveWriteEncryption("network/preAuthKey")
-	if err != nil {
-		return fmt.Errorf("deriving preauth update encryption: %w", err)
+	var recipients []dwncrypto.KeyEncryptionInput
+	if params.UseContextEncryption {
+		recipients, err = params.EncryptionKeyManager.DeriveContextWriteEncryption(params.NetworkRecordID)
+		if err != nil {
+			return fmt.Errorf("deriving preauth context update encryption: %w", err)
+		}
+	} else {
+		recipients, err = params.EncryptionKeyManager.DeriveWriteEncryption("network/preAuthKey")
+		if err != nil {
+			return fmt.Errorf("deriving preauth update encryption: %w", err)
+		}
 	}
 
 	_, status, err := api.Write(ctx, params.AnchorDID, dwn.WriteParams{
@@ -395,6 +610,7 @@ func markPreAuthKeyUsed(ctx context.Context, api *dwn.DwnAPI, params ApprovePreA
 		DateCreated:          record.DateCreated,
 		Data:                 data,
 		EncryptionRecipients: recipients,
+		PermissionGrantID:    params.WritePermissionGrantID,
 	})
 	if err != nil {
 		return fmt.Errorf("updating preauth key: %w", err)
@@ -405,7 +621,45 @@ func markPreAuthKeyUsed(ctx context.Context, api *dwn.DwnAPI, params ApprovePreA
 	return nil
 }
 
-func nodeRecordExists(ctx context.Context, api *dwn.DwnAPI, anchorDID, networkID, nodeDID string) (bool, error) {
+func ensureMemberRecord(ctx context.Context, api *dwn.DwnAPI, params ApprovePreAuthRequestsParams, memberDID, label string) (string, error) {
+	records, status, err := api.Query(ctx, params.AnchorDID, dwn.QueryParams{
+		Filter: dwn.RecordsFilter{
+			Protocol:     protocols.MeshProtocolURI,
+			ProtocolPath: "network/member",
+			ContextID:    params.NetworkRecordID,
+			Recipient:    memberDID,
+		},
+		DateSort:          "createdDescending",
+		PermissionGrantID: params.ReadPermissionGrantID,
+	}, "")
+	if err != nil {
+		return "", err
+	}
+	if status.Code != 200 {
+		return "", fmt.Errorf("member query failed: %d %s", status.Code, status.Detail)
+	}
+	if len(records) > 0 {
+		return records[0].ID, nil
+	}
+
+	reg, err := CreateMember(ctx, CreateMemberParams{
+		AnchorEndpoint:       params.AnchorEndpoint,
+		AnchorDID:            params.AnchorDID,
+		NetworkRecordID:      params.NetworkRecordID,
+		MemberDID:            memberDID,
+		Signer:               params.Signer,
+		EncryptionKeyManager: params.EncryptionKeyManager,
+		Label:                label,
+		PermissionGrantID:    params.WritePermissionGrantID,
+		UseContextEncryption: params.UseContextEncryption,
+	})
+	if err != nil {
+		return "", err
+	}
+	return reg.MemberRecordID, nil
+}
+
+func nodeRecordExists(ctx context.Context, api *dwn.DwnAPI, anchorDID, networkID, nodeDID string, permissionGrantID string) (bool, error) {
 	records, status, err := api.Query(ctx, anchorDID, dwn.QueryParams{
 		Filter: dwn.RecordsFilter{
 			Protocol:     protocols.MeshProtocolURI,
@@ -413,7 +667,8 @@ func nodeRecordExists(ctx context.Context, api *dwn.DwnAPI, anchorDID, networkID
 			ContextID:    networkID,
 			Recipient:    nodeDID,
 		},
-		DateSort: "createdDescending",
+		DateSort:          "createdDescending",
+		PermissionGrantID: permissionGrantID,
 	}, "")
 	if err != nil {
 		return false, err
@@ -421,11 +676,51 @@ func nodeRecordExists(ctx context.Context, api *dwn.DwnAPI, anchorDID, networkID
 	if status.Code != 200 {
 		return false, fmt.Errorf("node query failed: %d %s", status.Code, status.Detail)
 	}
-	return len(records) > 0, nil
+	if len(records) > 0 {
+		return true, nil
+	}
+
+	memberRecords, status, err := api.Query(ctx, anchorDID, dwn.QueryParams{
+		Filter: dwn.RecordsFilter{
+			Protocol:     protocols.MeshProtocolURI,
+			ProtocolPath: "network/member",
+			ContextID:    networkID,
+		},
+		DateSort:          "createdDescending",
+		PermissionGrantID: permissionGrantID,
+	}, "")
+	if err != nil {
+		return false, err
+	}
+	if status.Code != 200 {
+		return false, fmt.Errorf("member query failed: %d %s", status.Code, status.Detail)
+	}
+	for _, memberRecord := range memberRecords {
+		memberNodes, status, err := api.Query(ctx, anchorDID, dwn.QueryParams{
+			Filter: dwn.RecordsFilter{
+				Protocol:     protocols.MeshProtocolURI,
+				ProtocolPath: "network/member/node",
+				ContextID:    networkID + "/" + memberRecord.ID,
+				Recipient:    nodeDID,
+			},
+			DateSort:          "createdDescending",
+			PermissionGrantID: permissionGrantID,
+		}, "")
+		if err != nil {
+			return false, err
+		}
+		if status.Code != 200 {
+			return false, fmt.Errorf("member node query failed: %d %s", status.Code, status.Detail)
+		}
+		if len(memberNodes) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
-func deleteRecord(ctx context.Context, api *dwn.DwnAPI, target, recordID string) error {
-	status, err := api.Delete(ctx, target, recordID, false, "")
+func deleteRecord(ctx context.Context, api *dwn.DwnAPI, target, recordID string, permissionGrantID string) error {
+	status, err := api.Delete(ctx, target, recordID, false, "", permissionGrantID)
 	if err != nil {
 		return err
 	}

--- a/internal/mesh/preauth_test.go
+++ b/internal/mesh/preauth_test.go
@@ -1,0 +1,243 @@
+package mesh
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/enboxorg/meshd/internal/did"
+	"github.com/enboxorg/meshd/internal/dwn"
+	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
+	"github.com/enboxorg/meshd/internal/invite"
+	"github.com/enboxorg/meshd/protocols"
+)
+
+func TestApprovePreAuthRequestsRegistersWalletOwnedNodeUnderMember(t *testing.T) {
+	anchor := preAuthTestDID(t)
+	member := preAuthTestDID(t)
+	node := preAuthTestDID(t)
+
+	const (
+		networkID       = "network-record"
+		requestRecordID = "request-record"
+		preAuthRecordID = "preauth-record"
+		preAuthSecret   = "preauth-secret"
+	)
+
+	nodeSigner := &dwn.Signer{DID: node.URI, PrivateKey: node.SigningKey}
+	nodeRequest := NodeRequestData{
+		NodeDID:      node.URI,
+		MemberDID:    member.URI,
+		RequestedBy:  member.URI,
+		NodeProof:    SignNodeJoinProof(nodeSigner, networkID, node.URI, member.URI, preAuthRecordID),
+		Label:        "wallet-owned-node",
+		PreAuthKeyID: preAuthRecordID,
+		PreAuthProof: invite.Proof(preAuthSecret, networkID, node.URI),
+		RequestedAt:  time.Now().UTC().Format(time.RFC3339),
+	}
+	preAuthKey := PreAuthKeyData{
+		Key:       preAuthSecret,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		Label:     "wallet-owned-node",
+	}
+
+	var (
+		mu                  sync.Mutex
+		memberRecordID      string
+		memberNodeWrite     *dwn.Message
+		topLevelNodeWritten bool
+		deleteRecordID      string
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var rpcReq dwn.JsonRpcRequest
+		if err := json.Unmarshal([]byte(r.Header.Get("dwn-request")), &rpcReq); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if rpcReq.Params == nil || rpcReq.Params.Message == nil {
+			http.Error(w, "missing DWN message", http.StatusBadRequest)
+			return
+		}
+
+		msg := rpcReq.Params.Message
+		switch descriptorString(msg.Descriptor, "method") {
+		case "Query":
+			filter, _ := msg.Descriptor["filter"].(map[string]any)
+			var entries []json.RawMessage
+			switch descriptorString(filter, "protocolPath") {
+			case "network/node":
+				entries = nil
+			case "network/member":
+				entries = nil
+			case "network/nodeRequest":
+				entries = []json.RawMessage{
+					recordsWriteEntry(t, requestRecordID, networkID+"/"+requestRecordID, "network/nodeRequest", "", nodeRequest),
+				}
+			case "network/preAuthKey":
+				entries = []json.RawMessage{
+					recordsWriteEntry(t, preAuthRecordID, networkID+"/"+preAuthRecordID, "network/preAuthKey", "", preAuthKey),
+				}
+			default:
+				entries = nil
+			}
+			writeDWNTestReply(t, w, rpcReq.ID, dwn.Status{Code: 200, Detail: "OK"}, entries)
+		case "Write":
+			mu.Lock()
+			switch descriptorString(msg.Descriptor, "protocolPath") {
+			case "network/member":
+				memberRecordID = msg.RecordID
+			case "network/member/node":
+				copyMsg := *msg
+				memberNodeWrite = &copyMsg
+			case "network/node":
+				topLevelNodeWritten = true
+			}
+			mu.Unlock()
+			writeDWNTestReply(t, w, rpcReq.ID, dwn.Status{Code: 202, Detail: "Accepted"}, nil)
+		case "Delete":
+			mu.Lock()
+			deleteRecordID = descriptorString(msg.Descriptor, "recordId")
+			mu.Unlock()
+			writeDWNTestReply(t, w, rpcReq.ID, dwn.Status{Code: 202, Detail: "Accepted"}, nil)
+		default:
+			t.Errorf("unexpected DWN method %q", descriptorString(msg.Descriptor, "method"))
+			writeDWNTestReply(t, w, rpcReq.ID, dwn.Status{Code: 400, Detail: "Unexpected method"}, nil)
+		}
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	result, err := ApprovePreAuthRequests(ctx, ApprovePreAuthRequestsParams{
+		AnchorEndpoint:  server.URL,
+		AnchorDID:       anchor.URI,
+		NetworkRecordID: networkID,
+		MeshCIDR:        "10.200.0.0/16",
+		Signer: &dwn.Signer{
+			DID:        anchor.URI,
+			PrivateKey: anchor.SigningKey,
+		},
+		EncryptionKeyManager: &dwncrypto.EncryptionKeyManager{
+			RootPrivateKey: anchor.EncryptionPrivateKey,
+			RootKeyID:      anchor.EncryptionKeyID(),
+			ProtocolURI:    protocols.MeshProtocolURI,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApprovePreAuthRequests: %v", err)
+	}
+	if result.Approved != 1 || result.Pending != 0 || result.Rejected != 0 {
+		t.Fatalf("result = %#v, want one approved request", result)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if memberRecordID == "" {
+		t.Fatal("member record was not created")
+	}
+	if memberNodeWrite == nil {
+		t.Fatal("member-associated node record was not written")
+	}
+	if topLevelNodeWritten {
+		t.Fatal("approved wallet-owned node was written as top-level network/node")
+	}
+	if got := descriptorString(memberNodeWrite.Descriptor, "protocolPath"); got != "network/member/node" {
+		t.Fatalf("node protocolPath = %q, want network/member/node", got)
+	}
+	if got := descriptorString(memberNodeWrite.Descriptor, "recipient"); got != node.URI {
+		t.Fatalf("node recipient = %q, want node DID", got)
+	}
+	if got := descriptorString(memberNodeWrite.Descriptor, "parentId"); got != memberRecordID {
+		t.Fatalf("node parentId = %q, want member record %q", got, memberRecordID)
+	}
+	if wantPrefix := networkID + "/" + memberRecordID + "/"; !strings.HasPrefix(memberNodeWrite.ContextID, wantPrefix) {
+		t.Fatalf("node contextId = %q, want prefix %q", memberNodeWrite.ContextID, wantPrefix)
+	}
+	if deleteRecordID != requestRecordID {
+		t.Fatalf("deleted record = %q, want node request %q", deleteRecordID, requestRecordID)
+	}
+}
+
+func preAuthTestDID(t *testing.T) *did.DID {
+	t.Helper()
+	id, err := did.Generate()
+	if err != nil {
+		t.Fatalf("Generate DID: %v", err)
+	}
+	return id
+}
+
+func recordsWriteEntry(t *testing.T, recordID, contextID, protocolPath, recipient string, data any) json.RawMessage {
+	t.Helper()
+
+	dataBytes, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("marshal entry data: %v", err)
+	}
+
+	descriptor := map[string]any{
+		"interface":        "Records",
+		"method":           "Write",
+		"protocol":         protocols.MeshProtocolURI,
+		"protocolPath":     protocolPath,
+		"dataFormat":       "application/json",
+		"dateCreated":      dwn.Now(),
+		"messageTimestamp": dwn.Now(),
+	}
+	if recipient != "" {
+		descriptor["recipient"] = recipient
+	}
+
+	entry := map[string]any{
+		"recordId":    recordID,
+		"contextId":   contextID,
+		"descriptor":  descriptor,
+		"encodedData": base64.RawURLEncoding.EncodeToString(dataBytes),
+	}
+	entryBytes, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal entry: %v", err)
+	}
+	return entryBytes
+}
+
+func writeDWNTestReply(t *testing.T, w http.ResponseWriter, id string, status dwn.Status, entries []json.RawMessage) {
+	t.Helper()
+
+	var entriesJSON json.RawMessage
+	if entries != nil {
+		var err error
+		entriesJSON, err = json.Marshal(entries)
+		if err != nil {
+			t.Fatalf("marshal entries: %v", err)
+		}
+	}
+
+	reply := &dwn.JsonRpcResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result: &dwn.JsonRpcResult{
+			Reply: &dwn.DwnReply{
+				Status:  status,
+				Entries: entriesJSON,
+			},
+		},
+	}
+	if err := json.NewEncoder(w).Encode(reply); err != nil {
+		t.Fatalf("write DWN reply: %v", err)
+	}
+}
+
+func descriptorString(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	v, _ := m[key].(string)
+	return v
+}

--- a/internal/mesh/register.go
+++ b/internal/mesh/register.go
@@ -17,13 +17,14 @@ import (
 )
 
 const (
-	schemaMember      = "https://enbox.id/schemas/wireguard-mesh/member"
-	schemaNodeRequest = "https://enbox.id/schemas/wireguard-mesh/node-request"
-	schemaNode        = "https://enbox.id/schemas/wireguard-mesh/node"
-	schemaNodeInfo    = "https://enbox.id/schemas/wireguard-mesh/node-info"
-	schemaEndpoint    = "https://enbox.id/schemas/wireguard-mesh/endpoint"
-	schemaACLPolicy   = "https://enbox.id/schemas/wireguard-mesh/acl-policy"
-	schemaPreAuthKey  = "https://enbox.id/schemas/wireguard-mesh/pre-auth-key"
+	schemaMember       = "https://enbox.id/schemas/wireguard-mesh/member"
+	schemaNodeRequest  = "https://enbox.id/schemas/wireguard-mesh/node-request"
+	schemaNodeApproval = "https://enbox.id/schemas/wireguard-mesh/node-approval"
+	schemaNode         = "https://enbox.id/schemas/wireguard-mesh/node"
+	schemaNodeInfo     = "https://enbox.id/schemas/wireguard-mesh/node-info"
+	schemaEndpoint     = "https://enbox.id/schemas/wireguard-mesh/endpoint"
+	schemaACLPolicy    = "https://enbox.id/schemas/wireguard-mesh/acl-policy"
+	schemaPreAuthKey   = "https://enbox.id/schemas/wireguard-mesh/pre-auth-key"
 )
 
 // MemberRegistration holds the result of creating a member record.
@@ -41,6 +42,8 @@ type CreateMemberParams struct {
 	Signer               *dwn.Signer
 	EncryptionKeyManager *dwncrypto.EncryptionKeyManager
 	Label                string
+	PermissionGrantID    string
+	UseContextEncryption bool
 }
 
 // CreateMember creates a member record on the anchor DWN.
@@ -58,12 +61,18 @@ func CreateMember(ctx context.Context, params CreateMemberParams) (*MemberRegist
 		return nil, fmt.Errorf("marshaling member data: %w", err)
 	}
 
-	// Member records use Protocol Path encryption (anchor-owned).
 	var recipients []dwncrypto.KeyEncryptionInput
 	if params.EncryptionKeyManager != nil {
-		recipients, err = params.EncryptionKeyManager.DeriveWriteEncryption("network/member")
-		if err != nil {
-			return nil, fmt.Errorf("deriving member encryption: %w", err)
+		if params.UseContextEncryption {
+			recipients, err = params.EncryptionKeyManager.DeriveContextWriteEncryption(params.NetworkRecordID)
+			if err != nil {
+				return nil, fmt.Errorf("deriving member context encryption: %w", err)
+			}
+		} else {
+			recipients, err = params.EncryptionKeyManager.DeriveWriteEncryption("network/member")
+			if err != nil {
+				return nil, fmt.Errorf("deriving member encryption: %w", err)
+			}
 		}
 	}
 
@@ -79,6 +88,7 @@ func CreateMember(ctx context.Context, params CreateMemberParams) (*MemberRegist
 		ParentContextID:      params.NetworkRecordID,
 		Data:                 memberDataBytes,
 		EncryptionRecipients: recipients,
+		PermissionGrantID:    params.PermissionGrantID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("writing member record: %w", err)
@@ -140,6 +150,22 @@ type RegisterNodeParams struct {
 	// Label is a human-readable label for this node.
 	Label string
 
+	// OwnerDID is the wallet/member DID that owns this node. It is optional
+	// and defaults to NodeDID for local-only devices.
+	OwnerDID string
+
+	// DelegateDID is the local delegate/session DID that has wallet grants to
+	// operate this node. It is optional and omitted for local-only devices.
+	DelegateDID string
+
+	// ExpiresAt is the optional owner-controlled membership expiry. Empty means
+	// the node membership does not expire automatically.
+	ExpiresAt string
+
+	// NodeKeyDelivery is this node's key-delivery ProtocolPath public key,
+	// used by anchors to encrypt delivered network context keys to the node.
+	NodeKeyDelivery *dwncrypto.KeyDeliveryPublic
+
 	// ExistingNodeRecordID is set when updating an existing node record.
 	// Leave empty for initial registration.
 	ExistingNodeRecordID string
@@ -156,6 +182,10 @@ type RegisterNodeParams struct {
 
 	// Squash indicates this is a squash (snapshot) write.
 	Squash bool
+
+	// PermissionGrantID invokes a wallet/member grant when the signer is a
+	// local node DID acting for the network owner.
+	PermissionGrantID string
 }
 
 // RegisterNode writes or updates the node record (encrypted) on the anchor DWN.
@@ -178,6 +208,22 @@ func RegisterNode(ctx context.Context, params RegisterNodeParams) (*NodeRegistra
 	}
 	if params.Label != "" {
 		nodeData["label"] = params.Label
+	}
+	if params.OwnerDID != "" && params.OwnerDID != params.NodeDID {
+		nodeData["ownerDID"] = params.OwnerDID
+		nodeData["memberDID"] = params.OwnerDID
+	}
+	if params.DelegateDID != "" && params.DelegateDID != params.NodeDID {
+		nodeData["delegateDID"] = params.DelegateDID
+	}
+	if params.ExpiresAt != "" {
+		nodeData["expiresAt"] = params.ExpiresAt
+	}
+	if params.NodeKeyDelivery != nil {
+		if err := validateNodeKeyDelivery(params.NodeDID, params.NodeKeyDelivery); err != nil {
+			return nil, err
+		}
+		nodeData["nodeKeyDelivery"] = params.NodeKeyDelivery
 	}
 	nodeDataBytes, err := json.Marshal(nodeData)
 	if err != nil {
@@ -229,6 +275,7 @@ func RegisterNode(ctx context.Context, params RegisterNodeParams) (*NodeRegistra
 		Data:                 nodeDataBytes,
 		EncryptionRecipients: recipients,
 		Squash:               params.Squash,
+		PermissionGrantID:    params.PermissionGrantID,
 	}
 
 	// If updating, set the existing record ID and preserve dateCreated.
@@ -266,6 +313,7 @@ type WriteNodeInfoParams struct {
 	Signer               *dwn.Signer
 	EncryptionKeyManager *dwncrypto.EncryptionKeyManager
 	Hostname             string
+	PermissionGrantID    string
 
 	// UseContextEncryption enables Protocol Context encryption.
 	UseContextEncryption bool
@@ -336,6 +384,7 @@ func WriteNodeInfo(ctx context.Context, params WriteNodeInfoParams) error {
 		Data:                 infoDataBytes,
 		EncryptionRecipients: recipients,
 		Squash:               true,
+		PermissionGrantID:    params.PermissionGrantID,
 	})
 	if err != nil {
 		return fmt.Errorf("writing nodeInfo: %w", err)
@@ -411,6 +460,7 @@ func WriteEndpoint(ctx context.Context, params WriteEndpointParams) error {
 		Data:                 endpointData,
 		EncryptionRecipients: recipients,
 		Squash:               true,
+		PermissionGrantID:    params.PermissionGrantID,
 	})
 	if err != nil {
 		return fmt.Errorf("writing endpoint: %w", err)
@@ -434,6 +484,7 @@ type WriteEndpointParams struct {
 	PublicEndpoints      []control.PublicEndpoint
 	LocalEndpoints       []string
 	NATType              string
+	PermissionGrantID    string
 
 	// DiscoKey is this node's current disco public key (base64).
 	DiscoKey string
@@ -449,6 +500,8 @@ type WriteACLPolicyParams struct {
 	NetworkRecordID      string
 	Signer               *dwn.Signer
 	EncryptionKeyManager *dwncrypto.EncryptionKeyManager
+	PermissionGrantID    string
+	UseContextEncryption bool
 
 	// PolicyData is the JSON-encoded ACL policy payload.
 	PolicyData []byte
@@ -461,10 +514,18 @@ func WriteACLPolicy(ctx context.Context, params WriteACLPolicyParams) error {
 		return fmt.Errorf("EncryptionKeyManager is required for encrypted writes")
 	}
 
-	// The anchor always uses Protocol Path encryption for records it owns.
-	recipients, err := params.EncryptionKeyManager.DeriveWriteEncryption("network/aclPolicy")
-	if err != nil {
-		return fmt.Errorf("deriving ACL policy encryption: %w", err)
+	var recipients []dwncrypto.KeyEncryptionInput
+	var err error
+	if params.UseContextEncryption {
+		recipients, err = params.EncryptionKeyManager.DeriveContextWriteEncryption(params.NetworkRecordID)
+		if err != nil {
+			return fmt.Errorf("deriving ACL policy context encryption: %w", err)
+		}
+	} else {
+		recipients, err = params.EncryptionKeyManager.DeriveWriteEncryption("network/aclPolicy")
+		if err != nil {
+			return fmt.Errorf("deriving ACL policy encryption: %w", err)
+		}
 	}
 
 	agent := dwn.NewSimpleAgent(params.AnchorEndpoint, params.Signer)
@@ -479,6 +540,7 @@ func WriteACLPolicy(ctx context.Context, params WriteACLPolicyParams) error {
 		Data:                 params.PolicyData,
 		EncryptionRecipients: recipients,
 		Squash:               true,
+		PermissionGrantID:    params.PermissionGrantID,
 	})
 	if err != nil {
 		return fmt.Errorf("writing ACL policy: %w", err)

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -60,6 +60,94 @@ type Entry struct {
 	Name      string `json:"name"`
 	DID       string `json:"did"`
 	CreatedAt string `json:"createdAt"`
+
+	// AuthType identifies how this profile's local credentials were created.
+	// Empty means local-vault for backwards compatibility with older configs.
+	AuthType string `json:"authType,omitempty"`
+
+	// OwnerDID is the durable wallet/member DID this profile acts for.
+	// Local-only profiles default this to DID.
+	OwnerDID string `json:"ownerDID,omitempty"`
+
+	// ConnectedDID is the pre-beta name for OwnerDID. Keep writing and reading
+	// it while wallet-connected profiles transition.
+	ConnectedDID string `json:"connectedDid,omitempty"`
+
+	// DelegateDID is the local control/session DID that receives wallet-issued
+	// grants for this node. Legacy wallet sessions may leave it empty and grant
+	// directly to NodeDID instead.
+	DelegateDID string `json:"delegateDid,omitempty"`
+
+	// NodeDID is the machine/device DID used for WireGuard keys and node
+	// records. Local-only profiles default this to DID.
+	NodeDID string `json:"nodeDid,omitempty"`
+
+	// WalletOrigin records the wallet origin that granted this profile.
+	WalletOrigin string `json:"walletOrigin,omitempty"`
+
+	// ExpiresAt records the wallet delegate/session expiry, if any.
+	ExpiresAt string `json:"expiresAt,omitempty"`
+}
+
+const (
+	AuthTypeLocalVault           = "local-vault"
+	AuthTypeWalletAuthorizedNode = "wallet-authorized-node"
+
+	// AuthTypeWalletDelegate is the pre-beta name for wallet-authorized node
+	// profiles. Keep accepting it so existing config files continue to work.
+	AuthTypeWalletDelegate = "wallet-delegate"
+)
+
+// NormalizeAuthType returns the canonical auth type, applying legacy aliases.
+func NormalizeAuthType(authType string) string {
+	switch authType {
+	case "", AuthTypeLocalVault:
+		return AuthTypeLocalVault
+	case AuthTypeWalletDelegate, AuthTypeWalletAuthorizedNode:
+		return AuthTypeWalletAuthorizedNode
+	default:
+		return authType
+	}
+}
+
+// EffectiveAuthType returns the auth type, applying the legacy default.
+func (e *Entry) EffectiveAuthType() string {
+	if e == nil {
+		return AuthTypeLocalVault
+	}
+	return NormalizeAuthType(e.AuthType)
+}
+
+// EffectiveOwnerDID returns the wallet/member DID, applying local defaults.
+func (e *Entry) EffectiveOwnerDID() string {
+	if e == nil {
+		return ""
+	}
+	if e.OwnerDID != "" {
+		return e.OwnerDID
+	}
+	if e.ConnectedDID != "" {
+		return e.ConnectedDID
+	}
+	return e.DID
+}
+
+// EffectiveConnectedDID returns the wallet/member DID, applying local defaults.
+//
+// Deprecated: use EffectiveOwnerDID.
+func (e *Entry) EffectiveConnectedDID() string {
+	return e.EffectiveOwnerDID()
+}
+
+// EffectiveNodeDID returns the node/device DID, applying local defaults.
+func (e *Entry) EffectiveNodeDID() string {
+	if e == nil {
+		return ""
+	}
+	if e.NodeDID != "" {
+		return e.NodeDID
+	}
+	return e.DID
 }
 
 // EnboxHome returns the base directory for enbox data.
@@ -149,8 +237,28 @@ func WriteConfig(cfg *Config) error {
 // UpsertProfile adds or updates a profile entry in config.json.
 // If this is the first profile, it becomes the default.
 func UpsertProfile(name, did string) error {
+	return UpsertProfileEntry(&Entry{
+		Name:         name,
+		DID:          did,
+		AuthType:     AuthTypeLocalVault,
+		OwnerDID:     did,
+		ConnectedDID: did,
+		NodeDID:      did,
+	})
+}
+
+// UpsertProfileEntry adds or updates a profile entry in config.json.
+// If this is the first profile, it becomes the default.
+func UpsertProfileEntry(entry *Entry) error {
+	if entry == nil {
+		return fmt.Errorf("profile entry is required")
+	}
+	name := entry.Name
 	if err := ValidateName(name); err != nil {
 		return err
+	}
+	if entry.DID == "" {
+		return fmt.Errorf("profile DID is required")
 	}
 
 	cfg, err := ReadConfig()
@@ -159,18 +267,28 @@ func UpsertProfile(name, did string) error {
 	}
 
 	isNew := cfg.Profiles[name] == nil
-	entry := &Entry{
-		Name:      name,
-		DID:       did,
-		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+	next := *entry
+	next.CreatedAt = time.Now().UTC().Format(time.RFC3339)
+	next.AuthType = NormalizeAuthType(next.AuthType)
+	if next.OwnerDID == "" {
+		next.OwnerDID = next.ConnectedDID
+	}
+	if next.ConnectedDID == "" {
+		next.ConnectedDID = next.OwnerDID
+	}
+	if next.OwnerDID == "" {
+		next.OwnerDID = next.DID
+		next.ConnectedDID = next.DID
+	}
+	if next.NodeDID == "" {
+		next.NodeDID = next.DID
 	}
 	if !isNew {
 		// Preserve original createdAt on updates.
-		entry.CreatedAt = cfg.Profiles[name].CreatedAt
-		entry.DID = did
+		next.CreatedAt = cfg.Profiles[name].CreatedAt
 	}
 
-	cfg.Profiles[name] = entry
+	cfg.Profiles[name] = &next
 
 	// First profile becomes the default.
 	if len(cfg.Profiles) == 1 || cfg.DefaultProfile == "" {

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -122,6 +122,85 @@ func TestUpsertProfileFirstIsDefault(t *testing.T) {
 	if cfg.Profiles["first"] == nil {
 		t.Fatal("profile 'first' missing")
 	}
+	if cfg.Profiles["first"].AuthType != AuthTypeLocalVault {
+		t.Errorf("authType = %q, want %q", cfg.Profiles["first"].AuthType, AuthTypeLocalVault)
+	}
+	if cfg.Profiles["first"].OwnerDID != "did:dht:111" {
+		t.Errorf("ownerDID = %q", cfg.Profiles["first"].OwnerDID)
+	}
+	if cfg.Profiles["first"].ConnectedDID != "did:dht:111" {
+		t.Errorf("connectedDid = %q", cfg.Profiles["first"].ConnectedDID)
+	}
+	if cfg.Profiles["first"].NodeDID != "did:dht:111" {
+		t.Errorf("nodeDid = %q", cfg.Profiles["first"].NodeDID)
+	}
+}
+
+func TestEntryEffectiveIdentityDefaults(t *testing.T) {
+	entry := &Entry{DID: "did:jwk:local"}
+	if got := entry.EffectiveAuthType(); got != AuthTypeLocalVault {
+		t.Fatalf("EffectiveAuthType = %q, want %q", got, AuthTypeLocalVault)
+	}
+	if got := entry.EffectiveOwnerDID(); got != "did:jwk:local" {
+		t.Fatalf("EffectiveOwnerDID = %q", got)
+	}
+	if got := entry.EffectiveNodeDID(); got != "did:jwk:local" {
+		t.Fatalf("EffectiveNodeDID = %q", got)
+	}
+}
+
+func TestEntryEffectiveAuthTypeNormalizesLegacyWalletDelegate(t *testing.T) {
+	entry := &Entry{
+		DID:      "did:jwk:node",
+		AuthType: AuthTypeWalletDelegate,
+	}
+	if got := entry.EffectiveAuthType(); got != AuthTypeWalletAuthorizedNode {
+		t.Fatalf("EffectiveAuthType = %q, want %q", got, AuthTypeWalletAuthorizedNode)
+	}
+}
+
+func TestUpsertProfileEntryWalletAuthorizedNode(t *testing.T) {
+	withEnboxHome(t)
+	err := UpsertProfileEntry(&Entry{
+		Name:         "cli",
+		DID:          "did:jwk:delegate",
+		AuthType:     AuthTypeWalletAuthorizedNode,
+		OwnerDID:     "did:dht:wallet",
+		DelegateDID:  "did:jwk:delegate",
+		NodeDID:      "did:jwk:node",
+		WalletOrigin: "https://wallet.enbox.id",
+		ExpiresAt:    "2026-07-23T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("UpsertProfileEntry: %v", err)
+	}
+
+	cfg, err := ReadConfig()
+	if err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+	got := cfg.Profiles["cli"]
+	if got == nil {
+		t.Fatal("profile missing")
+	}
+	if got.AuthType != AuthTypeWalletAuthorizedNode {
+		t.Fatalf("stored authType = %q, want %q", got.AuthType, AuthTypeWalletAuthorizedNode)
+	}
+	if got.EffectiveAuthType() != AuthTypeWalletAuthorizedNode {
+		t.Fatalf("authType = %q", got.AuthType)
+	}
+	if got.EffectiveOwnerDID() != "did:dht:wallet" {
+		t.Fatalf("ownerDID = %q", got.EffectiveOwnerDID())
+	}
+	if got.ConnectedDID != "did:dht:wallet" {
+		t.Fatalf("legacy connectedDid = %q", got.ConnectedDID)
+	}
+	if got.EffectiveNodeDID() != "did:jwk:node" {
+		t.Fatalf("nodeDid = %q", got.EffectiveNodeDID())
+	}
+	if got.DelegateDID != "did:jwk:delegate" || got.WalletOrigin != "https://wallet.enbox.id" {
+		t.Fatalf("wallet metadata not preserved: %+v", got)
+	}
 }
 
 func TestUpsertProfileSecondDoesNotChangeDefault(t *testing.T) {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -65,6 +65,25 @@ type NetworkState struct {
 	// MeshIP is this node's allocated IP within the mesh.
 	MeshIP string `json:"meshIp,omitempty"`
 
+	// NodeDID is this machine's device DID. It is the DID used for WireGuard
+	// key derivation, node records, endpoint writes, and "this device" UI.
+	// Older state files omit it; callers should fall back to the local profile
+	// DID when empty.
+	NodeDID string `json:"nodeDid,omitempty"`
+
+	// OwnerDID is the durable wallet/member DID that owns this node. In
+	// local-vault mode it is usually the same as NodeDID. In wallet-connected
+	// mode it is the wallet identity while NodeDID remains device-local.
+	OwnerDID string `json:"ownerDid,omitempty"`
+
+	// MemberDID is the pre-beta JSON name for OwnerDID. Keep writing and reading
+	// it so existing network.json files and tooling continue to work.
+	MemberDID string `json:"memberDid,omitempty"`
+
+	// DelegateDID is the local control/session DID with wallet-issued grants for
+	// this node. Older state may omit it and grant directly to NodeDID.
+	DelegateDID string `json:"delegateDid,omitempty"`
+
 	// NodeRecordID is the record ID of this node's node record on the anchor DWN.
 	NodeRecordID string `json:"nodeRecordId,omitempty"`
 
@@ -81,6 +100,14 @@ type NetworkState struct {
 	// record write. Required for updates because dateCreated is immutable.
 	MemberDateCreated string `json:"memberDateCreated,omitempty"`
 
+	// PendingOwnerRequestID is set while this node is waiting for a wallet
+	// owner to approve it from the dashboard. During this state
+	// NetworkRecordID and NodeRecordID are intentionally empty.
+	PendingOwnerRequestID string `json:"pendingOwnerRequestId,omitempty"`
+
+	// PendingOwnerRequestAt is when the owner-scoped node request was written.
+	PendingOwnerRequestAt string `json:"pendingOwnerRequestAt,omitempty"`
+
 	// ContextKey is a legacy plaintext cache of the Protocol Context
 	// encryption key (base64-encoded X25519 private key). New encrypted
 	// identity profiles store context keys in secrets.vault.json instead.
@@ -90,6 +117,48 @@ type NetworkState struct {
 	ContextKey string `json:"contextKey,omitempty"`
 }
 
+// NormalizeOwnerDID keeps the newer ownerDid field and the older memberDid
+// field interchangeable while local state files transition.
+func (ns *NetworkState) NormalizeOwnerDID() {
+	if ns == nil {
+		return
+	}
+	if ns.OwnerDID == "" {
+		ns.OwnerDID = ns.MemberDID
+	}
+	if ns.MemberDID == "" {
+		ns.MemberDID = ns.OwnerDID
+	}
+}
+
+// EffectiveNodeDID returns the node/device DID, applying the legacy fallback.
+func (ns *NetworkState) EffectiveNodeDID(fallback string) string {
+	if ns != nil && ns.NodeDID != "" {
+		return ns.NodeDID
+	}
+	return fallback
+}
+
+// EffectiveOwnerDID returns the wallet owner/member DID, applying local defaults.
+func (ns *NetworkState) EffectiveOwnerDID(fallback string) string {
+	if ns != nil {
+		if ns.OwnerDID != "" {
+			return ns.OwnerDID
+		}
+		if ns.MemberDID != "" {
+			return ns.MemberDID
+		}
+	}
+	return fallback
+}
+
+// EffectiveMemberDID returns the wallet/member DID, applying local defaults.
+//
+// Deprecated: use EffectiveOwnerDID.
+func (ns *NetworkState) EffectiveMemberDID(fallback string) string {
+	return ns.EffectiveOwnerDID(fallback)
+}
+
 const networkFile = "network.json"
 
 // SaveNetworkState persists network membership state.
@@ -97,6 +166,7 @@ func SaveNetworkState(stateDir string, ns *NetworkState) error {
 	if err := os.MkdirAll(stateDir, 0700); err != nil {
 		return fmt.Errorf("create state dir: %w", err)
 	}
+	ns.NormalizeOwnerDID()
 
 	data, err := json.MarshalIndent(ns, "", "  ")
 	if err != nil {
@@ -131,6 +201,7 @@ func LoadNetworkState(stateDir string) (*NetworkState, error) {
 	if err := json.Unmarshal(data, &ns); err != nil {
 		return nil, fmt.Errorf("unmarshal: %w", err)
 	}
+	ns.NormalizeOwnerDID()
 	return &ns, nil
 }
 

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,0 +1,52 @@
+package state
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNetworkStateOwnerDIDCompatibility(t *testing.T) {
+	t.Run("save writes owner and legacy member aliases", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := SaveNetworkState(dir, &NetworkState{
+			NetworkRecordID: "network-1",
+			OwnerDID:        "did:dht:wallet",
+			NodeDID:         "did:jwk:node",
+		}); err != nil {
+			t.Fatalf("SaveNetworkState: %v", err)
+		}
+
+		data, err := os.ReadFile(filepath.Join(dir, networkFile))
+		if err != nil {
+			t.Fatalf("ReadFile: %v", err)
+		}
+		var raw map[string]any
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if raw["ownerDid"] != "did:dht:wallet" || raw["memberDid"] != "did:dht:wallet" {
+			t.Fatalf("raw aliases = owner %v member %v", raw["ownerDid"], raw["memberDid"])
+		}
+	})
+
+	t.Run("load old member state populates owner", func(t *testing.T) {
+		dir := t.TempDir()
+		data := []byte(`{"networkRecordId":"network-1","memberDid":"did:dht:wallet","nodeDid":"did:jwk:node"}`)
+		if err := os.WriteFile(filepath.Join(dir, networkFile), data, 0600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		ns, err := LoadNetworkState(dir)
+		if err != nil {
+			t.Fatalf("LoadNetworkState: %v", err)
+		}
+		if ns.OwnerDID != "did:dht:wallet" || ns.MemberDID != "did:dht:wallet" {
+			t.Fatalf("state aliases = owner %q member %q", ns.OwnerDID, ns.MemberDID)
+		}
+		if got := ns.EffectiveOwnerDID("fallback"); got != "did:dht:wallet" {
+			t.Fatalf("EffectiveOwnerDID = %q", got)
+		}
+	})
+}

--- a/internal/state/wallet_session.go
+++ b/internal/state/wallet_session.go
@@ -1,0 +1,147 @@
+package state
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/enboxorg/meshd/internal/vault"
+)
+
+const walletSessionFile = "session.vault.json"
+
+type WalletSession struct {
+	Version int `json:"version"`
+	// OwnerDID is the wallet/member DID that issued the grants.
+	OwnerDID string `json:"ownerDID,omitempty"`
+	// ConnectedDID is the pre-beta name for OwnerDID. Keep writing and reading
+	// it while wallet-connected profiles transition.
+	ConnectedDID string `json:"connectedDid,omitempty"`
+	// DelegateDID is the local control/session DID that receives wallet-issued
+	// grants for this node. Older sessions may omit it and grant directly to
+	// NodeDID instead.
+	DelegateDID string `json:"delegateDid,omitempty"`
+	// NodeDID is the local device DID used for mesh identity and node records.
+	NodeDID                     string            `json:"nodeDid"`
+	WalletOrigin                string            `json:"walletOrigin,omitempty"`
+	ExpiresAt                   string            `json:"expiresAt,omitempty"`
+	Grants                      []json.RawMessage `json:"grants,omitempty"`
+	NodeContextKeys             []json.RawMessage `json:"nodeContextKeys,omitempty"`
+	NodeMultiPartyProtocols     []string          `json:"nodeMultiPartyProtocols,omitempty"`
+	DelegateDecryptionKeys      []json.RawMessage `json:"delegateDecryptionKeys,omitempty"`
+	DelegateContextKeys         []json.RawMessage `json:"delegateContextKeys,omitempty"`
+	DelegateMultiPartyProtocols []string          `json:"delegateMultiPartyProtocols,omitempty"`
+}
+
+func (s *WalletSession) NormalizeOwnerDID() {
+	if s == nil {
+		return
+	}
+	if s.OwnerDID == "" {
+		s.OwnerDID = s.ConnectedDID
+	}
+	if s.ConnectedDID == "" {
+		s.ConnectedDID = s.OwnerDID
+	}
+}
+
+func (s *WalletSession) EffectiveOwnerDID() string {
+	if s == nil {
+		return ""
+	}
+	if s.OwnerDID != "" {
+		return s.OwnerDID
+	}
+	return s.ConnectedDID
+}
+
+func (s *WalletSession) EffectiveNodeContextKeys() []json.RawMessage {
+	if s == nil {
+		return nil
+	}
+	if len(s.NodeContextKeys) > 0 {
+		return s.NodeContextKeys
+	}
+	return s.DelegateContextKeys
+}
+
+func (s *WalletSession) EffectiveNodeMultiPartyProtocols() []string {
+	if s == nil {
+		return nil
+	}
+	if len(s.NodeMultiPartyProtocols) > 0 {
+		return s.NodeMultiPartyProtocols
+	}
+	return s.DelegateMultiPartyProtocols
+}
+
+func StoreWalletSession(stateDir string, password string, session *WalletSession) error {
+	if session == nil {
+		return fmt.Errorf("wallet session is required")
+	}
+	if session.Version == 0 {
+		session.Version = 1
+	}
+	session.NormalizeOwnerDID()
+	if session.EffectiveOwnerDID() == "" {
+		return fmt.Errorf("owner DID is required")
+	}
+	if session.NodeDID == "" {
+		return fmt.Errorf("node DID is required")
+	}
+	if len(session.NodeContextKeys) == 0 && len(session.DelegateContextKeys) > 0 {
+		session.NodeContextKeys = append([]json.RawMessage(nil), session.DelegateContextKeys...)
+	}
+	if len(session.NodeMultiPartyProtocols) == 0 && len(session.DelegateMultiPartyProtocols) > 0 {
+		session.NodeMultiPartyProtocols = append([]string(nil), session.DelegateMultiPartyProtocols...)
+	}
+	if err := os.MkdirAll(stateDir, 0700); err != nil {
+		return fmt.Errorf("create state dir: %w", err)
+	}
+	plaintext, err := json.Marshal(session)
+	if err != nil {
+		return fmt.Errorf("marshal wallet session: %w", err)
+	}
+	sealed, err := vault.Seal(plaintext, password)
+	if err != nil {
+		return err
+	}
+
+	target := filepath.Join(stateDir, walletSessionFile)
+	tmp := target + ".tmp"
+	if err := os.WriteFile(tmp, sealed, 0600); err != nil {
+		return fmt.Errorf("write encrypted wallet session: %w", err)
+	}
+	if err := os.Rename(tmp, target); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("rename encrypted wallet session: %w", err)
+	}
+	return nil
+}
+
+func LoadWalletSession(stateDir string, password string) (*WalletSession, error) {
+	target := filepath.Join(stateDir, walletSessionFile)
+	data, err := os.ReadFile(target)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read encrypted wallet session: %w", err)
+	}
+	plaintext, err := vault.Open(data, password)
+	if err != nil {
+		return nil, fmt.Errorf("open encrypted wallet session: %w", err)
+	}
+	var session WalletSession
+	if err := json.Unmarshal(plaintext, &session); err != nil {
+		return nil, fmt.Errorf("unmarshal wallet session: %w", err)
+	}
+	session.NormalizeOwnerDID()
+	return &session, nil
+}
+
+func WalletSessionExists(stateDir string) bool {
+	_, err := os.Stat(filepath.Join(stateDir, walletSessionFile))
+	return err == nil
+}

--- a/internal/state/wallet_session_test.go
+++ b/internal/state/wallet_session_test.go
@@ -1,0 +1,92 @@
+package state
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestWalletSessionRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	session := &WalletSession{
+		OwnerDID:                "did:dht:wallet",
+		DelegateDID:             "did:jwk:delegate",
+		NodeDID:                 "did:jwk:node",
+		WalletOrigin:            "https://wallet.enbox.id",
+		ExpiresAt:               "2026-07-23T00:00:00Z",
+		Grants:                  []json.RawMessage{json.RawMessage(`{"id":"grant-1"}`)},
+		NodeContextKeys:         []json.RawMessage{json.RawMessage(`{"contextId":"network-1"}`)},
+		NodeMultiPartyProtocols: []string{"https://enbox.id/protocols/wireguard-mesh"},
+	}
+	if err := StoreWalletSession(dir, "password", session); err != nil {
+		t.Fatalf("StoreWalletSession: %v", err)
+	}
+	if !WalletSessionExists(dir) {
+		t.Fatal("wallet session file not found")
+	}
+
+	got, err := LoadWalletSession(dir, "password")
+	if err != nil {
+		t.Fatalf("LoadWalletSession: %v", err)
+	}
+	if got.EffectiveOwnerDID() != session.OwnerDID {
+		t.Fatalf("owner DID = %q", got.EffectiveOwnerDID())
+	}
+	if got.ConnectedDID != session.OwnerDID {
+		t.Fatalf("legacy connected DID = %q", got.ConnectedDID)
+	}
+	if got.NodeDID != session.NodeDID {
+		t.Fatalf("node DID = %q", got.NodeDID)
+	}
+	if len(got.Grants) != 1 || string(got.Grants[0]) != `{"id":"grant-1"}` {
+		t.Fatalf("grants = %v", got.Grants)
+	}
+	if len(got.EffectiveNodeContextKeys()) != 1 {
+		t.Fatalf("node context keys = %v", got.EffectiveNodeContextKeys())
+	}
+	if len(got.EffectiveNodeMultiPartyProtocols()) != 1 {
+		t.Fatalf("node protocols = %v", got.EffectiveNodeMultiPartyProtocols())
+	}
+}
+
+func TestWalletSessionLegacyConnectedDIDFallback(t *testing.T) {
+	dir := t.TempDir()
+	session := &WalletSession{
+		ConnectedDID: "did:dht:wallet",
+		NodeDID:      "did:jwk:node",
+	}
+	if err := StoreWalletSession(dir, "password", session); err != nil {
+		t.Fatalf("StoreWalletSession: %v", err)
+	}
+
+	got, err := LoadWalletSession(dir, "password")
+	if err != nil {
+		t.Fatalf("LoadWalletSession: %v", err)
+	}
+	if got.OwnerDID != "did:dht:wallet" || got.ConnectedDID != "did:dht:wallet" {
+		t.Fatalf("owner aliases = owner %q connected %q", got.OwnerDID, got.ConnectedDID)
+	}
+}
+
+func TestWalletSessionLegacyDelegateContextKeysFallback(t *testing.T) {
+	dir := t.TempDir()
+	session := &WalletSession{
+		ConnectedDID:                "did:dht:wallet",
+		NodeDID:                     "did:jwk:node",
+		DelegateContextKeys:         []json.RawMessage{json.RawMessage(`{"contextId":"network-1"}`)},
+		DelegateMultiPartyProtocols: []string{"https://enbox.id/protocols/wireguard-mesh"},
+	}
+	if err := StoreWalletSession(dir, "password", session); err != nil {
+		t.Fatalf("StoreWalletSession: %v", err)
+	}
+
+	got, err := LoadWalletSession(dir, "password")
+	if err != nil {
+		t.Fatalf("LoadWalletSession: %v", err)
+	}
+	if len(got.NodeContextKeys) != 1 || len(got.EffectiveNodeContextKeys()) != 1 {
+		t.Fatalf("node context keys = direct %v effective %v", got.NodeContextKeys, got.EffectiveNodeContextKeys())
+	}
+	if len(got.NodeMultiPartyProtocols) != 1 || len(got.EffectiveNodeMultiPartyProtocols()) != 1 {
+		t.Fatalf("node protocols = direct %v effective %v", got.NodeMultiPartyProtocols, got.EffectiveNodeMultiPartyProtocols())
+	}
+}

--- a/internal/walletconnect/walletconnect.go
+++ b/internal/walletconnect/walletconnect.go
@@ -1,0 +1,697 @@
+// Package walletconnect defines the CLI-to-wallet handoff format used by
+// meshd wallet-connected profiles.
+package walletconnect
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/enboxorg/meshd/internal/did"
+	"github.com/enboxorg/meshd/internal/dwn"
+	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
+	"github.com/enboxorg/meshd/protocols"
+)
+
+const (
+	SchemePrefix = "meshd://connect/"
+
+	RequestType  = "meshd-cli-connect-request"
+	ResponseType = "meshd-cli-connect-response"
+
+	NetworkCreateSchemePrefix = "meshd://network-create/"
+	NetworkCreateRequestType  = "meshd-network-create-request"
+	NetworkCreateResponseType = "meshd-network-create-response"
+
+	ResponseEnvelopeType = "meshd-wallet-response-envelope"
+
+	currentVersion = 1
+	challengeBytes = 32
+)
+
+type Request struct {
+	Version          int                `json:"version"`
+	Type             string             `json:"type"`
+	AppName          string             `json:"appName"`
+	ProfileName      string             `json:"profileName,omitempty"`
+	NodeDID          string             `json:"nodeDid"`
+	DelegateDID      string             `json:"delegateDid,omitempty"`
+	NodeProof        string             `json:"nodeProof"`
+	Challenge        string             `json:"challenge"`
+	CallbackURL      string             `json:"callbackUrl,omitempty"`
+	ResponseEndpoint string             `json:"responseEndpoint,omitempty"`
+	ResponseToken    string             `json:"responseToken,omitempty"`
+	Protocol         string             `json:"protocol"`
+	Permissions      []string           `json:"permissions"`
+	NodeKeyDelivery  *KeyDeliveryPublic `json:"nodeKeyDelivery,omitempty"`
+	CreatedAt        string             `json:"createdAt"`
+}
+
+type Response struct {
+	Version                     int               `json:"version"`
+	Type                        string            `json:"type"`
+	ProfileName                 string            `json:"profileName,omitempty"`
+	OwnerDID                    string            `json:"ownerDID,omitempty"`
+	ConnectedDID                string            `json:"connectedDid,omitempty"`
+	DelegateDID                 string            `json:"delegateDid,omitempty"`
+	NodeDID                     string            `json:"nodeDid"`
+	WalletOrigin                string            `json:"walletOrigin,omitempty"`
+	ExpiresAt                   string            `json:"expiresAt,omitempty"`
+	Grants                      []json.RawMessage `json:"grants,omitempty"`
+	NodeContextKeys             []json.RawMessage `json:"nodeContextKeys,omitempty"`
+	NodeMultiPartyProtocols     []string          `json:"nodeMultiPartyProtocols,omitempty"`
+	DelegateDecryptionKeys      []json.RawMessage `json:"delegateDecryptionKeys,omitempty"`
+	DelegateContextKeys         []json.RawMessage `json:"delegateContextKeys,omitempty"`
+	DelegateMultiPartyProtocols []string          `json:"delegateMultiPartyProtocols,omitempty"`
+}
+
+type NetworkCreateRequest struct {
+	Version           int                `json:"version"`
+	Type              string             `json:"type"`
+	AppName           string             `json:"appName"`
+	ProfileName       string             `json:"profileName,omitempty"`
+	NodeDID           string             `json:"nodeDid"`
+	DelegateDID       string             `json:"delegateDid,omitempty"`
+	NodeProof         string             `json:"nodeProof"`
+	Challenge         string             `json:"challenge"`
+	CallbackURL       string             `json:"callbackUrl,omitempty"`
+	ResponseEndpoint  string             `json:"responseEndpoint,omitempty"`
+	ResponseToken     string             `json:"responseToken,omitempty"`
+	Protocol          string             `json:"protocol"`
+	NetworkName       string             `json:"networkName"`
+	MeshCIDR          string             `json:"meshCIDR"`
+	RequestedEndpoint string             `json:"requestedEndpoint,omitempty"`
+	NodeKeyDelivery   *KeyDeliveryPublic `json:"nodeKeyDelivery,omitempty"`
+	CreatedAt         string             `json:"createdAt"`
+}
+
+type NetworkCreateResponse struct {
+	Version                     int               `json:"version"`
+	Type                        string            `json:"type"`
+	ProfileName                 string            `json:"profileName,omitempty"`
+	OwnerDID                    string            `json:"ownerDID,omitempty"`
+	ConnectedDID                string            `json:"connectedDid,omitempty"`
+	DelegateDID                 string            `json:"delegateDid,omitempty"`
+	NodeDID                     string            `json:"nodeDid"`
+	WalletOrigin                string            `json:"walletOrigin,omitempty"`
+	ExpiresAt                   string            `json:"expiresAt,omitempty"`
+	AnchorEndpoint              string            `json:"anchorEndpoint"`
+	NetworkRecordID             string            `json:"networkRecordId"`
+	NetworkName                 string            `json:"networkName"`
+	MeshCIDR                    string            `json:"meshCIDR"`
+	MeshIP                      string            `json:"meshIP"`
+	MemberRecordID              string            `json:"memberRecordId,omitempty"`
+	MemberDateCreated           string            `json:"memberDateCreated,omitempty"`
+	NodeRecordID                string            `json:"nodeRecordId,omitempty"`
+	NodeDateCreated             string            `json:"nodeDateCreated,omitempty"`
+	Grants                      []json.RawMessage `json:"grants,omitempty"`
+	NodeContextKeys             []json.RawMessage `json:"nodeContextKeys,omitempty"`
+	NodeMultiPartyProtocols     []string          `json:"nodeMultiPartyProtocols,omitempty"`
+	DelegateContextKeys         []json.RawMessage `json:"delegateContextKeys,omitempty"`
+	DelegateMultiPartyProtocols []string          `json:"delegateMultiPartyProtocols,omitempty"`
+}
+
+type ResponseEnvelope struct {
+	Version       int             `json:"version"`
+	Type          string          `json:"type"`
+	ResponseToken string          `json:"responseToken"`
+	ResponseType  string          `json:"responseType"`
+	Response      json.RawMessage `json:"response"`
+}
+
+type KeyDeliveryPublic = dwncrypto.KeyDeliveryPublic
+
+func (r Response) EffectiveNodeContextKeys() []json.RawMessage {
+	if len(r.NodeContextKeys) > 0 {
+		return r.NodeContextKeys
+	}
+	return r.DelegateContextKeys
+}
+
+func (r Response) EffectiveNodeMultiPartyProtocols() []string {
+	if len(r.NodeMultiPartyProtocols) > 0 {
+		return r.NodeMultiPartyProtocols
+	}
+	return r.DelegateMultiPartyProtocols
+}
+
+func (r *Response) NormalizeOwnerDID() {
+	if r == nil {
+		return
+	}
+	if r.OwnerDID == "" {
+		r.OwnerDID = r.ConnectedDID
+	}
+	if r.ConnectedDID == "" {
+		r.ConnectedDID = r.OwnerDID
+	}
+}
+
+func (r Response) EffectiveOwnerDID() string {
+	if r.OwnerDID != "" {
+		return r.OwnerDID
+	}
+	return r.ConnectedDID
+}
+
+func (r NetworkCreateResponse) EffectiveNodeContextKeys() []json.RawMessage {
+	if len(r.NodeContextKeys) > 0 {
+		return r.NodeContextKeys
+	}
+	return r.DelegateContextKeys
+}
+
+func (r NetworkCreateResponse) EffectiveNodeMultiPartyProtocols() []string {
+	if len(r.NodeMultiPartyProtocols) > 0 {
+		return r.NodeMultiPartyProtocols
+	}
+	return r.DelegateMultiPartyProtocols
+}
+
+func (r *NetworkCreateResponse) NormalizeOwnerDID() {
+	if r == nil {
+		return
+	}
+	if r.OwnerDID == "" {
+		r.OwnerDID = r.ConnectedDID
+	}
+	if r.ConnectedDID == "" {
+		r.ConnectedDID = r.OwnerDID
+	}
+}
+
+func (r NetworkCreateResponse) EffectiveOwnerDID() string {
+	if r.OwnerDID != "" {
+		return r.OwnerDID
+	}
+	return r.ConnectedDID
+}
+
+func NewRequest(profileName string, identity *did.DID, delegateIdentities ...*did.DID) (Request, error) {
+	if identity == nil {
+		return Request{}, fmt.Errorf("node identity is required")
+	}
+	signer := &dwn.Signer{DID: identity.URI, PrivateKey: identity.SigningKey}
+	if signer == nil || signer.DID == "" || len(signer.PrivateKey) != ed25519.PrivateKeySize {
+		return Request{}, fmt.Errorf("node signer is required")
+	}
+	challenge, err := GenerateChallenge()
+	if err != nil {
+		return Request{}, err
+	}
+	keyDelivery, err := NewKeyDeliveryPublic(identity)
+	if err != nil {
+		return Request{}, err
+	}
+	delegateDID := ""
+	if len(delegateIdentities) > 0 && delegateIdentities[0] != nil {
+		delegateDID = strings.TrimSpace(delegateIdentities[0].URI)
+	}
+	req := Request{
+		Version:         currentVersion,
+		Type:            RequestType,
+		AppName:         "meshd CLI",
+		ProfileName:     strings.TrimSpace(profileName),
+		NodeDID:         strings.TrimSpace(signer.DID),
+		DelegateDID:     delegateDID,
+		Challenge:       challenge,
+		Protocol:        protocols.MeshProtocolURI,
+		Permissions:     []string{"mesh-node"},
+		NodeKeyDelivery: keyDelivery,
+		CreatedAt:       time.Now().UTC().Format(time.RFC3339),
+	}
+	req.NodeProof = SignNodeProof(signer, req.Challenge, req.NodeDID, req.DelegateDID, "", "", "", permissionsProofValue(req.Permissions))
+	return req, nil
+}
+
+func NewNetworkCreateRequest(profileName string, identity *did.DID, networkName string, endpoint string, meshCIDR string, delegateIdentities ...*did.DID) (NetworkCreateRequest, error) {
+	if identity == nil {
+		return NetworkCreateRequest{}, fmt.Errorf("node identity is required")
+	}
+	networkName = strings.TrimSpace(networkName)
+	if networkName == "" {
+		return NetworkCreateRequest{}, fmt.Errorf("network name is required")
+	}
+	meshCIDR = strings.TrimSpace(meshCIDR)
+	if meshCIDR == "" {
+		meshCIDR = "10.200.0.0/16"
+	}
+	signer := &dwn.Signer{DID: identity.URI, PrivateKey: identity.SigningKey}
+	challenge, err := GenerateChallenge()
+	if err != nil {
+		return NetworkCreateRequest{}, err
+	}
+	keyDelivery, err := NewKeyDeliveryPublic(identity)
+	if err != nil {
+		return NetworkCreateRequest{}, err
+	}
+	delegateDID := ""
+	if len(delegateIdentities) > 0 && delegateIdentities[0] != nil {
+		delegateDID = strings.TrimSpace(delegateIdentities[0].URI)
+	}
+	req := NetworkCreateRequest{
+		Version:           currentVersion,
+		Type:              NetworkCreateRequestType,
+		AppName:           "meshd CLI",
+		ProfileName:       strings.TrimSpace(profileName),
+		NodeDID:           strings.TrimSpace(identity.URI),
+		DelegateDID:       delegateDID,
+		Challenge:         challenge,
+		Protocol:          protocols.MeshProtocolURI,
+		NetworkName:       networkName,
+		MeshCIDR:          meshCIDR,
+		RequestedEndpoint: strings.TrimSpace(endpoint),
+		NodeKeyDelivery:   keyDelivery,
+		CreatedAt:         time.Now().UTC().Format(time.RFC3339),
+	}
+	req.NodeProof = SignNetworkCreateProof(signer, req.Challenge, req.NodeDID, req.NetworkName, req.RequestedEndpoint, req.MeshCIDR, req.DelegateDID, "", "", "")
+	return req, nil
+}
+
+func SignRequest(identity *did.DID, req *Request) error {
+	if identity == nil {
+		return fmt.Errorf("node identity is required")
+	}
+	if req == nil {
+		return fmt.Errorf("wallet connect request is required")
+	}
+	signer := &dwn.Signer{DID: identity.URI, PrivateKey: identity.SigningKey}
+	req.NodeProof = SignNodeProof(signer, req.Challenge, req.NodeDID, req.DelegateDID, req.CallbackURL, req.ResponseEndpoint, req.ResponseToken, permissionsProofValue(req.Permissions))
+	return nil
+}
+
+func SignNetworkCreateRequest(identity *did.DID, req *NetworkCreateRequest) error {
+	if identity == nil {
+		return fmt.Errorf("node identity is required")
+	}
+	if req == nil {
+		return fmt.Errorf("network create request is required")
+	}
+	signer := &dwn.Signer{DID: identity.URI, PrivateKey: identity.SigningKey}
+	req.NodeProof = SignNetworkCreateProof(signer, req.Challenge, req.NodeDID, req.NetworkName, req.RequestedEndpoint, req.MeshCIDR, req.DelegateDID, req.CallbackURL, req.ResponseEndpoint, req.ResponseToken)
+	return nil
+}
+
+func NewKeyDeliveryPublic(identity *did.DID) (*KeyDeliveryPublic, error) {
+	if identity == nil {
+		return nil, fmt.Errorf("node identity is required")
+	}
+	return dwncrypto.NewKeyDeliveryPublic(
+		identity.EncryptionPrivateKey,
+		identity.EncryptionKeyID(),
+		protocols.KeyDeliveryProtocolURI,
+	)
+}
+
+func EncodeRequest(req Request) (string, error) {
+	if req.Version == 0 {
+		req.Version = currentVersion
+	}
+	if err := req.Validate(); err != nil {
+		return "", err
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		return "", fmt.Errorf("marshal wallet connect request: %w", err)
+	}
+	return SchemePrefix + base64.RawURLEncoding.EncodeToString(data), nil
+}
+
+func DecodeRequest(raw string) (Request, error) {
+	payload := strings.TrimSpace(raw)
+	if strings.HasPrefix(payload, SchemePrefix) {
+		payload = strings.TrimPrefix(payload, SchemePrefix)
+	}
+	if payload == "" {
+		return Request{}, fmt.Errorf("empty wallet connect request")
+	}
+	data, err := base64.RawURLEncoding.DecodeString(payload)
+	if err != nil {
+		return Request{}, fmt.Errorf("decode wallet connect request: %w", err)
+	}
+	var req Request
+	if err := json.Unmarshal(data, &req); err != nil {
+		return Request{}, fmt.Errorf("parse wallet connect request: %w", err)
+	}
+	if err := req.Validate(); err != nil {
+		return Request{}, err
+	}
+	return req, nil
+}
+
+func EncodeNetworkCreateRequest(req NetworkCreateRequest) (string, error) {
+	if req.Version == 0 {
+		req.Version = currentVersion
+	}
+	if err := req.Validate(); err != nil {
+		return "", err
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		return "", fmt.Errorf("marshal network create request: %w", err)
+	}
+	return NetworkCreateSchemePrefix + base64.RawURLEncoding.EncodeToString(data), nil
+}
+
+func DecodeNetworkCreateRequest(raw string) (NetworkCreateRequest, error) {
+	payload := strings.TrimSpace(raw)
+	if strings.HasPrefix(payload, NetworkCreateSchemePrefix) {
+		payload = strings.TrimPrefix(payload, NetworkCreateSchemePrefix)
+	}
+	if payload == "" {
+		return NetworkCreateRequest{}, fmt.Errorf("empty network create request")
+	}
+	data, err := base64.RawURLEncoding.DecodeString(payload)
+	if err != nil {
+		return NetworkCreateRequest{}, fmt.Errorf("decode network create request: %w", err)
+	}
+	var req NetworkCreateRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return NetworkCreateRequest{}, fmt.Errorf("parse network create request: %w", err)
+	}
+	if err := req.Validate(); err != nil {
+		return NetworkCreateRequest{}, err
+	}
+	return req, nil
+}
+
+func (r Request) Validate() error {
+	if r.Version != currentVersion {
+		return fmt.Errorf("unsupported wallet connect request version %d", r.Version)
+	}
+	if r.Type != RequestType {
+		return fmt.Errorf("unsupported wallet connect request type %q", r.Type)
+	}
+	if r.NodeDID == "" {
+		return fmt.Errorf("wallet connect request missing node DID")
+	}
+	if r.Challenge == "" {
+		return fmt.Errorf("wallet connect request missing challenge")
+	}
+	if r.NodeProof == "" {
+		return fmt.Errorf("wallet connect request missing node proof")
+	}
+	if !VerifyNodeProof(r.NodeDID, r.NodeProof, r.Challenge, r.DelegateDID, r.CallbackURL, r.ResponseEndpoint, r.ResponseToken, permissionsProofValue(r.Permissions)) {
+		return fmt.Errorf("wallet connect request node proof is invalid")
+	}
+	if r.NodeKeyDelivery != nil {
+		if r.NodeKeyDelivery.RootKeyID == "" {
+			return fmt.Errorf("wallet connect request node key delivery missing rootKeyId")
+		}
+		if r.NodeKeyDelivery.PublicKeyJWK.X == "" {
+			return fmt.Errorf("wallet connect request node key delivery missing publicKeyJwk.x")
+		}
+	}
+	return nil
+}
+
+func (r Response) Validate() error {
+	if r.Version != currentVersion {
+		return fmt.Errorf("unsupported wallet connect response version %d", r.Version)
+	}
+	if r.Type != ResponseType {
+		return fmt.Errorf("unsupported wallet connect response type %q", r.Type)
+	}
+	if strings.TrimSpace(r.EffectiveOwnerDID()) == "" {
+		return fmt.Errorf("wallet connect response missing owner DID")
+	}
+	if strings.TrimSpace(r.NodeDID) == "" {
+		return fmt.Errorf("wallet connect response missing node DID")
+	}
+	return nil
+}
+
+func (r NetworkCreateRequest) Validate() error {
+	if r.Version != currentVersion {
+		return fmt.Errorf("unsupported network create request version %d", r.Version)
+	}
+	if r.Type != NetworkCreateRequestType {
+		return fmt.Errorf("unsupported network create request type %q", r.Type)
+	}
+	if strings.TrimSpace(r.NodeDID) == "" {
+		return fmt.Errorf("network create request missing node DID")
+	}
+	if strings.TrimSpace(r.NetworkName) == "" {
+		return fmt.Errorf("network create request missing network name")
+	}
+	if strings.TrimSpace(r.MeshCIDR) == "" {
+		return fmt.Errorf("network create request missing mesh CIDR")
+	}
+	if strings.TrimSpace(r.Protocol) != protocols.MeshProtocolURI {
+		return fmt.Errorf("unsupported network create protocol %q", r.Protocol)
+	}
+	if strings.TrimSpace(r.Challenge) == "" {
+		return fmt.Errorf("network create request missing challenge")
+	}
+	if strings.TrimSpace(r.NodeProof) == "" {
+		return fmt.Errorf("network create request missing node proof")
+	}
+	if !VerifyNetworkCreateProof(r.NodeDID, r.NodeProof, r.Challenge, r.NetworkName, r.RequestedEndpoint, r.MeshCIDR, r.DelegateDID, r.CallbackURL, r.ResponseEndpoint, r.ResponseToken) {
+		return fmt.Errorf("network create request node proof is invalid")
+	}
+	if r.NodeKeyDelivery != nil {
+		if r.NodeKeyDelivery.RootKeyID == "" {
+			return fmt.Errorf("network create request node key delivery missing rootKeyId")
+		}
+		if r.NodeKeyDelivery.PublicKeyJWK.X == "" {
+			return fmt.Errorf("network create request node key delivery missing publicKeyJwk.x")
+		}
+	}
+	return nil
+}
+
+func (r NetworkCreateResponse) Validate() error {
+	if r.Version != currentVersion {
+		return fmt.Errorf("unsupported network create response version %d", r.Version)
+	}
+	if r.Type != NetworkCreateResponseType {
+		return fmt.Errorf("unsupported network create response type %q", r.Type)
+	}
+	if strings.TrimSpace(r.EffectiveOwnerDID()) == "" {
+		return fmt.Errorf("network create response missing owner DID")
+	}
+	if strings.TrimSpace(r.NodeDID) == "" {
+		return fmt.Errorf("network create response missing node DID")
+	}
+	if strings.TrimSpace(r.AnchorEndpoint) == "" {
+		return fmt.Errorf("network create response missing anchor endpoint")
+	}
+	if strings.TrimSpace(r.NetworkRecordID) == "" {
+		return fmt.Errorf("network create response missing network record ID")
+	}
+	if strings.TrimSpace(r.NetworkName) == "" {
+		return fmt.Errorf("network create response missing network name")
+	}
+	if strings.TrimSpace(r.MeshCIDR) == "" {
+		return fmt.Errorf("network create response missing mesh CIDR")
+	}
+	if strings.TrimSpace(r.MeshIP) == "" {
+		return fmt.Errorf("network create response missing mesh IP")
+	}
+	return nil
+}
+
+func NewResponseEnvelope(responseToken string, response json.RawMessage) (*ResponseEnvelope, error) {
+	responseToken = strings.TrimSpace(responseToken)
+	if responseToken == "" {
+		return nil, fmt.Errorf("response token is required")
+	}
+	var header struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(response, &header); err != nil {
+		return nil, fmt.Errorf("parse wallet response for envelope: %w", err)
+	}
+	if strings.TrimSpace(header.Type) == "" {
+		return nil, fmt.Errorf("wallet response missing type")
+	}
+	env := &ResponseEnvelope{
+		Version:       currentVersion,
+		Type:          ResponseEnvelopeType,
+		ResponseToken: responseToken,
+		ResponseType:  header.Type,
+		Response:      append(json.RawMessage(nil), response...),
+	}
+	return env, nil
+}
+
+func DecodeResponseEnvelope(data []byte, expectedToken string) (json.RawMessage, error) {
+	var env ResponseEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil, fmt.Errorf("parse wallet response envelope: %w", err)
+	}
+	if err := env.Validate(); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(expectedToken) != "" && env.ResponseToken != strings.TrimSpace(expectedToken) {
+		return nil, fmt.Errorf("wallet response envelope token mismatch")
+	}
+	return append(json.RawMessage(nil), env.Response...), nil
+}
+
+func (e ResponseEnvelope) Validate() error {
+	if e.Version != currentVersion {
+		return fmt.Errorf("unsupported wallet response envelope version %d", e.Version)
+	}
+	if e.Type != ResponseEnvelopeType {
+		return fmt.Errorf("unsupported wallet response envelope type %q", e.Type)
+	}
+	if strings.TrimSpace(e.ResponseToken) == "" {
+		return fmt.Errorf("wallet response envelope missing response token")
+	}
+	if strings.TrimSpace(e.ResponseType) == "" {
+		return fmt.Errorf("wallet response envelope missing response type")
+	}
+	if len(e.Response) == 0 {
+		return fmt.Errorf("wallet response envelope missing response")
+	}
+	return nil
+}
+
+func GenerateChallenge() (string, error) {
+	var b [challengeBytes]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("generate wallet connect challenge: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b[:]), nil
+}
+
+func NodeProofMessage(challenge, nodeDID string, delivery ...string) []byte {
+	delegateDID, callbackURL, responseEndpoint, responseToken, permissions := nodeProofFields(delivery)
+	msg := "meshd wallet connect v1\n" +
+		"challenge=" + challenge + "\n" +
+		"node=" + nodeDID + "\n"
+	if delegateDID != "" {
+		msg += "delegate=" + delegateDID + "\n"
+	}
+	msg += "callback=" + callbackURL + "\n" +
+		"responseEndpoint=" + responseEndpoint + "\n" +
+		"responseToken=" + responseToken + "\n" +
+		"permissions=" + permissions + "\n"
+	return []byte(msg)
+}
+
+func NetworkCreateProofMessage(challenge, nodeDID, networkName, endpoint, meshCIDR string, delivery ...string) []byte {
+	delegateDID, callbackURL, responseEndpoint, responseToken := networkCreateProofFields(delivery)
+	msg := "meshd network create v1\n" +
+		"challenge=" + challenge + "\n" +
+		"node=" + nodeDID + "\n"
+	if delegateDID != "" {
+		msg += "delegate=" + delegateDID + "\n"
+	}
+	msg += "name=" + networkName + "\n" +
+		"endpoint=" + endpoint + "\n" +
+		"cidr=" + meshCIDR + "\n" +
+		"callback=" + callbackURL + "\n" +
+		"responseEndpoint=" + responseEndpoint + "\n" +
+		"responseToken=" + responseToken + "\n"
+	return []byte(msg)
+}
+
+func SignNodeProof(signer *dwn.Signer, challenge, nodeDID string, delivery ...string) string {
+	if signer == nil || signer.DID != nodeDID || len(signer.PrivateKey) != ed25519.PrivateKeySize {
+		return ""
+	}
+	sig := ed25519.Sign(signer.PrivateKey, NodeProofMessage(challenge, nodeDID, delivery...))
+	return base64.RawURLEncoding.EncodeToString(sig)
+}
+
+func VerifyNodeProof(nodeDID, proof, challenge string, delivery ...string) bool {
+	pub, err := did.ParseURI(nodeDID)
+	if err != nil {
+		return false
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(proof)
+	if err != nil {
+		return false
+	}
+	return did.VerifyWith(pub, NodeProofMessage(challenge, nodeDID, delivery...), sig)
+}
+
+func SignNetworkCreateProof(signer *dwn.Signer, challenge, nodeDID, networkName, endpoint, meshCIDR string, delivery ...string) string {
+	if signer == nil || signer.DID != nodeDID || len(signer.PrivateKey) != ed25519.PrivateKeySize {
+		return ""
+	}
+	sig := ed25519.Sign(signer.PrivateKey, NetworkCreateProofMessage(challenge, nodeDID, networkName, endpoint, meshCIDR, delivery...))
+	return base64.RawURLEncoding.EncodeToString(sig)
+}
+
+func VerifyNetworkCreateProof(nodeDID, proof, challenge, networkName, endpoint, meshCIDR string, delivery ...string) bool {
+	pub, err := did.ParseURI(nodeDID)
+	if err != nil {
+		return false
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(proof)
+	if err != nil {
+		return false
+	}
+	return did.VerifyWith(pub, NetworkCreateProofMessage(challenge, nodeDID, networkName, endpoint, meshCIDR, delivery...), sig)
+}
+
+func nodeProofFields(values []string) (delegateDID, callbackURL, responseEndpoint, responseToken, permissions string) {
+	if len(values) >= 5 {
+		return strings.TrimSpace(values[0]),
+			strings.TrimSpace(values[1]),
+			strings.TrimSpace(values[2]),
+			strings.TrimSpace(values[3]),
+			strings.TrimSpace(values[4])
+	}
+	if len(values) > 0 {
+		callbackURL = strings.TrimSpace(values[0])
+	}
+	if len(values) > 1 {
+		responseEndpoint = strings.TrimSpace(values[1])
+	}
+	if len(values) > 2 {
+		responseToken = strings.TrimSpace(values[2])
+	}
+	if len(values) > 3 {
+		permissions = strings.TrimSpace(values[3])
+	}
+	return "", callbackURL, responseEndpoint, responseToken, permissions
+}
+
+func networkCreateProofFields(values []string) (delegateDID, callbackURL, responseEndpoint, responseToken string) {
+	if len(values) >= 4 {
+		return strings.TrimSpace(values[0]),
+			strings.TrimSpace(values[1]),
+			strings.TrimSpace(values[2]),
+			strings.TrimSpace(values[3])
+	}
+	if len(values) > 0 {
+		callbackURL = strings.TrimSpace(values[0])
+	}
+	if len(values) > 1 {
+		responseEndpoint = strings.TrimSpace(values[1])
+	}
+	if len(values) > 2 {
+		responseToken = strings.TrimSpace(values[2])
+	}
+	return "", callbackURL, responseEndpoint, responseToken
+}
+
+func permissionsProofValue(permissions []string) string {
+	if len(permissions) == 0 {
+		return ""
+	}
+	seen := make(map[string]struct{}, len(permissions))
+	values := make([]string, 0, len(permissions))
+	for _, permission := range permissions {
+		permission = strings.TrimSpace(permission)
+		if permission == "" {
+			continue
+		}
+		if _, ok := seen[permission]; ok {
+			continue
+		}
+		seen[permission] = struct{}{}
+		values = append(values, permission)
+	}
+	sort.Strings(values)
+	return strings.Join(values, ",")
+}

--- a/internal/walletconnect/walletconnect_test.go
+++ b/internal/walletconnect/walletconnect_test.go
@@ -1,0 +1,262 @@
+package walletconnect
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/enboxorg/meshd/internal/did"
+)
+
+func TestRequestEncodeDecodeVerifiesNodeProof(t *testing.T) {
+	node, err := did.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	req, err := NewRequest("personal", node)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if req.NodeProof == "" {
+		t.Fatal("node proof is empty")
+	}
+	if req.NodeKeyDelivery == nil || req.NodeKeyDelivery.RootKeyID != node.EncryptionKeyID() {
+		t.Fatalf("node key delivery = %+v, want root %s", req.NodeKeyDelivery, node.EncryptionKeyID())
+	}
+
+	encoded, err := EncodeRequest(req)
+	if err != nil {
+		t.Fatalf("EncodeRequest: %v", err)
+	}
+	decoded, err := DecodeRequest(encoded)
+	if err != nil {
+		t.Fatalf("DecodeRequest: %v", err)
+	}
+	if decoded.NodeDID != node.URI {
+		t.Fatalf("node DID = %q, want %q", decoded.NodeDID, node.URI)
+	}
+	if len(decoded.Permissions) != 1 || decoded.Permissions[0] != "mesh-node" {
+		t.Fatalf("permissions = %v, want [mesh-node]", decoded.Permissions)
+	}
+	if !VerifyNodeProof(decoded.NodeDID, decoded.NodeProof, decoded.Challenge, "", "", "", permissionsProofValue(decoded.Permissions)) {
+		t.Fatal("node proof did not verify")
+	}
+}
+
+func TestRequestRejectsTamperedChallenge(t *testing.T) {
+	node, err := did.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	req, err := NewRequest("personal", node)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Challenge = "tampered"
+	if err := req.Validate(); err == nil {
+		t.Fatal("expected tampered request to fail validation")
+	}
+}
+
+func TestRequestRejectsTamperedResponseEndpoint(t *testing.T) {
+	node, err := did.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	req, err := NewRequest("personal", node)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.CallbackURL = "http://127.0.0.1:1234/meshd/wallet-callback/token"
+	req.ResponseEndpoint = "https://dev.aws.dwn.enbox.id"
+	req.ResponseToken = "response-token"
+	if err := SignRequest(node, &req); err != nil {
+		t.Fatalf("SignRequest: %v", err)
+	}
+	if err := req.Validate(); err != nil {
+		t.Fatalf("Validate signed request: %v", err)
+	}
+
+	req.ResponseEndpoint = "https://attacker.example"
+	if err := req.Validate(); err == nil {
+		t.Fatal("expected tampered response endpoint to fail validation")
+	}
+}
+
+func TestRequestRejectsTamperedPermissions(t *testing.T) {
+	node, err := did.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	req, err := NewRequest("personal", node)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Permissions = append(req.Permissions, "mesh-admin")
+	if err := req.Validate(); err == nil {
+		t.Fatal("expected tampered permissions to fail validation")
+	}
+}
+
+func TestNetworkCreateRequestEncodeDecodeVerifiesNodeProof(t *testing.T) {
+	node, err := did.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	req, err := NewNetworkCreateRequest(
+		"personal",
+		node,
+		"home",
+		"https://dev.aws.dwn.enbox.id",
+		"10.200.0.0/16",
+	)
+	if err != nil {
+		t.Fatalf("NewNetworkCreateRequest: %v", err)
+	}
+	if req.NodeProof == "" {
+		t.Fatal("node proof is empty")
+	}
+	if req.NodeKeyDelivery == nil || req.NodeKeyDelivery.RootKeyID != node.EncryptionKeyID() {
+		t.Fatalf("node key delivery = %+v, want root %s", req.NodeKeyDelivery, node.EncryptionKeyID())
+	}
+
+	encoded, err := EncodeNetworkCreateRequest(req)
+	if err != nil {
+		t.Fatalf("EncodeNetworkCreateRequest: %v", err)
+	}
+	decoded, err := DecodeNetworkCreateRequest(encoded)
+	if err != nil {
+		t.Fatalf("DecodeNetworkCreateRequest: %v", err)
+	}
+	if decoded.NodeDID != node.URI {
+		t.Fatalf("node DID = %q, want %q", decoded.NodeDID, node.URI)
+	}
+	if decoded.NetworkName != "home" || decoded.RequestedEndpoint != "https://dev.aws.dwn.enbox.id" {
+		t.Fatalf("decoded network request = %+v", decoded)
+	}
+	if !VerifyNetworkCreateProof(decoded.NodeDID, decoded.NodeProof, decoded.Challenge, decoded.NetworkName, decoded.RequestedEndpoint, decoded.MeshCIDR) {
+		t.Fatal("network create node proof did not verify")
+	}
+}
+
+func TestResponseEnvelopeRoundTrip(t *testing.T) {
+	response := json.RawMessage(`{"version":1,"type":"meshd-cli-connect-response","connectedDid":"did:jwk:wallet","nodeDid":"did:jwk:node"}`)
+	env, err := NewResponseEnvelope("response-token", response)
+	if err != nil {
+		t.Fatalf("NewResponseEnvelope: %v", err)
+	}
+	data, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got, err := DecodeResponseEnvelope(data, "response-token")
+	if err != nil {
+		t.Fatalf("DecodeResponseEnvelope: %v", err)
+	}
+	if string(got) != string(response) {
+		t.Fatalf("response = %s, want %s", got, response)
+	}
+	if _, err := DecodeResponseEnvelope(data, "wrong-token"); err == nil {
+		t.Fatal("expected token mismatch to fail")
+	}
+}
+
+func TestResponseOwnerDIDCompatibility(t *testing.T) {
+	resp := Response{
+		Version:  1,
+		Type:     ResponseType,
+		OwnerDID: "did:jwk:wallet",
+		NodeDID:  "did:jwk:node",
+	}
+	if err := resp.Validate(); err != nil {
+		t.Fatalf("ownerDID response Validate: %v", err)
+	}
+	resp.NormalizeOwnerDID()
+	if resp.ConnectedDID != "did:jwk:wallet" || resp.EffectiveOwnerDID() != "did:jwk:wallet" {
+		t.Fatalf("owner aliases = owner %q connected %q", resp.OwnerDID, resp.ConnectedDID)
+	}
+
+	legacy := Response{
+		Version:      1,
+		Type:         ResponseType,
+		ConnectedDID: "did:jwk:wallet",
+		NodeDID:      "did:jwk:node",
+	}
+	if err := legacy.Validate(); err != nil {
+		t.Fatalf("legacy response Validate: %v", err)
+	}
+	legacy.NormalizeOwnerDID()
+	if legacy.OwnerDID != "did:jwk:wallet" || legacy.EffectiveOwnerDID() != "did:jwk:wallet" {
+		t.Fatalf("legacy owner aliases = owner %q connected %q", legacy.OwnerDID, legacy.ConnectedDID)
+	}
+}
+
+func TestNetworkCreateResponseOwnerDIDCompatibility(t *testing.T) {
+	resp := NetworkCreateResponse{
+		Version:         1,
+		Type:            NetworkCreateResponseType,
+		OwnerDID:        "did:jwk:wallet",
+		NodeDID:         "did:jwk:node",
+		AnchorEndpoint:  "https://dev.aws.dwn.enbox.id",
+		NetworkRecordID: "network-1",
+		NetworkName:     "home",
+		MeshCIDR:        "10.200.0.0/16",
+		MeshIP:          "10.200.1.2",
+	}
+	if err := resp.Validate(); err != nil {
+		t.Fatalf("ownerDID network response Validate: %v", err)
+	}
+	resp.NormalizeOwnerDID()
+	if resp.ConnectedDID != "did:jwk:wallet" || resp.EffectiveOwnerDID() != "did:jwk:wallet" {
+		t.Fatalf("network owner aliases = owner %q connected %q", resp.OwnerDID, resp.ConnectedDID)
+	}
+}
+
+func TestResponseNodeContextKeysPreferNodeFieldsWithDelegateFallback(t *testing.T) {
+	nodeKey := json.RawMessage(`{"contextId":"node"}`)
+	delegateKey := json.RawMessage(`{"contextId":"legacy"}`)
+
+	resp := Response{
+		NodeContextKeys:             []json.RawMessage{nodeKey},
+		NodeMultiPartyProtocols:     []string{"node-protocol"},
+		DelegateContextKeys:         []json.RawMessage{delegateKey},
+		DelegateMultiPartyProtocols: []string{"legacy-protocol"},
+	}
+	if got := resp.EffectiveNodeContextKeys(); len(got) != 1 || string(got[0]) != string(nodeKey) {
+		t.Fatalf("response node context keys = %v", got)
+	}
+	if got := resp.EffectiveNodeMultiPartyProtocols(); len(got) != 1 || got[0] != "node-protocol" {
+		t.Fatalf("response node protocols = %v", got)
+	}
+
+	legacy := NetworkCreateResponse{
+		DelegateContextKeys:         []json.RawMessage{delegateKey},
+		DelegateMultiPartyProtocols: []string{"legacy-protocol"},
+	}
+	if got := legacy.EffectiveNodeContextKeys(); len(got) != 1 || string(got[0]) != string(delegateKey) {
+		t.Fatalf("legacy network response context keys = %v", got)
+	}
+	if got := legacy.EffectiveNodeMultiPartyProtocols(); len(got) != 1 || got[0] != "legacy-protocol" {
+		t.Fatalf("legacy network response protocols = %v", got)
+	}
+}
+
+func TestNetworkCreateRequestRejectsTamperedNetworkName(t *testing.T) {
+	node, err := did.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	req, err := NewNetworkCreateRequest(
+		"personal",
+		node,
+		"home",
+		"https://dev.aws.dwn.enbox.id",
+		"10.200.0.0/16",
+	)
+	if err != nil {
+		t.Fatalf("NewNetworkCreateRequest: %v", err)
+	}
+	req.NetworkName = "tampered"
+	if err := req.Validate(); err == nil {
+		t.Fatal("expected tampered request to fail validation")
+	}
+}

--- a/protocols/embed.go
+++ b/protocols/embed.go
@@ -9,8 +9,16 @@ var MeshProtocolJSON []byte
 //go:embed key-delivery.json
 var KeyDeliveryProtocolJSON []byte
 
+//go:embed wallet-response.json
+var WalletResponseProtocolJSON []byte
+
 // MeshProtocolURI is the canonical URI of the wireguard-mesh protocol.
 const MeshProtocolURI = "https://enbox.id/protocols/wireguard-mesh"
 
-// KeyDeliveryProtocolURI is the canonical URI of the key delivery protocol.
-const KeyDeliveryProtocolURI = "https://enbox.id/protocols/key-delivery"
+// KeyDeliveryProtocolURI is the canonical URI of the DID/Web5 key delivery
+// protocol used for encrypted Protocol Context key records.
+const KeyDeliveryProtocolURI = "https://identity.foundation/protocols/key-delivery"
+
+// WalletResponseProtocolURI is the canonical URI for CLI wallet response
+// handoff records.
+const WalletResponseProtocolURI = "https://enbox.id/protocols/meshd-wallet-response"

--- a/protocols/key-delivery.json
+++ b/protocols/key-delivery.json
@@ -1,5 +1,5 @@
 {
-  "protocol": "https://enbox.id/protocols/key-delivery",
+  "protocol": "https://identity.foundation/protocols/key-delivery",
   "published": false,
   "types": {
     "contextKey": {

--- a/protocols/protocol_test.go
+++ b/protocols/protocol_test.go
@@ -28,8 +28,9 @@ func TestProtocolDoesNotUseUnsupportedRecordLimitStrategies(t *testing.T) {
 
 func protocolFixtures() map[string][]byte {
 	return map[string][]byte{
-		"wireguard-mesh": MeshProtocolJSON,
-		"key-delivery":   KeyDeliveryProtocolJSON,
+		"wireguard-mesh":  MeshProtocolJSON,
+		"key-delivery":    KeyDeliveryProtocolJSON,
+		"wallet-response": WalletResponseProtocolJSON,
 	}
 }
 

--- a/protocols/wallet-response.json
+++ b/protocols/wallet-response.json
@@ -1,0 +1,19 @@
+{
+  "protocol": "https://enbox.id/protocols/meshd-wallet-response",
+  "published": false,
+  "types": {
+    "response": {
+      "schema": "https://enbox.id/schemas/meshd-wallet-response/response",
+      "dataFormats": ["application/json"]
+    }
+  },
+  "structure": {
+    "response": {
+      "$actions": [
+        { "who": "anyone", "can": ["create"] },
+        { "who": "recipient", "of": "response", "can": ["read"] },
+        { "who": "author", "of": "response", "can": ["read"] }
+      ]
+    }
+  }
+}

--- a/protocols/wireguard-mesh.json
+++ b/protocols/wireguard-mesh.json
@@ -14,6 +14,10 @@
       "schema": "https://enbox.id/schemas/wireguard-mesh/node-request",
       "dataFormats": ["application/json"]
     },
+    "nodeApproval": {
+      "schema": "https://enbox.id/schemas/wireguard-mesh/node-approval",
+      "dataFormats": ["application/json"]
+    },
     "node": {
       "schema": "https://enbox.id/schemas/wireguard-mesh/node",
       "dataFormats": ["application/json"],
@@ -46,6 +50,23 @@
     }
   },
   "structure": {
+    "nodeRequest": {
+      "$size": { "max": 3000 },
+      "$actions": [
+        { "who": "anyone", "can": ["create"] },
+        { "who": "recipient", "of": "nodeRequest", "can": ["create", "read", "delete"] },
+        { "who": "author", "of": "nodeRequest", "can": ["create", "read", "delete"] }
+      ]
+    },
+
+    "nodeApproval": {
+      "$size": { "max": 3000 },
+      "$actions": [
+        { "who": "recipient", "of": "nodeApproval", "can": ["read"] },
+        { "who": "author", "of": "nodeApproval", "can": ["create", "read", "delete"] }
+      ]
+    },
+
     "network": {
       "$encryption": {
         "rootKeyId": "#dwn-enc",

--- a/schemas/network.json
+++ b/schemas/network.json
@@ -15,6 +15,11 @@
       "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+/[0-9]+$",
       "description": "The IP range for mesh-internal addresses, e.g. 100.64.0.0/10"
     },
+    "anchorEndpoint": {
+      "type": "string",
+      "format": "uri",
+      "description": "DWN endpoint hosting the anchor tenant for invite joins"
+    },
     "defaultRelays": {
       "type": "array",
       "items": {

--- a/schemas/node-approval.json
+++ b/schemas/node-approval.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://enbox.id/schemas/wireguard-mesh/node-approval",
+  "type": "object",
+  "required": ["ownerDID", "nodeDID", "networkRecordId", "nodeRecordId", "meshIP", "approvedAt"],
+  "additionalProperties": false,
+  "properties": {
+    "ownerDID": {
+      "type": "string",
+      "description": "The wallet/account DID that approved this node"
+    },
+    "nodeDID": {
+      "type": "string",
+      "description": "The device DID that was approved"
+    },
+    "networkRecordId": {
+      "type": "string",
+      "description": "The mesh network record ID the node was approved into"
+    },
+    "networkName": {
+      "type": "string",
+      "description": "Human-readable network name"
+    },
+    "meshCIDR": {
+      "type": "string",
+      "description": "The mesh IP range"
+    },
+    "meshIP": {
+      "type": "string",
+      "description": "Allocated IP for this node"
+    },
+    "anchorEndpoint": {
+      "type": "string",
+      "format": "uri",
+      "description": "DWN endpoint for the owner/anchor"
+    },
+    "memberRecordId": {
+      "type": "string",
+      "description": "The owner/member record that owns this node"
+    },
+    "memberDateCreated": {
+      "type": "string",
+      "format": "date-time",
+      "description": "dateCreated timestamp for the member record"
+    },
+    "nodeRecordId": {
+      "type": "string",
+      "description": "The approved node record ID"
+    },
+    "nodeDateCreated": {
+      "type": "string",
+      "format": "date-time",
+      "description": "dateCreated timestamp for the node record"
+    },
+    "label": {
+      "type": "string",
+      "maxLength": 128,
+      "description": "Owner-assigned node label"
+    },
+    "expiresAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When this node membership expires; omitted means never expires"
+    },
+    "approvedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the owner approved the node"
+    },
+    "requestRecordId": {
+      "type": "string",
+      "description": "The owner-scoped request record this approval satisfies"
+    }
+  }
+}

--- a/schemas/node-request.json
+++ b/schemas/node-request.json
@@ -9,6 +9,39 @@
       "type": "string",
       "description": "The DID of the device being proposed for network membership"
     },
+    "memberDID": {
+      "type": "string",
+      "description": "Legacy alias for ownerDID. The durable wallet/member DID that owns the proposed device. Defaults to nodeDID for local-only joins."
+    },
+    "ownerDID": {
+      "type": "string",
+      "description": "The durable wallet/member DID that owns the proposed device. Defaults to nodeDID for local-only joins."
+    },
+    "delegateDID": {
+      "type": "string",
+      "description": "The local delegate/session DID that should receive wallet grants for this device, when distinct from nodeDID."
+    },
+    "requestedBy": {
+      "type": "string",
+      "description": "The DID that submitted the request, such as a wallet delegate or the node DID."
+    },
+    "nodeProof": {
+      "type": "string",
+      "description": "Base64url Ed25519 signature from nodeDID over the join or owner-access request statement."
+    },
+    "requestKind": {
+      "type": "string",
+      "enum": ["owner-node", "network-preauth"],
+      "description": "The enrollment path used by this request"
+    },
+    "networkRecordId": {
+      "type": "string",
+      "description": "Requested network record ID, when the node already knows the target network"
+    },
+    "networkName": {
+      "type": "string",
+      "description": "Requested or display network name"
+    },
     "sourceDWN": {
       "type": "string",
       "format": "uri",
@@ -18,6 +51,35 @@
       "type": "string",
       "maxLength": 128,
       "description": "Optional label for the proposed device"
+    },
+    "nodeKeyDelivery": {
+      "type": "object",
+      "description": "Public key material used by the anchor to encrypt the delivered mesh context key to this node",
+      "required": ["rootKeyId", "publicKeyJwk"],
+      "additionalProperties": false,
+      "properties": {
+        "rootKeyId": {
+          "type": "string",
+          "description": "The node's root encryption key ID"
+        },
+        "publicKeyJwk": {
+          "type": "object",
+          "required": ["kty", "crv", "x"],
+          "additionalProperties": true,
+          "properties": {
+            "kty": { "type": "string", "const": "OKP" },
+            "crv": { "type": "string", "const": "X25519" },
+            "x": {
+              "type": "string",
+              "description": "Base64url-encoded X25519 public key derived for key delivery"
+            },
+            "kid": {
+              "type": "string",
+              "description": "Optional key ID; rootKeyId is authoritative when present"
+            }
+          }
+        }
+      }
     },
     "preAuthKeyId": {
       "type": "string",
@@ -31,6 +93,11 @@
       "type": "string",
       "format": "date-time",
       "description": "When the device requested to join"
+    },
+    "expiresAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Optional request expiry"
     }
   }
 }

--- a/schemas/node.json
+++ b/schemas/node.json
@@ -19,15 +19,61 @@
       "format": "date-time",
       "description": "When this node was added to the network"
     },
+    "expiresAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When this node membership expires; omitted means never expires"
+    },
     "label": {
       "type": "string",
       "maxLength": 128,
       "description": "Human-readable label for this node"
     },
+    "memberDID": {
+      "type": "string",
+      "description": "Legacy alias for ownerDID. The wallet/member DID that owns this node. Defaults to the node DID for local-only devices."
+    },
+    "ownerDID": {
+      "type": "string",
+      "description": "The wallet/member DID that owns this node. Defaults to the node DID for local-only devices."
+    },
+    "delegateDID": {
+      "type": "string",
+      "description": "The local delegate/session DID that currently has wallet grants to operate this node."
+    },
     "sourceDWN": {
       "type": "string",
       "format": "uri",
       "description": "The DWN endpoint where the device's authoritative records live (for cross-DWN member devices)"
+    },
+    "nodeKeyDelivery": {
+      "type": "object",
+      "description": "Public key material used by the anchor to encrypt delivered mesh context keys to this node",
+      "required": ["rootKeyId", "publicKeyJwk"],
+      "additionalProperties": false,
+      "properties": {
+        "rootKeyId": {
+          "type": "string",
+          "description": "The node's root encryption key ID"
+        },
+        "publicKeyJwk": {
+          "type": "object",
+          "required": ["kty", "crv", "x"],
+          "additionalProperties": true,
+          "properties": {
+            "kty": { "type": "string", "const": "OKP" },
+            "crv": { "type": "string", "const": "X25519" },
+            "x": {
+              "type": "string",
+              "description": "Base64url-encoded X25519 public key derived for key delivery"
+            },
+            "kid": {
+              "type": "string",
+              "description": "Optional key ID; rootKeyId is authoritative when present"
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a standalone meshd admin dapp that connects through the wallet-style dapp flow, installs/verifies mesh protocols, manages networks, node approvals, peers, and invite tokens
- add CLI/backend support for dashboard-owned node enrollment, wallet response sessions, permission grants, background daemon startup, vault password caching, and clearer peer/status UX
- add the Cloudflare Pages workflow and Mac/Linux smoke-test runbook for validating the current beta flow

## Validation
- go test -count=1 ./...
- npm test (admin-dapp)
- npm run build (admin-dapp)
- git diff --check
- staged scan for enbox.org domain references, invite-token leaks, and private-key markers

## Notes
- Node membership expiry/editing is intentionally deferred until the existing owner-request/admin approval flow is validated end to end.
- Local npm build emits a Node 21.6.2 warning from Vite; the workflow pins Node 20.19.0, which is in Vite's supported range.