### PR TITLE
chore: ignore admin dapp vite cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ Thumbs.db
 /dist/
 admin-dapp/dist/
 admin-dapp/node_modules/
+admin-dapp/.vite/
 
 # Config (may contain keys)
 *.key


### PR DESCRIPTION
## Summary
- ignore the local Vite cache produced by admin dapp test/build runs

## Validation
- not run; .gitignore-only change