### PR TITLE
fix: skip admin dapp deploy without cloudflare secrets

### DIFF
--- a/.github/workflows/admin-dapp.yml
+++ b/.github/workflows/admin-dapp.yml
@@ -79,7 +79,21 @@ jobs:
         working-directory: admin-dapp
         run: npm run build
 
+      - name: Check Cloudflare credentials
+        id: cloudflare
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ -n "$CLOUDFLARE_API_TOKEN" ] && [ -n "$CLOUDFLARE_ACCOUNT_ID" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Skipping Cloudflare Pages deploy because CLOUDFLARE_API_TOKEN or CLOUDFLARE_ACCOUNT_ID is not configured."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Deploy to Cloudflare Pages
+        if: steps.cloudflare.outputs.configured == 'true'
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary
- keep the admin dapp build/test workflow green when Cloudflare Pages secrets are not configured
- skip only the Wrangler deploy step when `CLOUDFLARE_API_TOKEN` or `CLOUDFLARE_ACCOUNT_ID` resolves empty

## Validation
- git diff --check

## Notes
- the previous `main` push failed in the deploy job with Wrangler `Not logged in`; build and tests passed.