### PR TITLE
docs: use deployed dashboard in smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ DWN. See [DESIGN.md](DESIGN.md) for the full architecture.
 
 ## Quick start
 
+Install the latest release:
+
+```bash
+curl -fsSL https://meshd.sh/install | bash
+meshd --version
+```
+
 ```bash
 # On your first machine
 meshd up --create my-network --endpoint https://dwn.example.com
@@ -57,6 +64,8 @@ meshd up
 waits. After approval, the dashboard writes the node membership record, delivers
 the network context key, and writes a node approval response that the CLI
 consumes on the next `meshd up`.
+
+The default dashboard is deployed at `https://meshd-admin.pages.dev`.
 
 For a full Mac/Linux validation pass, see
 [docs/smoke-test-mac-linux.md](docs/smoke-test-mac-linux.md).

--- a/admin-dapp/README.md
+++ b/admin-dapp/README.md
@@ -7,6 +7,12 @@ account. This dapp connects to that wallet, receives delegated DWN grants, and
 then manages networks, invites, pending node approvals, and removals on behalf
 of the owner.
 
+Production dashboard:
+
+```text
+https://meshd-admin.pages.dev
+```
+
 ## Local development
 
 ```bash
@@ -65,7 +71,9 @@ protocol readiness checks. `npm run build` typechecks and builds the static app.
 ## Cloudflare Pages
 
 The repository workflow `.github/workflows/admin-dapp.yml` builds this app on
-PRs and deploys it on pushes to `main`.
+PRs and on pushes to `main`. On `main`, it deploys only when the Cloudflare
+secrets below are configured; otherwise it leaves build/test green and skips
+the Pages deployment step.
 
 Required GitHub secrets:
 
@@ -78,4 +86,13 @@ The workflow deploys `admin-dapp/dist` to the Cloudflare Pages project:
 
 ```text
 meshd-admin
+```
+
+For a manual deploy with a locally authenticated Wrangler CLI:
+
+```bash
+npm ci
+npm test
+npm run build
+wrangler pages deploy dist --project-name=meshd-admin --branch=main
 ```

--- a/docs/smoke-test-mac-linux.md
+++ b/docs/smoke-test-mac-linux.md
@@ -10,26 +10,57 @@ Assumptions:
 - Both machines may already run Tailscale. meshd uses `10.200.0.0/16`, so it
   should not overlap Tailscale's `100.64.0.0/10` address space.
 - The beta DWN endpoint is `https://dev.aws.dwn.enbox.id`.
-- You have the standalone meshd Admin dapp available locally or deployed.
+- The released CLI is installed on both machines.
+- The standalone meshd Admin dapp is deployed at
+  `https://meshd-admin.pages.dev`.
 
-## 1. Start the admin dashboard on the Mac
+## 0. Install or update meshd
 
-From the repository checkout:
+On both the Mac and the Linux server:
+
+```bash
+curl -fsSL https://meshd.sh/install | bash
+meshd --version
+```
+
+Expected result:
+
+```text
+meshd 0.4.0
+```
+
+If your shell has not picked up the installer PATH update yet, run:
+
+```bash
+~/.meshd/bin/meshd --version
+```
+
+## 1. Open the admin dashboard on the Mac
+
+Use the deployed dashboard:
+
+```bash
+meshd admin --print
+```
+
+Open the printed URL. It should use:
+
+```text
+https://meshd-admin.pages.dev
+```
+
+Connect the owner wallet and approve meshd Admin. Create a network if one does
+not already exist. Copy the owner DID from the wallet or dashboard header.
+
+If the deployed dashboard is unavailable, run the local fallback from a repo
+checkout:
 
 ```bash
 cd ~/src/enboxorg/meshd/admin-dapp
 npm ci
 npm run dev -- --host 127.0.0.1
+meshd admin --dashboard http://127.0.0.1:5173 --print
 ```
-
-Open the printed Vite URL, usually:
-
-```text
-http://127.0.0.1:5173/
-```
-
-Connect the owner wallet and approve meshd Admin. Create a network if one does
-not already exist. Copy the owner DID from the wallet or dashboard header.
 
 ## 2. Submit the Linux node request
 


### PR DESCRIPTION
## Summary
- update the Mac/Linux smoke test to start from the released installer and deployed admin dashboard
- document the production dashboard URL and manual Wrangler deploy path
- clarify that the admin dapp workflow skips deploy when Cloudflare secrets are absent

## Validation
- git diff --check
- scanned touched docs for enbox.org domain references
- verified https://meshd-admin.pages.dev returns HTTP 200