### PR TITLE
feat: enforce expired node memberships

### DIFF
--- a/internal/control/control_test.go
+++ b/internal/control/control_test.go
@@ -184,6 +184,80 @@ func TestBuildMapResponseFallsBackToDeterministicMeshIP(t *testing.T) {
 	}
 }
 
+func TestBuildMapResponseSkipsExpiredPeer(t *testing.T) {
+	selfDID, _ := testDIDJWK(t)
+	expiredPeerDID, _ := testDIDJWK(t)
+	activePeerDID, _ := testDIDJWK(t)
+	c := NewDWNClient("https://dwn.example", "did:example:anchor", "network-1", selfDID, nil)
+	c.network = &NetworkConfig{Name: "test", MeshCIDR: "10.200.0.0/16"}
+	c.nodes[selfDID] = &NodeRecord{DID: selfDID, MeshIP: "10.200.0.2", RecordID: "self-record"}
+	c.nodes[expiredPeerDID] = &NodeRecord{
+		DID:       expiredPeerDID,
+		MeshIP:    "10.200.0.3",
+		RecordID:  "expired-peer-record",
+		ExpiresAt: time.Now().UTC().Add(-time.Minute).Format(time.RFC3339),
+	}
+	c.nodes[activePeerDID] = &NodeRecord{
+		DID:       activePeerDID,
+		MeshIP:    "10.200.0.4",
+		RecordID:  "active-peer-record",
+		ExpiresAt: time.Now().UTC().Add(time.Hour).Format(time.RFC3339),
+	}
+
+	resp := c.buildMapResponse()
+	if resp == nil {
+		t.Fatal("buildMapResponse returned nil")
+	}
+	if len(resp.Peers) != 1 {
+		t.Fatalf("peers = %d, want 1", len(resp.Peers))
+	}
+	if resp.Peers[0].DID != activePeerDID {
+		t.Fatalf("peer DID = %s, want active peer %s", resp.Peers[0].DID, activePeerDID)
+	}
+}
+
+func TestBuildMapResponseReturnsNilWhenSelfExpired(t *testing.T) {
+	selfDID, _ := testDIDJWK(t)
+	peerDID, _ := testDIDJWK(t)
+	c := NewDWNClient("https://dwn.example", "did:example:anchor", "network-1", selfDID, nil)
+	c.network = &NetworkConfig{Name: "test", MeshCIDR: "10.200.0.0/16"}
+	c.nodes[selfDID] = &NodeRecord{
+		DID:       selfDID,
+		MeshIP:    "10.200.0.2",
+		RecordID:  "self-record",
+		ExpiresAt: time.Now().UTC().Add(-time.Minute).Format(time.RFC3339),
+	}
+	c.nodes[peerDID] = &NodeRecord{DID: peerDID, MeshIP: "10.200.0.3", RecordID: "peer-record"}
+
+	if resp := c.buildMapResponse(); resp != nil {
+		t.Fatalf("buildMapResponse returned %#v, want nil", resp)
+	}
+}
+
+func TestNodeRecordExpired(t *testing.T) {
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+
+	tests := map[string]struct {
+		expiresAt string
+		want      bool
+	}{
+		"empty":     {expiresAt: "", want: false},
+		"future":    {expiresAt: now.Add(time.Minute).Format(time.RFC3339), want: false},
+		"exact now": {expiresAt: now.Format(time.RFC3339), want: false},
+		"past":      {expiresAt: now.Add(-time.Minute).Format(time.RFC3339), want: true},
+		"malformed": {expiresAt: "not-a-time", want: false},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := nodeRecordExpired(&NodeRecord{ExpiresAt: tc.expiresAt}, now)
+			if got != tc.want {
+				t.Fatalf("nodeRecordExpired(%q) = %v, want %v", tc.expiresAt, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestNodeRecordToNode(t *testing.T) {
 	now := time.Now().UTC()
 	recentUpdate := now.Add(-2 * time.Minute).Format(time.RFC3339)

--- a/internal/control/data.go
+++ b/internal/control/data.go
@@ -28,6 +28,7 @@ type NodeRecord struct {
 	MeshIP          string                       `json:"meshIP"`
 	AllowedIPs      []string                     `json:"allowedIPs,omitempty"`
 	AddedAt         string                       `json:"addedAt"`
+	ExpiresAt       string                       `json:"expiresAt,omitempty"`
 	Label           string                       `json:"label,omitempty"`
 	MemberDID       string                       `json:"memberDID,omitempty"`
 	OwnerDID        string                       `json:"ownerDID,omitempty"`

--- a/internal/control/dwnclient.go
+++ b/internal/control/dwnclient.go
@@ -664,9 +664,24 @@ func (c *DWNClient) buildMapResponse() *MapResponse {
 	}
 	sort.Strings(dids)
 
+	now := time.Now().UTC()
 	var nodeID int64 = 1
 	for _, did := range dids {
 		rec := c.nodes[did]
+		if nodeRecordExpired(rec, now) {
+			if did == c.selfDID {
+				c.logger.Debug("self node membership is expired",
+					slog.String("did", did),
+					slog.String("expiresAt", rec.ExpiresAt),
+				)
+				return nil
+			}
+			c.logger.Debug("skipping expired peer in network map",
+				slog.String("did", did),
+				slog.String("expiresAt", rec.ExpiresAt),
+			)
+			continue
+		}
 		node := nodeRecordToNode(nodeID, did, rec)
 		nodeID++
 		c.applyFallbackMeshIP(node)
@@ -701,6 +716,17 @@ func (c *DWNClient) buildMapResponse() *MapResponse {
 	}
 
 	return resp
+}
+
+func nodeRecordExpired(rec *NodeRecord, now time.Time) bool {
+	if rec == nil || rec.ExpiresAt == "" {
+		return false
+	}
+	expiresAt, err := time.Parse(time.RFC3339, rec.ExpiresAt)
+	if err != nil {
+		return false
+	}
+	return now.After(expiresAt)
 }
 
 func (c *DWNClient) applyFallbackMeshIP(node *Node) {


### PR DESCRIPTION
## Summary
- parse `expiresAt` from node membership records in the Go control plane
- skip expired peer records when building the WireGuard network map
- return no map when the local node membership itself has expired

## Validation
- go test -count=1 ./internal/control
- go test -count=1 ./...
- git diff --check

## Notes
- This only enforces existing `expiresAt` node records at runtime. Admin controls for setting, editing, and renewing node expiry remain a separate UI/API slice after the current smoke flow is validated.