### PR TITLE
feat: add admin node expiry controls

### DIFF
--- a/admin-dapp/src/App.tsx
+++ b/admin-dapp/src/App.tsx
@@ -27,6 +27,7 @@ import {
   rejectMeshdNodeRequest,
   removeMeshdNode,
   revokeMeshdInvite,
+  updateMeshdNodeExpiry,
   type CreateMeshdInviteResult,
   type MeshdAdminSession,
   type MeshdNetworkSummary,
@@ -37,9 +38,9 @@ import {
 } from "./meshd/admin";
 
 type LoadState = "idle" | "loading" | "ready" | "error";
-type InviteExpiryValue = "1h" | "24h" | "7d" | "30d" | "never";
+type ExpiryValue = "1h" | "24h" | "7d" | "30d" | "never";
 
-const INVITE_EXPIRY_OPTIONS: Array<{ value: InviteExpiryValue; label: string; durationMs?: number }> = [
+const EXPIRY_OPTIONS: Array<{ value: ExpiryValue; label: string; durationMs?: number }> = [
   { value: "1h", label: "1 hour", durationMs: 60 * 60 * 1000 },
   { value: "24h", label: "24 hours", durationMs: 24 * 60 * 60 * 1000 },
   { value: "7d", label: "7 days", durationMs: 7 * 24 * 60 * 60 * 1000 },
@@ -64,13 +65,23 @@ function formatTime(value?: string) {
   }).format(date);
 }
 
+function expiryState(value?: string) {
+  if (!value) return "none";
+  const time = new Date(value).getTime();
+  if (!Number.isFinite(time)) return "unknown";
+  const remaining = time - Date.now();
+  if (remaining <= 0) return "expired";
+  if (remaining <= 24 * 60 * 60 * 1000) return "soon";
+  return "active";
+}
+
 async function copyToClipboard(value: string) {
   await navigator.clipboard.writeText(value);
   toast.success("Copied");
 }
 
-function inviteExpiryTimestamp(value: InviteExpiryValue) {
-  const option = INVITE_EXPIRY_OPTIONS.find((item) => item.value === value);
+function expiryTimestamp(value: ExpiryValue) {
+  const option = EXPIRY_OPTIONS.find((item) => item.value === value);
   if (!option?.durationMs) {
     return undefined;
   }
@@ -170,7 +181,8 @@ function Dashboard() {
   const [error, setError] = useState<string>();
   const [inviteResult, setInviteResult] = useState<CreateMeshdInviteResult>();
   const [inviteLabel, setInviteLabel] = useState("");
-  const [inviteExpiry, setInviteExpiry] = useState<InviteExpiryValue>("24h");
+  const [inviteExpiry, setInviteExpiry] = useState<ExpiryValue>("24h");
+  const [approvalExpiry, setApprovalExpiry] = useState<ExpiryValue>("never");
   const [inviteReusable, setInviteReusable] = useState(false);
   const [networkName, setNetworkName] = useState("");
   const [networkCIDR, setNetworkCIDR] = useState("10.200.0.0/16");
@@ -253,7 +265,7 @@ function Dashboard() {
     await runAction("create-invite", async () => {
       const result = await createMeshdInvite(session, selectedNetwork, {
         label: inviteLabel.trim() || selectedNetwork.name,
-        expiresAt: inviteExpiryTimestamp(inviteExpiry),
+        expiresAt: expiryTimestamp(inviteExpiry),
         reusable: inviteReusable
       });
       setInviteLabel("");
@@ -266,7 +278,9 @@ function Dashboard() {
   async function handleApprove(request: MeshdNodeRequestSummary) {
     if (!session || !selectedNetwork) return;
     await runAction(`approve-${request.recordId}`, async () => {
-      const result = await approveMeshdNodeRequest(session, selectedNetwork, request);
+      const result = await approveMeshdNodeRequest(session, selectedNetwork, request, {
+        expiresAt: expiryTimestamp(approvalExpiry)
+      });
       toast.success(`Node approved at ${result.meshIP}`);
       await refreshTopology();
     });
@@ -277,6 +291,15 @@ function Dashboard() {
     await runAction(`reject-${request.recordId}`, async () => {
       await rejectMeshdNodeRequest(session, request);
       toast.success("Request rejected");
+      await refreshTopology();
+    });
+  }
+
+  async function handleUpdateNodeExpiry(node: MeshdNodeSummary, value: ExpiryValue) {
+    if (!session || !selectedNetwork) return;
+    await runAction(`expiry-${node.recordId}`, async () => {
+      await updateMeshdNodeExpiry(session, selectedNetwork, node, expiryTimestamp(value));
+      toast.success(value === "never" ? "Node expiry cleared" : "Node expiry updated");
       await refreshTopology();
     });
   }
@@ -402,8 +425,8 @@ function Dashboard() {
                 </label>
                 <label>
                   Expires
-                  <select value={inviteExpiry} onChange={(event) => setInviteExpiry(event.target.value as InviteExpiryValue)}>
-                    {INVITE_EXPIRY_OPTIONS.map((option) => (
+                  <select value={inviteExpiry} onChange={(event) => setInviteExpiry(event.target.value as ExpiryValue)}>
+                    {EXPIRY_OPTIONS.map((option) => (
                       <option key={option.value} value={option.value}>{option.label}</option>
                     ))}
                   </select>
@@ -445,6 +468,16 @@ function Dashboard() {
                 <span>Pending</span>
                 <small>{topology?.pendingRequests.length ?? 0}</small>
               </div>
+              <div className="inline-control">
+                <label>
+                  Approve for
+                  <select value={approvalExpiry} onChange={(event) => setApprovalExpiry(event.target.value as ExpiryValue)}>
+                    {EXPIRY_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>{option.label}</option>
+                    ))}
+                  </select>
+                </label>
+              </div>
               <div className="stack">
                 {topology?.pendingRequests.length ? topology.pendingRequests.map((request) => (
                   <PendingRequestRow
@@ -465,7 +498,14 @@ function Dashboard() {
               </div>
               <div className="node-grid">
                 {allNodes.length ? allNodes.map(({ node, member }) => (
-                  <NodeCard key={node.recordId} node={node} owner={member?.did} busyAction={busyAction} onRemove={handleRemoveNode} />
+                  <NodeCard
+                    key={node.recordId}
+                    node={node}
+                    owner={member?.did}
+                    busyAction={busyAction}
+                    onRemove={handleRemoveNode}
+                    onUpdateExpiry={handleUpdateNodeExpiry}
+                  />
                 )) : <EmptyRow icon={<ServerIcon size={18} />} text="No nodes" />}
               </div>
             </section>
@@ -533,16 +573,26 @@ function NodeCard({
   node,
   owner,
   busyAction,
-  onRemove
+  onRemove,
+  onUpdateExpiry
 }: {
   node: MeshdNodeSummary;
   owner?: string;
   busyAction?: string;
   onRemove: (node: MeshdNodeSummary) => Promise<void>;
+  onUpdateExpiry: (node: MeshdNodeSummary, value: ExpiryValue) => Promise<void>;
 }) {
   const removing = busyAction === `remove-${node.recordId}`;
+  const updatingExpiry = busyAction === `expiry-${node.recordId}`;
+  const [expiryChoice, setExpiryChoice] = useState<ExpiryValue>("30d");
+  const state = expiryState(node.expiresAt);
+  const expiryLabel = node.expiresAt
+    ? state === "expired"
+      ? `Expired ${formatTime(node.expiresAt)}`
+      : `Expires ${formatTime(node.expiresAt)}`
+    : "No expiry";
   return (
-    <article className="node-card">
+    <article className={`node-card ${state === "expired" ? "expired" : state === "soon" ? "expiring" : ""}`}>
       <div className="node-card-header">
         <span className="row-icon"><ServerIcon size={17} /></span>
         <strong>{node.label || node.meshIP || truncateDid(node.did, 12, 6)}</strong>
@@ -554,8 +604,25 @@ function NodeCard({
         <div><dt>Mesh IP</dt><dd>{node.meshIP || "unknown"}</dd></div>
         <div><dt>Node</dt><dd title={node.did}>{truncateDid(node.did)}</dd></div>
         {owner ? <div><dt>Owner</dt><dd title={owner}>{truncateDid(owner)}</dd></div> : null}
-        {node.expiresAt ? <div><dt>Expires</dt><dd>{formatTime(node.expiresAt)}</dd></div> : null}
+        <div><dt>Expiry</dt><dd>{expiryLabel}</dd></div>
       </dl>
+      <div className="expiry-editor">
+        <select value={expiryChoice} onChange={(event) => setExpiryChoice(event.target.value as ExpiryValue)}>
+          {EXPIRY_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>{option.label}</option>
+          ))}
+        </select>
+        <button
+          className="icon-button success"
+          type="button"
+          aria-label="Apply node expiry"
+          title="Apply expiry"
+          disabled={updatingExpiry || removing}
+          onClick={() => void onUpdateExpiry(node, expiryChoice)}
+        >
+          {updatingExpiry ? <Loader2Icon className="spin" size={15} /> : <CheckIcon size={15} />}
+        </button>
+      </div>
     </article>
   );
 }

--- a/admin-dapp/src/meshd/admin.test.ts
+++ b/admin-dapp/src/meshd/admin.test.ts
@@ -8,6 +8,7 @@ import {
   createMeshdInvite,
   createMeshdNetwork,
   fetchMeshdNetworks,
+  updateMeshdNodeExpiry,
   type MeshdAdminAgent,
   type MeshdAdminSession,
   type MeshdNetworkSummary
@@ -285,6 +286,103 @@ describe("meshd admin DWN operations", () => {
       secret: "secret-value",
       expiresAt: "2026-06-25T00:00:00Z"
     });
+  });
+
+  it("updates node expiry while preserving the existing node payload", async () => {
+    const { session, requests } = createFakeSession({ delegate: true, recordIds: ["node-record"] });
+    const network: MeshdNetworkSummary = {
+      recordId: "network-record",
+      name: "Home mesh",
+      meshCIDR: "10.200.0.0/16"
+    };
+
+    const node = await updateMeshdNodeExpiry(session, network, {
+      recordId: "node-record",
+      did: "did:example:node",
+      meshIP: "10.200.0.10",
+      allowedIPs: ["10.200.0.10/32", "192.168.1.0/24"],
+      label: "server",
+      ownerDID: "did:example:owner",
+      memberDID: "did:example:owner",
+      delegateDID: "did:example:delegate",
+      memberRecordId: "member-record",
+      addedAt: "2026-06-24T00:00:00Z",
+      expiresAt: "2026-06-25T00:00:00Z",
+      sourceDWN: "https://node.dwn.example",
+      nodeKeyDelivery: {
+        rootKeyId: "did:example:node#1",
+        publicKeyJwk: {
+          kid: "did:example:node#1",
+          kty: "OKP",
+          crv: "X25519",
+          x: "abc"
+        }
+      },
+      createdAt: "2026-06-24T00:00:00Z"
+    }, "2026-07-01T00:00:00Z");
+
+    expect(node.expiresAt).toBe("2026-07-01T00:00:00Z");
+    expect(requests[0]).toMatchObject({
+      encryption: true,
+      messageType: DwnInterface.RecordsWrite,
+      messageParams: {
+        protocol: MESHD_PROTOCOL_URI,
+        protocolPath: "network/member/node",
+        schema: "https://enbox.id/schemas/wireguard-mesh/node",
+        recipient: "did:example:node",
+        parentContextId: "network-record/member-record",
+        recordId: "node-record",
+        dateCreated: "2026-06-24T00:00:00Z"
+      }
+    });
+    await expect(blobJson(requests[0].dataStream)).resolves.toEqual({
+      meshIP: "10.200.0.10",
+      allowedIPs: ["10.200.0.10/32", "192.168.1.0/24"],
+      addedAt: "2026-06-24T00:00:00Z",
+      expiresAt: "2026-07-01T00:00:00Z",
+      label: "server",
+      ownerDID: "did:example:owner",
+      memberDID: "did:example:owner",
+      delegateDID: "did:example:delegate",
+      sourceDWN: "https://node.dwn.example",
+      nodeKeyDelivery: {
+        rootKeyId: "did:example:node#1",
+        publicKeyJwk: {
+          kid: "did:example:node#1",
+          kty: "OKP",
+          crv: "X25519",
+          x: "abc"
+        }
+      }
+    });
+  });
+
+  it("clears node expiry when renewing to never", async () => {
+    const { session, requests } = createFakeSession({ recordIds: ["node-record"] });
+    const network: MeshdNetworkSummary = {
+      recordId: "network-record",
+      name: "Home mesh",
+      meshCIDR: "10.200.0.0/16"
+    };
+
+    const node = await updateMeshdNodeExpiry(session, network, {
+      recordId: "node-record",
+      did: "did:example:node",
+      meshIP: "10.200.0.10",
+      addedAt: "2026-06-24T00:00:00Z",
+      expiresAt: "2026-06-25T00:00:00Z",
+      createdAt: "2026-06-24T00:00:00Z"
+    });
+
+    expect(node.expiresAt).toBeUndefined();
+    expect(requests[0]).toMatchObject({
+      messageParams: {
+        protocolPath: "network/node",
+        parentContextId: "network-record",
+        recordId: "node-record"
+      }
+    });
+    await expect(blobJson(requests[0].dataStream)).resolves.not.toHaveProperty("expiresAt");
   });
 
   it("fetches and sorts network records through delegated records queries", async () => {

--- a/admin-dapp/src/meshd/admin.ts
+++ b/admin-dapp/src/meshd/admin.ts
@@ -78,6 +78,7 @@ export type MeshdNodeSummary = {
   recordId: string;
   did: string;
   meshIP?: string;
+  allowedIPs?: string[];
   label?: string;
   ownerDID?: string;
   memberDID?: string;
@@ -85,6 +86,8 @@ export type MeshdNodeSummary = {
   memberRecordId?: string;
   addedAt?: string;
   expiresAt?: string;
+  sourceDWN?: string;
+  nodeKeyDelivery?: MeshdNodeKeyDelivery;
   createdAt?: string;
 };
 
@@ -166,6 +169,14 @@ function isObject(value: unknown): value is Record<string, unknown> {
 
 function getString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() !== "" ? value.trim() : undefined;
+}
+
+function getStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const items = value
+    .filter((item): item is string => typeof item === "string" && item.trim() !== "")
+    .map((item) => item.trim());
+  return items.length ? items : undefined;
 }
 
 function base64UrlDecode(value: string): string {
@@ -472,6 +483,7 @@ export function parseMeshdNodeRecord(rawEntry: unknown, memberRecordId?: string)
     recordId,
     did,
     meshIP: getString(data.meshIP),
+    allowedIPs: getStringArray(data.allowedIPs),
     label: getString(data.label),
     ownerDID: getString(data.ownerDID) ?? getString(data.memberDID),
     memberDID: getString(data.memberDID) ?? getString(data.ownerDID),
@@ -479,6 +491,8 @@ export function parseMeshdNodeRecord(rawEntry: unknown, memberRecordId?: string)
     memberRecordId,
     addedAt: getString(data.addedAt),
     expiresAt: getString(data.expiresAt),
+    sourceDWN: getString(data.sourceDWN),
+    nodeKeyDelivery: isObject(data.nodeKeyDelivery) ? data.nodeKeyDelivery as MeshdNodeKeyDelivery : undefined,
     createdAt: getString(descriptor.dateCreated) ?? getString(wrapper.dateCreated)
   };
 }
@@ -1148,7 +1162,8 @@ async function deliverNetworkContextKey(
 export async function approveMeshdNodeRequest(
   session: MeshdAdminSession,
   network: MeshdNetworkSummary,
-  request: MeshdNodeRequestSummary
+  request: MeshdNodeRequestSummary,
+  options: { expiresAt?: string } = {}
 ): Promise<ApproveMeshdNodeRequestResult> {
   const ownerScopedRequest = isOwnerNodeRequest(request);
   if (ownerScopedRequest) {
@@ -1164,6 +1179,9 @@ export async function approveMeshdNodeRequest(
   const requestOwnerDID = nodeOwnerDID(request);
   const member = await ensureMemberRecord(session, network, requestOwnerDID, request.label);
   const meshIP = await allocateMeshIp(network.meshCIDR, request.nodeDID);
+  const expiresAt = Object.prototype.hasOwnProperty.call(options, "expiresAt")
+    ? options.expiresAt?.trim()
+    : request.expiresAt;
 
   const nodeRecord = await writeRecord(
     session,
@@ -1183,7 +1201,7 @@ export async function approveMeshdNodeRequest(
       ownerDID: requestOwnerDID,
       memberDID: requestOwnerDID,
       ...(request.delegateDID ? { delegateDID: request.delegateDID } : {}),
-      ...(request.expiresAt ? { expiresAt: request.expiresAt } : {}),
+      ...(expiresAt ? { expiresAt } : {}),
       nodeKeyDelivery
     },
     true
@@ -1218,7 +1236,7 @@ export async function approveMeshdNodeRequest(
         nodeRecordId: nodeRecord.recordId,
         ...(nodeRecord.dateCreated ? { nodeDateCreated: nodeRecord.dateCreated } : {}),
         ...(request.label ? { label: request.label } : {}),
-        ...(request.expiresAt ? { expiresAt: request.expiresAt } : {}),
+        ...(expiresAt ? { expiresAt } : {}),
         approvedAt: new Date().toISOString(),
         requestRecordId: request.recordId
       }
@@ -1239,6 +1257,56 @@ export async function rejectMeshdNodeRequest(
   request: MeshdNodeRequestSummary
 ): Promise<void> {
   await deleteRecord(session, MESHD_PROTOCOL_URI, request.recordId, false);
+}
+
+export async function updateMeshdNodeExpiry(
+  session: MeshdAdminSession,
+  network: MeshdNetworkSummary,
+  node: MeshdNodeSummary,
+  expiresAt?: string
+): Promise<MeshdNodeSummary> {
+  const nextExpiresAt = expiresAt?.trim();
+  if (!node.meshIP) {
+    throw new Error("Cannot update expiry for a node without a mesh IP.");
+  }
+
+  const protocolPath = node.memberRecordId ? "network/member/node" : "network/node";
+  const parentContextId = node.memberRecordId ? `${network.recordId}/${node.memberRecordId}` : network.recordId;
+  await writeRecord(
+    session,
+    MESHD_PROTOCOL_URI,
+    {
+      protocol: MESHD_PROTOCOL_URI,
+      protocolPath,
+      schema: "https://enbox.id/schemas/wireguard-mesh/node",
+      dataFormat: "application/json",
+      recipient: node.did,
+      parentContextId,
+      recordId: node.recordId,
+      ...(node.createdAt ? { dateCreated: node.createdAt } : {})
+    },
+    {
+      meshIP: node.meshIP,
+      ...(node.allowedIPs?.length ? { allowedIPs: node.allowedIPs } : {}),
+      addedAt: node.addedAt || new Date().toISOString(),
+      ...(nextExpiresAt ? { expiresAt: nextExpiresAt } : {}),
+      ...(node.label ? { label: node.label } : {}),
+      ...(node.ownerDID ? { ownerDID: node.ownerDID } : {}),
+      ...(node.memberDID ? { memberDID: node.memberDID } : {}),
+      ...(node.delegateDID ? { delegateDID: node.delegateDID } : {}),
+      ...(node.sourceDWN ? { sourceDWN: node.sourceDWN } : {}),
+      ...(node.nodeKeyDelivery ? { nodeKeyDelivery: node.nodeKeyDelivery } : {})
+    },
+    true
+  );
+
+  const nextNode = { ...node };
+  if (nextExpiresAt) {
+    nextNode.expiresAt = nextExpiresAt;
+  } else {
+    delete nextNode.expiresAt;
+  }
+  return nextNode;
 }
 
 function getRecordIdFromEntry(rawEntry: unknown): string | undefined {

--- a/admin-dapp/src/styles.css
+++ b/admin-dapp/src/styles.css
@@ -418,6 +418,16 @@ select:focus {
   min-width: 0;
 }
 
+.inline-control {
+  display: flex;
+  justify-content: flex-end;
+  min-width: 0;
+}
+
+.inline-control label {
+  width: min(220px, 100%);
+}
+
 .toggle-field {
   display: inline-flex;
   align-items: center;
@@ -465,6 +475,16 @@ select:focus {
   min-width: 0;
 }
 
+.node-card.expiring {
+  border-color: #d8b25d;
+  background: #fffdf6;
+}
+
+.node-card.expired {
+  border-color: #d36b61;
+  background: #fff8f7;
+}
+
 .node-card-header {
   display: grid;
   grid-template-columns: 32px minmax(0, 1fr) auto;
@@ -504,6 +524,14 @@ dd {
   font-size: 0.78rem;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.expiry-editor {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 38px;
+  gap: 0.5rem;
+  align-items: center;
+  min-width: 0;
 }
 
 .invite-result {


### PR DESCRIPTION
## Summary
- let the admin dashboard choose node membership expiry while approving pending requests
- add renew/clear expiry controls to existing node cards
- preserve encrypted node record fields when rewriting expiry metadata

## Tests
- npm test (admin-dapp)
- npm run build (admin-dapp)
- go test -count=1 ./...

## Notes
- `rg -n "enbox\.org" .` returned no matches
- local Vite build still warns because this machine is on Node 21.6.2 while Vite wants 20.19+ or 22.12+, but the build succeeds
