### PR TITLE
feat: show node membership expiry in CLI

### DIFF
--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -1424,7 +1424,7 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 	//   - network/member/node (member-associated)
 	encMgr := newEncryptionKeyManager(identity)
 
-	var nodeRecordID, nodeDateCreated, meshIP, memberRecordID string
+	var nodeRecordID, nodeDateCreated, meshIP, memberRecordID, nodeExpiresAt string
 
 	// Query network/node records to find one with our DID as recipient.
 	nodeRecords, queryStatus, err := api.Query(ctx, anchorDID, dwn.QueryParams{
@@ -1442,10 +1442,14 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 		nodeRecordID = nodeRecords[0].ID
 		nodeDateCreated = nodeRecords[0].DateCreated
 		var nodeData struct {
-			MeshIP string `json:"meshIP"`
+			MeshIP    string `json:"meshIP"`
+			ExpiresAt string `json:"expiresAt"`
 		}
-		if err := nodeRecords[0].Data().JSON(ctx, &nodeData); err == nil && nodeData.MeshIP != "" {
-			meshIP = nodeData.MeshIP
+		if err := nodeRecords[0].Data().JSON(ctx, &nodeData); err == nil {
+			if nodeData.MeshIP != "" {
+				meshIP = nodeData.MeshIP
+			}
+			nodeExpiresAt = strings.TrimSpace(nodeData.ExpiresAt)
 		}
 		fmt.Printf("  Found node record (owner-provisioned).\n")
 	}
@@ -1488,10 +1492,14 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 				nodeRecordID = memberNodeRecords[0].ID
 				nodeDateCreated = memberNodeRecords[0].DateCreated
 				var nodeData struct {
-					MeshIP string `json:"meshIP"`
+					MeshIP    string `json:"meshIP"`
+					ExpiresAt string `json:"expiresAt"`
 				}
-				if err := memberNodeRecords[0].Data().JSON(ctx, &nodeData); err == nil && nodeData.MeshIP != "" {
-					meshIP = nodeData.MeshIP
+				if err := memberNodeRecords[0].Data().JSON(ctx, &nodeData); err == nil {
+					if nodeData.MeshIP != "" {
+						meshIP = nodeData.MeshIP
+					}
+					nodeExpiresAt = strings.TrimSpace(nodeData.ExpiresAt)
 				}
 				fmt.Printf("  Found node record (member-associated).\n")
 				break
@@ -1590,6 +1598,7 @@ func cmdNetworkJoin(ctx context.Context, args []string, flagProfile string) erro
 		NetworkName:     networkData.Name,
 		MeshCIDR:        networkData.MeshCIDR,
 		MeshIP:          meshIP,
+		NodeExpiresAt:   nodeExpiresAt,
 		NodeDID:         nodeDID,
 		OwnerDID:        ownerDID,
 		MemberDID:       ownerDID,
@@ -2062,6 +2071,7 @@ func cmdPeerList(ctx context.Context, args []string, flagProfile string) error {
 			MeshIP    string `json:"meshIP"`
 			Label     string `json:"label"`
 			MemberDID string `json:"memberDID"`
+			ExpiresAt string `json:"expiresAt"`
 		}
 		if err := r.Data().JSON(ctx, &node); err != nil {
 			// Data may not be inline (encrypted records need context key).
@@ -2071,6 +2081,7 @@ func cmdPeerList(ctx context.Context, args []string, flagProfile string) error {
 				Device:  device,
 				Owner:   peerListOwner(peerDID, "", selfNodeDID, selfOwnerDID),
 				Label:   "(encrypted)",
+				Expires: "unknown",
 				Path:    r.ProtocolPath,
 			})
 			continue
@@ -2081,6 +2092,7 @@ func cmdPeerList(ctx context.Context, args []string, flagProfile string) error {
 			Device:  device,
 			Owner:   peerListOwner(peerDID, node.MemberDID, selfNodeDID, selfOwnerDID),
 			Label:   node.Label,
+			Expires: node.ExpiresAt,
 			Path:    r.ProtocolPath,
 		})
 	}
@@ -2121,6 +2133,7 @@ type peerListRow struct {
 	Device  string
 	Owner   string
 	Label   string
+	Expires string
 	Path    string
 }
 
@@ -2149,6 +2162,7 @@ func peerListRowsFromMapResponse(ns *state.NetworkState, resp *control.MapRespon
 			Device:  peerListDevice(node.DID, selfNodeDID),
 			Owner:   peerListOwner(node.DID, node.MemberDID, selfNodeDID, selfOwnerDID),
 			Label:   node.Name,
+			Expires: node.ExpiresAt,
 			Path:    peerListPath(node),
 		})
 	}
@@ -2161,18 +2175,34 @@ func printPeerListRows(networkName string, rows []peerListRow) {
 		return
 	}
 	fmt.Printf("Peers in %q:\n", networkName)
-	fmt.Printf("%-48s %-16s %-12s %-36s %-12s %s\n", "NODE DID", "MESH IP", "DEVICE", "OWNER", "LABEL", "PATH")
-	fmt.Println(strings.Repeat("-", 132))
+	fmt.Printf("%-44s %-15s %-11s %-28s %-12s %-17s %s\n", "NODE DID", "MESH IP", "DEVICE", "OWNER", "LABEL", "EXPIRES", "PATH")
+	fmt.Println(strings.Repeat("-", 139))
 	for _, row := range rows {
-		fmt.Printf("%-48s %-16s %-12s %-36s %-12s %s\n",
-			truncate(firstNonEmpty(row.NodeDID, "(unknown)"), 48),
+		fmt.Printf("%-44s %-15s %-11s %-28s %-12s %-17s %s\n",
+			truncate(firstNonEmpty(row.NodeDID, "(unknown)"), 44),
 			row.MeshIP,
 			row.Device,
-			truncate(row.Owner, 36),
-			row.Label,
+			truncate(row.Owner, 28),
+			truncate(row.Label, 12),
+			peerListExpiry(row.Expires),
 			row.Path,
 		)
 	}
+}
+
+func peerListExpiry(expiresAt string) string {
+	expiresAt = strings.TrimSpace(expiresAt)
+	if expiresAt == "" {
+		return "never"
+	}
+	parsed, err := time.Parse(time.RFC3339, expiresAt)
+	if err != nil {
+		return truncate(expiresAt, 17)
+	}
+	if time.Now().UTC().After(parsed) {
+		return "expired"
+	}
+	return parsed.UTC().Format("2006-01-02 15:04")
 }
 
 func peerListDevice(peerDID string, selfDID string) string {
@@ -2837,6 +2867,9 @@ func cmdStatus(ctx context.Context, args []string, flagProfile string) error {
 	}
 	if ns.MeshIP != "" {
 		fmt.Printf("  Mesh IP: %s\n", ns.MeshIP)
+	}
+	if ns.NodeExpiresAt != "" {
+		fmt.Printf("  Membership Expires: %s\n", ns.NodeExpiresAt)
 	}
 	// WireGuard public key is derived from the node DID, not stored.
 	if selfNodeDID != "" {
@@ -4375,6 +4408,7 @@ func refreshPendingOwnerApproval(ctx context.Context, stateDir string, ns *state
 		NetworkName:       firstNonEmpty(approval.NetworkName, "mesh"),
 		MeshCIDR:          firstNonEmpty(approval.MeshCIDR, "10.200.0.0/16"),
 		MeshIP:            approval.MeshIP,
+		NodeExpiresAt:     approval.ExpiresAt,
 		NodeDID:           nodeDID,
 		OwnerDID:          ownerDID,
 		MemberDID:         ownerDID,
@@ -4389,6 +4423,9 @@ func refreshPendingOwnerApproval(ctx context.Context, stateDir string, ns *state
 	fmt.Printf("Owner approval accepted.\n")
 	fmt.Printf("  Network: %s\n", refreshed.NetworkName)
 	fmt.Printf("  Mesh IP: %s\n", refreshed.MeshIP)
+	if refreshed.NodeExpiresAt != "" {
+		fmt.Printf("  Membership Expires: %s\n", refreshed.NodeExpiresAt)
+	}
 	if approvalRecordID != "" {
 		fmt.Printf("  Approval: %s\n", approvalRecordID)
 	}

--- a/cmd/meshd/main_test.go
+++ b/cmd/meshd/main_test.go
@@ -291,6 +291,7 @@ func TestPeerListRowsFromMapResponse(t *testing.T) {
 			MemberDID: "did:jwk:wallet",
 			Name:      "laptop",
 			MeshIP:    netip.MustParseAddr("10.200.0.5"),
+			ExpiresAt: "2026-07-01T00:00:00Z",
 		},
 		Peers: []*control.Node{
 			{
@@ -299,6 +300,7 @@ func TestPeerListRowsFromMapResponse(t *testing.T) {
 				MemberRecordID: "member-record",
 				Name:           "server",
 				MeshIP:         netip.MustParseAddr("10.200.0.8"),
+				ExpiresAt:      "2026-07-02T00:00:00Z",
 			},
 		},
 	}
@@ -315,6 +317,28 @@ func TestPeerListRowsFromMapResponse(t *testing.T) {
 	}
 	if rows[1].MeshIP != "10.200.0.8" || rows[1].Label != "server" {
 		t.Fatalf("peer row data = %+v", rows[1])
+	}
+	if rows[0].Expires != "2026-07-01T00:00:00Z" || rows[1].Expires != "2026-07-02T00:00:00Z" {
+		t.Fatalf("peer row expiry = %+v", rows)
+	}
+}
+
+func TestPeerListExpiry(t *testing.T) {
+	if got := peerListExpiry(""); got != "never" {
+		t.Fatalf("empty expiry = %q, want never", got)
+	}
+	if got := peerListExpiry("unknown"); got != "unknown" {
+		t.Fatalf("unknown expiry = %q", got)
+	}
+	future := time.Now().UTC().Add(24 * time.Hour).Truncate(time.Minute)
+	if got, want := peerListExpiry(future.Format(time.RFC3339)), future.Format("2006-01-02 15:04"); got != want {
+		t.Fatalf("future expiry = %q", got)
+	}
+	if got := peerListExpiry("2020-01-01T00:00:00Z"); got != "expired" {
+		t.Fatalf("past expiry = %q, want expired", got)
+	}
+	if got := peerListExpiry("not-a-valid-rfc3339-date"); got != "not-a-valid-rf..." {
+		t.Fatalf("malformed expiry = %q", got)
 	}
 }
 

--- a/docs/smoke-test-mac-linux.md
+++ b/docs/smoke-test-mac-linux.md
@@ -1,7 +1,7 @@
 # Mac/Linux beta smoke test
 
-Use this runbook to validate the current wallet-owned, dashboard-approved flow
-before adding node membership expiry or edit controls.
+Use this runbook to validate the current wallet-owned, dashboard-approved flow,
+including dashboard-managed node membership expiry.
 
 Assumptions:
 
@@ -26,7 +26,7 @@ meshd --version
 Expected result:
 
 ```text
-meshd 0.4.0
+meshd <latest release>
 ```
 
 If your shell has not picked up the installer PATH update yet, run:
@@ -84,8 +84,9 @@ On the Mac dashboard:
 
 1. Select the target network.
 2. Refresh if the pending request is not visible yet.
-3. Approve the Linux node.
-4. Confirm the node appears under `Nodes`.
+3. Pick an `Approve for` expiry such as `30 days`.
+4. Approve the Linux node.
+5. Confirm the node appears under `Nodes` with the selected expiry.
 
 The dashboard should write the member/node record, deliver the network context
 key to the node, and write a node approval response.
@@ -111,8 +112,11 @@ meshd peer list
 Expected result:
 
 - `meshd status` shows `Daemon: Running: yes`.
+- If an approval expiry was selected, the joining node's `meshd status` shows
+  `Membership Expires`.
 - Both machines show the same network name.
-- `meshd peer list` shows both peers with `10.200.x.x` mesh IPs.
+- `meshd peer list` shows both peers with `10.200.x.x` mesh IPs and an
+  `EXPIRES` column. Non-expiring nodes show `never`.
 
 ## 5. Ping both directions
 

--- a/internal/control/control_test.go
+++ b/internal/control/control_test.go
@@ -268,6 +268,7 @@ func TestNodeRecordToNode(t *testing.T) {
 		MeshIP:          "10.200.0.5",
 		AllowedIPs:      []string{"192.168.1.0/24"},
 		AddedAt:         "2026-01-01T00:00:00Z",
+		ExpiresAt:       "2026-07-01T00:00:00Z",
 		OwnerDID:        "did:jwk:wallet",
 		NodeKeyDelivery: &dwncrypto.KeyDeliveryPublic{RootKeyID: didURI + "#1"},
 		Info: &NodeInfoData{
@@ -298,6 +299,7 @@ func TestNodeRecordToNode(t *testing.T) {
 		"Key":           {got: node.Key, want: wantKey},
 		"MeshIP":        {got: node.MeshIP, want: netip.MustParseAddr("10.200.0.5")},
 		"MemberDID":     {got: node.MemberDID, want: "did:jwk:wallet"},
+		"ExpiresAt":     {got: node.ExpiresAt, want: "2026-07-01T00:00:00Z"},
 		"Name":          {got: node.Name, want: "myhost"},
 		"PreferredDERP": {got: node.PreferredDERP, want: 2},
 		"Online":        {got: node.Online, want: true},

--- a/internal/control/dwnclient.go
+++ b/internal/control/dwnclient.go
@@ -770,6 +770,7 @@ func nodeRecordToNodeWithThreshold(id int64, nodeDID string, rec *NodeRecord, st
 		DID:            nodeDID,
 		MemberDID:      rec.EffectiveOwnerDID(),
 		MemberRecordID: rec.MemberRecordID,
+		ExpiresAt:      rec.ExpiresAt,
 		KeyDelivery:    rec.NodeKeyDelivery,
 	}
 

--- a/internal/control/types.go
+++ b/internal/control/types.go
@@ -36,6 +36,10 @@ type Node struct {
 	// under network/member/node.
 	MemberRecordID string
 
+	// ExpiresAt is the owner-controlled membership expiry timestamp.
+	// Empty means the node membership does not expire.
+	ExpiresAt string
+
 	// Key is the WireGuard public key (Curve25519, base64).
 	// Derived from the node's did:jwk identity (Ed25519 → X25519 birational map),
 	// not read from a record field.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -65,6 +65,10 @@ type NetworkState struct {
 	// MeshIP is this node's allocated IP within the mesh.
 	MeshIP string `json:"meshIp,omitempty"`
 
+	// NodeExpiresAt is the owner-controlled expiry for this node's membership.
+	// Empty means the membership does not expire.
+	NodeExpiresAt string `json:"nodeExpiresAt,omitempty"`
+
 	// NodeDID is this machine's device DID. It is the DID used for WireGuard
 	// key derivation, node records, endpoint writes, and "this device" UI.
 	// Older state files omit it; callers should fall back to the local profile

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -14,6 +14,7 @@ func TestNetworkStateOwnerDIDCompatibility(t *testing.T) {
 			NetworkRecordID: "network-1",
 			OwnerDID:        "did:dht:wallet",
 			NodeDID:         "did:jwk:node",
+			NodeExpiresAt:   "2026-07-01T00:00:00Z",
 		}); err != nil {
 			t.Fatalf("SaveNetworkState: %v", err)
 		}
@@ -28,6 +29,9 @@ func TestNetworkStateOwnerDIDCompatibility(t *testing.T) {
 		}
 		if raw["ownerDid"] != "did:dht:wallet" || raw["memberDid"] != "did:dht:wallet" {
 			t.Fatalf("raw aliases = owner %v member %v", raw["ownerDid"], raw["memberDid"])
+		}
+		if raw["nodeExpiresAt"] != "2026-07-01T00:00:00Z" {
+			t.Fatalf("raw nodeExpiresAt = %v", raw["nodeExpiresAt"])
 		}
 	})
 


### PR DESCRIPTION
## Summary
- carry node membership expiry from DWN node records into control nodes and local network state
- show current node membership expiry in `meshd status`
- add an `EXPIRES` column to `meshd peer list` and document expiry validation in the Mac/Linux smoke test

## Tests
- go test -count=1 ./...
- npm test (admin-dapp)
- npm run build (admin-dapp)
- rg -n "enbox\.org" README.md docs cmd internal admin-dapp/src .github protocols || true

## Notes
- local Vite build still warns because this machine is on Node 21.6.2 while Vite wants 20.19+ or 22.12+, but the build succeeds
