### PR TITLE
feat: honor admin dashboard owner URL

### DIFF
--- a/admin-dapp/src/App.tsx
+++ b/admin-dapp/src/App.tsx
@@ -18,6 +18,11 @@ import { toast } from "sonner";
 
 import { useEnbox } from "./enbox/use-enbox";
 import {
+  dashboardContextFromSearch,
+  ownerMatchesDashboardContext,
+  type MeshdDashboardURLContext
+} from "./meshd/dashboard-url";
+import {
   approveMeshdNodeRequest,
   buildMeshdInviteURL,
   createMeshdInvite,
@@ -90,6 +95,7 @@ function expiryTimestamp(value: ExpiryValue) {
 
 export function App() {
   const enboxState = useEnbox();
+  const [dashboardContext] = useState(() => dashboardContextFromSearch(window.location.search));
 
   return (
     <div className="app-shell">
@@ -123,13 +129,13 @@ export function App() {
       </header>
 
       <main className="workspace">
-        {!enboxState.isConnected ? <ConnectPanel /> : <Dashboard />}
+        {!enboxState.isConnected ? <ConnectPanel context={dashboardContext} /> : <Dashboard context={dashboardContext} />}
       </main>
     </div>
   );
 }
 
-function ConnectPanel() {
+function ConnectPanel({ context }: { context: MeshdDashboardURLContext }) {
   const { connectWallet, isConnecting } = useEnbox();
   const [error, setError] = useState<string>();
 
@@ -154,6 +160,12 @@ function ConnectPanel() {
           <p>Connect an owner wallet to manage networks and node approvals.</p>
         </div>
       </div>
+      {context.ownerDID ? (
+        <div className="target-owner">
+          <span>Owner</span>
+          <code title={context.ownerDID}>{truncateDid(context.ownerDID)}</code>
+        </div>
+      ) : null}
       {error ? <div className="error-banner">{error}</div> : null}
       <button className="primary-button" type="button" disabled={isConnecting} onClick={() => void connect()}>
         {isConnecting ? <Loader2Icon className="spin" size={17} /> : <ShieldCheckIcon size={17} />}
@@ -163,7 +175,7 @@ function ConnectPanel() {
   );
 }
 
-function Dashboard() {
+function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
   const { did, delegateDid, enbox, protocolsInitialized, protocolSetupError } = useEnbox();
   const session = useMemo<MeshdAdminSession | undefined>(() => {
     if (!did || !enbox) return undefined;
@@ -175,7 +187,7 @@ function Dashboard() {
   }, [delegateDid, did, enbox]);
 
   const [networks, setNetworks] = useState<MeshdNetworkSummary[]>([]);
-  const [selectedNetworkId, setSelectedNetworkId] = useState(() => new URLSearchParams(window.location.search).get("network") ?? "");
+  const [selectedNetworkId, setSelectedNetworkId] = useState(() => context.networkRecordID ?? "");
   const [topology, setTopology] = useState<MeshdNetworkTopology>();
   const [loadState, setLoadState] = useState<LoadState>("idle");
   const [error, setError] = useState<string>();
@@ -194,7 +206,7 @@ function Dashboard() {
   }, [networks, selectedNetworkId]);
 
   const refreshNetworks = useCallback(async () => {
-    if (!session || !protocolsInitialized) return;
+    if (!session || !protocolsInitialized || !ownerMatchesDashboardContext(context, did)) return;
     setLoadState("loading");
     setError(undefined);
     try {
@@ -208,10 +220,10 @@ function Dashboard() {
       setError(err instanceof Error ? err.message : "Could not load networks.");
       setLoadState("error");
     }
-  }, [protocolsInitialized, selectedNetworkId, session]);
+  }, [context, did, protocolsInitialized, selectedNetworkId, session]);
 
   const refreshTopology = useCallback(async () => {
-    if (!session || !protocolsInitialized || !selectedNetwork) return;
+    if (!session || !protocolsInitialized || !selectedNetwork || !ownerMatchesDashboardContext(context, did)) return;
     setError(undefined);
     try {
       const nextTopology = await fetchMeshdNetworkTopology(session, selectedNetwork);
@@ -219,7 +231,7 @@ function Dashboard() {
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not load network topology.");
     }
-  }, [protocolsInitialized, selectedNetwork, session]);
+  }, [context, did, protocolsInitialized, selectedNetwork, session]);
 
   useEffect(() => {
     void refreshNetworks();
@@ -329,6 +341,15 @@ function Dashboard() {
       toast.success("Node removed");
       await refreshTopology();
     });
+  }
+
+  if (!ownerMatchesDashboardContext(context, did)) {
+    return (
+      <StatePanel
+        title="Wrong owner wallet"
+        detail={`This dashboard URL targets ${context.ownerDID}, but the connected wallet is ${did ?? "unknown"}. Disconnect and connect the owner wallet.`}
+      />
+    );
   }
 
   if (protocolSetupError) {

--- a/admin-dapp/src/meshd/dashboard-url.test.ts
+++ b/admin-dapp/src/meshd/dashboard-url.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { dashboardContextFromSearch, ownerMatchesDashboardContext } from "./dashboard-url";
+
+describe("meshd admin dashboard URL context", () => {
+  it("reads owner and network hints from query params", () => {
+    expect(dashboardContextFromSearch("?owner=did%3Aexample%3Aowner&network=network-record")).toEqual({
+      ownerDID: "did:example:owner",
+      networkRecordID: "network-record"
+    });
+  });
+
+  it("ignores empty hints", () => {
+    expect(dashboardContextFromSearch("?owner=+&network=")).toEqual({});
+  });
+
+  it("checks connected wallet owner against URL owner hint", () => {
+    expect(ownerMatchesDashboardContext({ ownerDID: "did:example:owner" }, "did:example:owner")).toBe(true);
+    expect(ownerMatchesDashboardContext({ ownerDID: "did:example:owner" }, "did:example:other")).toBe(false);
+    expect(ownerMatchesDashboardContext({}, "did:example:other")).toBe(true);
+  });
+});

--- a/admin-dapp/src/meshd/dashboard-url.ts
+++ b/admin-dapp/src/meshd/dashboard-url.ts
@@ -1,0 +1,23 @@
+export type MeshdDashboardURLContext = {
+  ownerDID?: string;
+  networkRecordID?: string;
+};
+
+function cleanParam(value: string | null): string | undefined {
+  const cleaned = value?.trim();
+  return cleaned || undefined;
+}
+
+export function dashboardContextFromSearch(search: string): MeshdDashboardURLContext {
+  const params = new URLSearchParams(search);
+  const ownerDID = cleanParam(params.get("owner"));
+  const networkRecordID = cleanParam(params.get("network"));
+  return {
+    ...(ownerDID ? { ownerDID } : {}),
+    ...(networkRecordID ? { networkRecordID } : {})
+  };
+}
+
+export function ownerMatchesDashboardContext(context: MeshdDashboardURLContext, connectedDID?: string): boolean {
+  return !context.ownerDID || context.ownerDID === connectedDID;
+}

--- a/admin-dapp/src/styles.css
+++ b/admin-dapp/src/styles.css
@@ -175,6 +175,21 @@ code {
   min-width: 0;
 }
 
+.target-owner {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.65rem;
+  border: 1px solid #d8dfd5;
+  border-radius: 8px;
+  background: #fbfcfa;
+  padding: 0.65rem;
+  min-width: 0;
+  color: #49534e;
+  font-size: 0.82rem;
+  font-weight: 650;
+}
+
 h1,
 p {
   margin: 0;
@@ -577,6 +592,10 @@ dd {
 
 .state-panel {
   justify-items: start;
+}
+
+.state-panel p {
+  overflow-wrap: anywhere;
 }
 
 .spin {


### PR DESCRIPTION
## Summary
- parse `owner` and `network` hints from meshd admin dashboard URLs
- show the target owner before wallet connection
- block dashboard actions when the connected wallet does not match the owner URL

## Tests
- npm test (admin-dapp)
- npm run build (admin-dapp)
- rg -n "enbox\.org" README.md docs cmd internal admin-dapp/src .github protocols || true

## Notes
- local Vite build still warns because this machine is on Node 21.6.2 while Vite wants 20.19+ or 22.12+, but the build succeeds
