### PR TITLE
feat: edit admin node labels

### DIFF
--- a/admin-dapp/src/App.tsx
+++ b/admin-dapp/src/App.tsx
@@ -8,6 +8,7 @@ import {
   NetworkIcon,
   PlusIcon,
   RefreshCwIcon,
+  SaveIcon,
   ServerIcon,
   ShieldCheckIcon,
   Trash2Icon,
@@ -33,6 +34,7 @@ import {
   removeMeshdNode,
   revokeMeshdInvite,
   updateMeshdNodeExpiry,
+  updateMeshdNodeLabel,
   type CreateMeshdInviteResult,
   type MeshdAdminSession,
   type MeshdNetworkSummary,
@@ -316,6 +318,15 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
     });
   }
 
+  async function handleUpdateNodeLabel(node: MeshdNodeSummary, label: string) {
+    if (!session || !selectedNetwork) return;
+    await runAction(`label-${node.recordId}`, async () => {
+      await updateMeshdNodeLabel(session, selectedNetwork, node, label);
+      toast.success(label.trim() ? "Node label updated" : "Node label cleared");
+      await refreshTopology();
+    });
+  }
+
   async function handleRevokeInvite(key: MeshdPreAuthKeySummary) {
     if (!session) return;
     await runAction(`revoke-${key.recordId}`, async () => {
@@ -526,6 +537,7 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
                     busyAction={busyAction}
                     onRemove={handleRemoveNode}
                     onUpdateExpiry={handleUpdateNodeExpiry}
+                    onUpdateLabel={handleUpdateNodeLabel}
                   />
                 )) : <EmptyRow icon={<ServerIcon size={18} />} text="No nodes" />}
               </div>
@@ -595,16 +607,20 @@ function NodeCard({
   owner,
   busyAction,
   onRemove,
-  onUpdateExpiry
+  onUpdateExpiry,
+  onUpdateLabel
 }: {
   node: MeshdNodeSummary;
   owner?: string;
   busyAction?: string;
   onRemove: (node: MeshdNodeSummary) => Promise<void>;
   onUpdateExpiry: (node: MeshdNodeSummary, value: ExpiryValue) => Promise<void>;
+  onUpdateLabel: (node: MeshdNodeSummary, label: string) => Promise<void>;
 }) {
   const removing = busyAction === `remove-${node.recordId}`;
+  const updatingLabel = busyAction === `label-${node.recordId}`;
   const updatingExpiry = busyAction === `expiry-${node.recordId}`;
+  const [labelValue, setLabelValue] = useState(node.label ?? "");
   const [expiryChoice, setExpiryChoice] = useState<ExpiryValue>("30d");
   const state = expiryState(node.expiresAt);
   const expiryLabel = node.expiresAt
@@ -612,6 +628,9 @@ function NodeCard({
       ? `Expired ${formatTime(node.expiresAt)}`
       : `Expires ${formatTime(node.expiresAt)}`
     : "No expiry";
+  useEffect(() => {
+    setLabelValue(node.label ?? "");
+  }, [node.label]);
   return (
     <article className={`node-card ${state === "expired" ? "expired" : state === "soon" ? "expiring" : ""}`}>
       <div className="node-card-header">
@@ -627,6 +646,22 @@ function NodeCard({
         {owner ? <div><dt>Owner</dt><dd title={owner}>{truncateDid(owner)}</dd></div> : null}
         <div><dt>Expiry</dt><dd>{expiryLabel}</dd></div>
       </dl>
+      <div className="label-editor">
+        <label>
+          Label
+          <input value={labelValue} onChange={(event) => setLabelValue(event.target.value)} placeholder={node.meshIP || "Node label"} />
+        </label>
+        <button
+          className="icon-button"
+          type="button"
+          aria-label="Apply node label"
+          title="Apply label"
+          disabled={updatingLabel || removing}
+          onClick={() => void onUpdateLabel(node, labelValue)}
+        >
+          {updatingLabel ? <Loader2Icon className="spin" size={15} /> : <SaveIcon size={15} />}
+        </button>
+      </div>
       <div className="expiry-editor">
         <select value={expiryChoice} onChange={(event) => setExpiryChoice(event.target.value as ExpiryValue)}>
           {EXPIRY_OPTIONS.map((option) => (

--- a/admin-dapp/src/meshd/admin.test.ts
+++ b/admin-dapp/src/meshd/admin.test.ts
@@ -9,6 +9,7 @@ import {
   createMeshdNetwork,
   fetchMeshdNetworks,
   updateMeshdNodeExpiry,
+  updateMeshdNodeLabel,
   type MeshdAdminAgent,
   type MeshdAdminSession,
   type MeshdNetworkSummary
@@ -383,6 +384,77 @@ describe("meshd admin DWN operations", () => {
       }
     });
     await expect(blobJson(requests[0].dataStream)).resolves.not.toHaveProperty("expiresAt");
+  });
+
+  it("updates node label while preserving expiry and membership metadata", async () => {
+    const { session, requests } = createFakeSession({ recordIds: ["node-record"] });
+    const network: MeshdNetworkSummary = {
+      recordId: "network-record",
+      name: "Home mesh",
+      meshCIDR: "10.200.0.0/16"
+    };
+
+    const node = await updateMeshdNodeLabel(session, network, {
+      recordId: "node-record",
+      did: "did:example:node",
+      meshIP: "10.200.0.10",
+      allowedIPs: ["10.200.0.10/32"],
+      label: "old label",
+      ownerDID: "did:example:owner",
+      memberDID: "did:example:owner",
+      memberRecordId: "member-record",
+      addedAt: "2026-06-24T00:00:00Z",
+      expiresAt: "2026-06-25T00:00:00Z",
+      createdAt: "2026-06-24T00:00:00Z"
+    }, "new label");
+
+    expect(node.label).toBe("new label");
+    expect(node.expiresAt).toBe("2026-06-25T00:00:00Z");
+    expect(requests[0]).toMatchObject({
+      messageParams: {
+        protocolPath: "network/member/node",
+        parentContextId: "network-record/member-record",
+        recordId: "node-record",
+        dateCreated: "2026-06-24T00:00:00Z"
+      }
+    });
+    await expect(blobJson(requests[0].dataStream)).resolves.toEqual({
+      meshIP: "10.200.0.10",
+      allowedIPs: ["10.200.0.10/32"],
+      addedAt: "2026-06-24T00:00:00Z",
+      expiresAt: "2026-06-25T00:00:00Z",
+      label: "new label",
+      ownerDID: "did:example:owner",
+      memberDID: "did:example:owner"
+    });
+  });
+
+  it("clears node label without clearing expiry", async () => {
+    const { session, requests } = createFakeSession({ recordIds: ["node-record"] });
+    const network: MeshdNetworkSummary = {
+      recordId: "network-record",
+      name: "Home mesh",
+      meshCIDR: "10.200.0.0/16"
+    };
+
+    const node = await updateMeshdNodeLabel(session, network, {
+      recordId: "node-record",
+      did: "did:example:node",
+      meshIP: "10.200.0.10",
+      label: "old label",
+      addedAt: "2026-06-24T00:00:00Z",
+      expiresAt: "2026-06-25T00:00:00Z",
+      createdAt: "2026-06-24T00:00:00Z"
+    }, "   ");
+
+    expect(node.label).toBeUndefined();
+    expect(node.expiresAt).toBe("2026-06-25T00:00:00Z");
+    await expect(blobJson(requests[0].dataStream)).resolves.toMatchObject({
+      meshIP: "10.200.0.10",
+      addedAt: "2026-06-24T00:00:00Z",
+      expiresAt: "2026-06-25T00:00:00Z"
+    });
+    await expect(blobJson(requests[0].dataStream)).resolves.not.toHaveProperty("label");
   });
 
   it("fetches and sorts network records through delegated records queries", async () => {

--- a/admin-dapp/src/meshd/admin.ts
+++ b/admin-dapp/src/meshd/admin.ts
@@ -1266,9 +1266,33 @@ export async function updateMeshdNodeExpiry(
   expiresAt?: string
 ): Promise<MeshdNodeSummary> {
   const nextExpiresAt = expiresAt?.trim();
+  return writeUpdatedMeshdNode(session, network, node, { expiresAt: nextExpiresAt });
+}
+
+export async function updateMeshdNodeLabel(
+  session: MeshdAdminSession,
+  network: MeshdNetworkSummary,
+  node: MeshdNodeSummary,
+  label?: string
+): Promise<MeshdNodeSummary> {
+  const nextLabel = label?.trim();
+  return writeUpdatedMeshdNode(session, network, node, { label: nextLabel });
+}
+
+async function writeUpdatedMeshdNode(
+  session: MeshdAdminSession,
+  network: MeshdNetworkSummary,
+  node: MeshdNodeSummary,
+  updates: { expiresAt?: string; label?: string }
+): Promise<MeshdNodeSummary> {
   if (!node.meshIP) {
-    throw new Error("Cannot update expiry for a node without a mesh IP.");
+    throw new Error("Cannot update a node without a mesh IP.");
   }
+
+  const hasExpiresAtUpdate = Object.prototype.hasOwnProperty.call(updates, "expiresAt");
+  const hasLabelUpdate = Object.prototype.hasOwnProperty.call(updates, "label");
+  const nextExpiresAt = hasExpiresAtUpdate ? updates.expiresAt?.trim() : node.expiresAt?.trim();
+  const nextLabel = hasLabelUpdate ? updates.label?.trim() : node.label?.trim();
 
   const protocolPath = node.memberRecordId ? "network/member/node" : "network/node";
   const parentContextId = node.memberRecordId ? `${network.recordId}/${node.memberRecordId}` : network.recordId;
@@ -1290,7 +1314,7 @@ export async function updateMeshdNodeExpiry(
       ...(node.allowedIPs?.length ? { allowedIPs: node.allowedIPs } : {}),
       addedAt: node.addedAt || new Date().toISOString(),
       ...(nextExpiresAt ? { expiresAt: nextExpiresAt } : {}),
-      ...(node.label ? { label: node.label } : {}),
+      ...(nextLabel ? { label: nextLabel } : {}),
       ...(node.ownerDID ? { ownerDID: node.ownerDID } : {}),
       ...(node.memberDID ? { memberDID: node.memberDID } : {}),
       ...(node.delegateDID ? { delegateDID: node.delegateDID } : {}),
@@ -1301,10 +1325,19 @@ export async function updateMeshdNodeExpiry(
   );
 
   const nextNode = { ...node };
-  if (nextExpiresAt) {
-    nextNode.expiresAt = nextExpiresAt;
-  } else {
-    delete nextNode.expiresAt;
+  if (hasExpiresAtUpdate) {
+    if (nextExpiresAt) {
+      nextNode.expiresAt = nextExpiresAt;
+    } else {
+      delete nextNode.expiresAt;
+    }
+  }
+  if (hasLabelUpdate) {
+    if (nextLabel) {
+      nextNode.label = nextLabel;
+    } else {
+      delete nextNode.label;
+    }
   }
   return nextNode;
 }

--- a/admin-dapp/src/styles.css
+++ b/admin-dapp/src/styles.css
@@ -549,6 +549,14 @@ dd {
   min-width: 0;
 }
 
+.label-editor {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 38px;
+  gap: 0.5rem;
+  align-items: end;
+  min-width: 0;
+}
+
 .invite-result {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;


### PR DESCRIPTION
## Summary
- add admin dashboard API support for updating or clearing node labels while preserving node metadata
- add a compact node-card label editor
- cover label update and label clear behavior in admin dapp tests

## Verification
- npm test
- npm run build
- rg -n "enbox\.org" README.md docs cmd internal admin-dapp/src .github protocols