### PR TITLE
feat: default owner requests to beta DWN

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Admin dapp; each machine keeps a local encrypted node DID.
 meshd admin --print
 
 # On a new device, request approval from that owner.
-meshd up --owner did:example:owner --endpoint https://dev.aws.dwn.enbox.id
+meshd up --owner did:example:owner
 
 # Approve the pending device in the dashboard, then start it.
 meshd up
@@ -64,6 +64,8 @@ meshd up
 waits. After approval, the dashboard writes the node membership record, delivers
 the network context key, and writes a node approval response that the CLI
 consumes on the next `meshd up`.
+If the owner DID does not advertise a DWN endpoint, meshd uses the beta DWN
+endpoint by default. Use `--endpoint` or `DWN_ENDPOINT` to override it.
 
 The default dashboard is deployed at `https://meshd-admin.pages.dev`.
 

--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -76,7 +76,7 @@ Network:
 
 Up flags:
   --create <name>   Create a new network and start (anchor mode)
-  --endpoint <url>  DWN endpoint for local-vault creation/join (or DWN_ENDPOINT)
+  --endpoint <url>  DWN endpoint override for create/join/owner requests
   --anchor <did>    Anchor DID when joining a network
   --network <id>    Network record ID when joining a network
   --owner <did>     Wallet owner DID for this local node when joining
@@ -107,7 +107,7 @@ Environment:
                      Unlock/create vault non-interactively
   MESHD_VAULT_CACHE_TTL
                      Cache interactive vault unlocks for this duration (default: 5m, 0 disables)
-  DWN_ENDPOINT       Default DWN endpoint URL
+  DWN_ENDPOINT       Default DWN endpoint URL override
   MESHD_WALLET_RESPONSE_ENDPOINT
                      DWN endpoint for wallet approval handoff on headless devices
 `
@@ -124,6 +124,8 @@ const (
 	walletResponseEndpointEnv     = "MESHD_WALLET_RESPONSE_ENDPOINT"
 	defaultWalletResponseEndpoint = "https://dev.aws.dwn.enbox.id"
 )
+
+var defaultOwnerRequestEndpoint = defaultWalletResponseEndpoint
 
 func main() {
 	if len(os.Args) < 2 {
@@ -4352,6 +4354,7 @@ func setupOwnerNodeRequest(ctx context.Context, f upFlags, stateDir string, iden
 
 	fmt.Printf("Node approval request submitted.\n")
 	fmt.Printf("  Owner DID: %s\n", ownerDID)
+	fmt.Printf("  Owner DWN: %s\n", endpoint)
 	fmt.Printf("  Node DID:  %s\n", identity.URI)
 	fmt.Printf("  Request:   %s\n", requestID)
 	fmt.Printf("  Dashboard: %s\n", buildAdminURL(defaultAdminDashboardURL, adminContext{OwnerDID: ownerDID}))
@@ -4360,21 +4363,40 @@ func setupOwnerNodeRequest(ctx context.Context, f upFlags, stateDir string, iden
 }
 
 func ownerDWNEndpointForRequest(ctx context.Context, ownerDID, explicitEndpoint string, scanner *bufio.Scanner) (string, error) {
-	endpoint := strings.TrimSpace(explicitEndpoint)
-	if endpoint != "" {
-		return endpoint, nil
+	if strings.TrimSpace(explicitEndpoint) != "" {
+		return ownerDWNEndpointFromInput(explicitEndpoint, "", nil, scanner, os.Stdout)
 	}
 	resolved, err := control.ResolvePeerDWNEndpoint(ctx, universalResolver{}, ownerDID, nil)
-	if err == nil && strings.TrimSpace(resolved) != "" {
-		return strings.TrimSpace(resolved), nil
+	return ownerDWNEndpointFromInput(explicitEndpoint, resolved, err, scanner, os.Stdout)
+}
+
+func ownerDWNEndpointFromInput(explicitEndpoint, resolvedEndpoint string, resolveErr error, scanner *bufio.Scanner, out io.Writer) (string, error) {
+	endpoint := strings.TrimSpace(explicitEndpoint)
+	if endpoint != "" {
+		return strings.TrimRight(endpoint, "/"), nil
+	}
+	resolved := strings.TrimSpace(resolvedEndpoint)
+	if resolved != "" {
+		return strings.TrimRight(resolved, "/"), nil
+	}
+	fallback := strings.TrimRight(strings.TrimSpace(defaultOwnerRequestEndpoint), "/")
+	if fallback == "" {
+		return "", fmt.Errorf("default owner DWN endpoint is empty")
 	}
 	if scanner != nil {
-		if err != nil {
-			fmt.Printf("Could not resolve an owner DWN endpoint automatically: %v\n", err)
+		if resolveErr != nil {
+			fmt.Fprintf(out, "Could not resolve an owner DWN endpoint automatically: %v\n", resolveErr)
 		}
-		return promptRequired(scanner, "Owner DWN endpoint URL")
+		fmt.Fprintf(out, "Owner DWN endpoint URL [%s]: ", fallback)
+		if !scanner.Scan() {
+			return "", fmt.Errorf("no input received")
+		}
+		if value := strings.TrimSpace(scanner.Text()); value != "" {
+			return strings.TrimRight(value, "/"), nil
+		}
+		return fallback, nil
 	}
-	return "", fmt.Errorf("--endpoint (or DWN_ENDPOINT env) is required because no DWN endpoint could be resolved for owner DID %s", ownerDID)
+	return fallback, nil
 }
 
 func refreshPendingOwnerApproval(ctx context.Context, stateDir string, ns *state.NetworkState, identity *did.DID) (*state.NetworkState, error) {

--- a/cmd/meshd/main_test.go
+++ b/cmd/meshd/main_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/netip"
@@ -1142,6 +1143,69 @@ func TestParseOwnerDIDArg(t *testing.T) {
 	got = parseOwnerDIDArg([]string{"--member", "did:dht:legacy"})
 	if got != "did:dht:legacy" {
 		t.Fatalf("legacy member alias owner DID = %q", got)
+	}
+}
+
+func TestOwnerDWNEndpointFromInput(t *testing.T) {
+	previous := defaultOwnerRequestEndpoint
+	defaultOwnerRequestEndpoint = "https://default.example.com/"
+	t.Cleanup(func() { defaultOwnerRequestEndpoint = previous })
+
+	got, err := ownerDWNEndpointFromInput("https://explicit.example.com/", "https://resolved.example.com", nil, nil, io.Discard)
+	if err != nil {
+		t.Fatalf("explicit endpoint: %v", err)
+	}
+	if got != "https://explicit.example.com" {
+		t.Fatalf("explicit endpoint = %q", got)
+	}
+
+	got, err = ownerDWNEndpointFromInput("", "https://resolved.example.com/", nil, nil, io.Discard)
+	if err != nil {
+		t.Fatalf("resolved endpoint: %v", err)
+	}
+	if got != "https://resolved.example.com" {
+		t.Fatalf("resolved endpoint = %q", got)
+	}
+
+	got, err = ownerDWNEndpointFromInput("", "", context.Canceled, nil, io.Discard)
+	if err != nil {
+		t.Fatalf("default endpoint: %v", err)
+	}
+	if got != "https://default.example.com" {
+		t.Fatalf("default endpoint = %q", got)
+	}
+}
+
+func TestOwnerDWNEndpointFromInputPromptDefault(t *testing.T) {
+	previous := defaultOwnerRequestEndpoint
+	defaultOwnerRequestEndpoint = "https://default.example.com/"
+	t.Cleanup(func() { defaultOwnerRequestEndpoint = previous })
+
+	var out bytes.Buffer
+	got, err := ownerDWNEndpointFromInput("", "", context.Canceled, bufio.NewScanner(strings.NewReader("\n")), &out)
+	if err != nil {
+		t.Fatalf("prompt default: %v", err)
+	}
+	if got != "https://default.example.com" {
+		t.Fatalf("prompt default endpoint = %q", got)
+	}
+	if !strings.Contains(out.String(), "Owner DWN endpoint URL [https://default.example.com]") {
+		t.Fatalf("prompt output = %q", out.String())
+	}
+}
+
+func TestOwnerDWNEndpointFromInputPromptOverride(t *testing.T) {
+	previous := defaultOwnerRequestEndpoint
+	defaultOwnerRequestEndpoint = "https://default.example.com/"
+	t.Cleanup(func() { defaultOwnerRequestEndpoint = previous })
+
+	var out bytes.Buffer
+	got, err := ownerDWNEndpointFromInput("", "", nil, bufio.NewScanner(strings.NewReader("https://custom.example.com/\n")), &out)
+	if err != nil {
+		t.Fatalf("prompt override: %v", err)
+	}
+	if got != "https://custom.example.com" {
+		t.Fatalf("prompt override endpoint = %q", got)
 	}
 }
 

--- a/docs/smoke-test-mac-linux.md
+++ b/docs/smoke-test-mac-linux.md
@@ -10,6 +10,8 @@ Assumptions:
 - Both machines may already run Tailscale. meshd uses `10.200.0.0/16`, so it
   should not overlap Tailscale's `100.64.0.0/10` address space.
 - The beta DWN endpoint is `https://dev.aws.dwn.enbox.id`.
+  `meshd up --owner` uses it automatically when the owner DID does not
+  advertise a DWN endpoint.
 - The released CLI is installed on both machines.
 - The standalone meshd Admin dapp is deployed at
   `https://meshd-admin.pages.dev`.
@@ -68,7 +70,7 @@ On the Linux server:
 
 ```bash
 meshd down || true
-meshd up --owner '<OWNER_DID>' --endpoint https://dev.aws.dwn.enbox.id
+meshd up --owner '<OWNER_DID>'
 ```
 
 Expected result:


### PR DESCRIPTION
## Summary
- let owner-node approval requests fall back to the beta DWN endpoint when the owner DID does not advertise a DWN endpoint
- make the interactive wizard accept the beta endpoint by pressing Enter
- print the owner DWN endpoint used and update the README/smoke test to use the simpler `meshd up --owner <did>` path

## Verification
- go test ./cmd/meshd -run 'TestOwnerDWNEndpointFromInput|TestParseOwnerDIDArg|TestParseUpFlags|TestParseNetworkJoin'
- go test ./...
- npm test
- npm run build
- rg -n "enbox\.org" README.md docs cmd internal admin-dapp/src .github protocols