### PR TITLE
chore(admin): default network creation DWN endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ the network context key, and writes a node approval response that the CLI
 consumes on the next `meshd up`.
 If the owner DID does not advertise a DWN endpoint, meshd uses the beta DWN
 endpoint by default. Use `--endpoint` or `DWN_ENDPOINT` to override it.
+The dashboard uses the same beta endpoint when creating a network for an owner
+without a published DWN endpoint.
 
 The default dashboard is deployed at `https://meshd-admin.pages.dev`.
 

--- a/admin-dapp/src/enbox/config.ts
+++ b/admin-dapp/src/enbox/config.ts
@@ -30,6 +30,7 @@ export const WALLET_OPTIONS = [
 export const DWN_ENDPOINTS = (
   import.meta.env.VITE_ENBOX_DWN_ENDPOINTS || "https://dev.aws.dwn.enbox.id,https://enbox-dwn.fly.dev"
 ).split(",").map((endpoint: string) => endpoint.trim()).filter(Boolean);
+export const DEFAULT_DWN_ENDPOINT = DWN_ENDPOINTS[0] || "https://dev.aws.dwn.enbox.id";
 
 export const MeshProtocolDefinition = meshProtocolDefinition;
 export const KeyDeliveryProtocolDefinition = keyDeliveryProtocolDefinition;

--- a/admin-dapp/src/meshd/admin.test.ts
+++ b/admin-dapp/src/meshd/admin.test.ts
@@ -1,7 +1,7 @@
 import { DwnInterface } from "@enbox/agent";
 import { describe, expect, it, vi } from "vitest";
 
-import { MESHD_PROTOCOL_URI } from "@/enbox/config";
+import { DEFAULT_DWN_ENDPOINT, MESHD_PROTOCOL_URI } from "@/enbox/config";
 
 import {
   buildMeshdInviteURL,
@@ -160,6 +160,23 @@ describe("meshd admin DWN operations", () => {
     ]);
   });
 
+  it("uses the beta DWN endpoint when the owner does not publish one", async () => {
+    const { session, requests } = createFakeSession({
+      endpoints: ["", "   "],
+      recordIds: ["network-record"]
+    });
+
+    const network = await createMeshdNetwork(session, {
+      name: "Home mesh",
+      meshCIDR: "10.200.0.0/16"
+    });
+
+    expect(network.anchorEndpoint).toBe(DEFAULT_DWN_ENDPOINT);
+    await expect(blobJson(requests[0].dataStream)).resolves.toMatchObject({
+      anchorEndpoint: DEFAULT_DWN_ENDPOINT
+    });
+  });
+
   it("normalizes and validates network CIDR before writing network records", async () => {
     const valid = createFakeSession({ recordIds: ["network-record"] });
 
@@ -286,6 +303,27 @@ describe("meshd admin DWN operations", () => {
       tokenId: "invite-record",
       secret: "secret-value",
       expiresAt: "2026-06-25T00:00:00Z"
+    });
+  });
+
+  it("rebuilds invite URLs with the beta endpoint when no network endpoint is stored", async () => {
+    const { session } = createFakeSession({ endpoints: [] });
+    const network: MeshdNetworkSummary = {
+      recordId: "network-record",
+      name: "Home mesh",
+      meshCIDR: "10.200.0.0/16"
+    };
+
+    const url = await buildMeshdInviteURL(session, network, {
+      recordId: "invite-record",
+      key: "secret-value",
+      usedBy: []
+    });
+
+    expect(decodeBase64UrlJson(url.slice("meshd://invite/".length))).toMatchObject({
+      endpoint: DEFAULT_DWN_ENDPOINT,
+      anchorDid: "did:example:owner",
+      networkId: "network-record"
     });
   });
 

--- a/admin-dapp/src/meshd/admin.ts
+++ b/admin-dapp/src/meshd/admin.ts
@@ -9,6 +9,7 @@ import { DidJwk } from "@enbox/dids";
 import { Message } from "@enbox/dwn-sdk-js";
 
 import {
+  DEFAULT_DWN_ENDPOINT,
   MESHD_KEY_DELIVERY_PROTOCOL_URI,
   MESHD_PROTOCOL_URI
 } from "@/enbox/config";
@@ -638,12 +639,17 @@ export async function fetchMeshdNetworkTopology(
 }
 
 async function ownerDefaultDwnEndpoint(session: MeshdAdminSession): Promise<string> {
-  const endpoints = await session.agent.dwn?.getDwnEndpointUrlsForTarget?.(session.ownerDid);
-  const endpoint = endpoints?.find((candidate) => candidate.trim() !== "");
-  if (!endpoint) {
-    throw new Error("The owner identity does not publish a DWN endpoint.");
+  let endpoints: string[] | undefined;
+  try {
+    endpoints = await session.agent.dwn?.getDwnEndpointUrlsForTarget?.(session.ownerDid);
+  } catch {
+    endpoints = undefined;
   }
-  return endpoint;
+  const endpoint = endpoints?.find((candidate) => candidate.trim() !== "") ?? DEFAULT_DWN_ENDPOINT;
+  if (!endpoint) {
+    throw new Error("No DWN endpoint is configured for this owner.");
+  }
+  return endpoint.trim().replace(/\/+$/, "");
 }
 
 export async function createMeshdNetwork(

--- a/docs/smoke-test-mac-linux.md
+++ b/docs/smoke-test-mac-linux.md
@@ -11,7 +11,8 @@ Assumptions:
   should not overlap Tailscale's `100.64.0.0/10` address space.
 - The beta DWN endpoint is `https://dev.aws.dwn.enbox.id`.
   `meshd up --owner` uses it automatically when the owner DID does not
-  advertise a DWN endpoint.
+  advertise a DWN endpoint. The dashboard uses the same default when creating
+  a network for that owner.
 - The released CLI is installed on both machines.
 - The standalone meshd Admin dapp is deployed at
   `https://meshd-admin.pages.dev`.


### PR DESCRIPTION
## Summary
- reuse the configured beta DWN endpoint as the admin dashboard fallback when an owner DID does not publish an endpoint
- let dashboard-created networks and rebuilt invite URLs stay compatible with the simplified `meshd up --owner <did>` CLI flow
- document that the dashboard and CLI share the same beta default endpoint behavior

## Verification
- npm test
- npm run build
- rg -n "enbox\.org" README.md docs cmd internal admin-dapp/src .github protocols
