### PR TITLE
feat(admin): copy owner setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Admin dapp; each machine keeps a local encrypted node DID.
 # Open the dashboard once as the owner so the wallet grants meshd Admin access.
 meshd admin --print
 
-# On a new device, request approval from that owner.
+# In the dashboard, copy the setup command from the target network.
+# On a new device, run it to request approval from that owner.
 meshd up --owner did:example:owner
 
 # Approve the pending device in the dashboard, then start it.

--- a/admin-dapp/src/App.tsx
+++ b/admin-dapp/src/App.tsx
@@ -11,6 +11,7 @@ import {
   SaveIcon,
   ServerIcon,
   ShieldCheckIcon,
+  TerminalIcon,
   Trash2Icon,
   UserPlusIcon,
   XIcon
@@ -23,6 +24,7 @@ import {
   ownerMatchesDashboardContext,
   type MeshdDashboardURLContext
 } from "./meshd/dashboard-url";
+import { ownerSetupCommand } from "./meshd/commands";
 import {
   approveMeshdNodeRequest,
   buildMeshdInviteURL,
@@ -342,6 +344,11 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
     await copyToClipboard(url);
   }
 
+  async function handleCopyOwnerSetupCommand() {
+    if (!did) return;
+    await copyToClipboard(ownerSetupCommand(did));
+  }
+
   async function handleRemoveNode(node: MeshdNodeSummary) {
     if (!session || !selectedNetwork) return;
     await runAction(`remove-${node.recordId}`, async () => {
@@ -439,6 +446,10 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
                 <p>{selectedNetwork.meshCIDR}</p>
               </div>
               <div className="header-buttons">
+                <button className="secondary-button" type="button" onClick={() => void handleCopyOwnerSetupCommand()}>
+                  <TerminalIcon size={16} />
+                  Copy Setup Command
+                </button>
                 <button className="secondary-button" type="button" onClick={() => void refreshTopology()}>
                   <RefreshCwIcon size={16} />
                   Refresh

--- a/admin-dapp/src/meshd/commands.test.ts
+++ b/admin-dapp/src/meshd/commands.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { ownerSetupCommand, shellQuote } from "./commands";
+
+describe("meshd admin command helpers", () => {
+  it("builds the owner setup command", () => {
+    expect(ownerSetupCommand("did:example:owner")).toBe("meshd up --owner 'did:example:owner'");
+  });
+
+  it("trims the owner DID before building commands", () => {
+    expect(ownerSetupCommand("  did:example:owner  ")).toBe("meshd up --owner 'did:example:owner'");
+  });
+
+  it("shell-quotes single quotes defensively", () => {
+    expect(shellQuote("did:example:o'wner")).toBe("'did:example:o'\\''wner'");
+  });
+
+  it("rejects empty owner DIDs", () => {
+    expect(() => ownerSetupCommand("   ")).toThrow("Owner DID is required.");
+  });
+});

--- a/admin-dapp/src/meshd/commands.ts
+++ b/admin-dapp/src/meshd/commands.ts
@@ -1,0 +1,11 @@
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+export function ownerSetupCommand(ownerDID: string): string {
+  const did = ownerDID.trim();
+  if (!did) {
+    throw new Error("Owner DID is required.");
+  }
+  return `meshd up --owner ${shellQuote(did)}`;
+}

--- a/docs/smoke-test-mac-linux.md
+++ b/docs/smoke-test-mac-linux.md
@@ -53,7 +53,7 @@ https://meshd-admin.pages.dev
 ```
 
 Connect the owner wallet and approve meshd Admin. Create a network if one does
-not already exist. Copy the owner DID from the wallet or dashboard header.
+not already exist. Click `Copy Setup Command` in the network header.
 
 If the deployed dashboard is unavailable, run the local fallback from a repo
 checkout:
@@ -67,7 +67,7 @@ meshd admin --dashboard http://127.0.0.1:5173 --print
 
 ## 2. Submit the Linux node request
 
-On the Linux server:
+On the Linux server, paste the setup command copied from the dashboard:
 
 ```bash
 meshd down || true


### PR DESCRIPTION
## Summary
- add a dashboard header action that copies `meshd up --owner '<owner DID>'` for the connected wallet
- add tested command formatting/shell quoting helpers
- update the README and Mac/Linux smoke test to use the copied setup command path

## Verification
- npm test
- npm run build
- rg -n "enbox\.org" README.md docs cmd internal admin-dapp/src .github protocols
