### PR TITLE
feat(cli): target admin dashboard by owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Admin dapp; each machine keeps a local encrypted node DID.
 
 ```bash
 # Open the dashboard once as the owner so the wallet grants meshd Admin access.
-meshd admin --print
+meshd admin
 
 # In the dashboard, copy the setup command from the target network.
 # On a new device, run it to request approval from that owner.
@@ -222,7 +222,10 @@ next command or admin action to try.
 Run `meshd admin` to open the standalone meshd Admin dapp for the active owner and
 network. From there you can create, copy, and revoke invite URLs, approve
 pending nodes, and remove devices without copying record IDs by hand. Use
-`meshd admin --print` on SSH servers when you only want the URL.
+`meshd admin --print` on SSH servers when you only want the URL. On a fresh
+machine or when approving a server from another device, target the owner
+explicitly with `meshd admin --owner <wallet-did>`; add `--network <record-id>`
+when you want the dashboard to preselect a specific network.
 
 For manual admin onboarding, use `meshd peer add <node-did> --owner
 <wallet-or-owner-did>` when the device DID and owning wallet/member DID are

--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -87,6 +87,12 @@ Up flags:
   --foreground      Run in the current terminal instead of background
   -v, --verbose     Enable debug logging
 
+Admin flags:
+  --owner <did>     Open the dashboard for a specific wallet/owner DID
+  --network <id>    Preselect a network record in the dashboard
+  --dashboard <url> Dashboard URL override
+  --print           Print the dashboard URL without opening a browser
+
 Quick start:
   meshd auth connect
   meshd up
@@ -775,8 +781,10 @@ func printWalletURL(rawURL string, autoOpen bool, remoteHandoff bool) {
 }
 
 type adminOptions struct {
-	dashboardURL string
-	printOnly    bool
+	dashboardURL    string
+	printOnly       bool
+	ownerDID        string
+	networkRecordID string
 }
 
 const defaultAdminDashboardURL = "https://meshd-admin.pages.dev"
@@ -790,6 +798,24 @@ func parseAdminArgs(args []string) (adminOptions, error) {
 				return opts, fmt.Errorf("%s requires a URL", args[i])
 			}
 			opts.dashboardURL = args[i+1]
+			i++
+		case "--owner":
+			if i+1 >= len(args) {
+				return opts, fmt.Errorf("--owner requires a DID")
+			}
+			opts.ownerDID = strings.TrimSpace(args[i+1])
+			if opts.ownerDID == "" {
+				return opts, fmt.Errorf("--owner requires a DID")
+			}
+			i++
+		case "--network":
+			if i+1 >= len(args) {
+				return opts, fmt.Errorf("--network requires a record ID")
+			}
+			opts.networkRecordID = strings.TrimSpace(args[i+1])
+			if opts.networkRecordID == "" {
+				return opts, fmt.Errorf("--network requires a record ID")
+			}
 			i++
 		case "--print", "--no-open":
 			opts.printOnly = true
@@ -807,7 +833,7 @@ func cmdAdmin(ctx context.Context, args []string, flagProfile string) error {
 	if err != nil {
 		return err
 	}
-	adminURL := buildAdminURL(opts.dashboardURL, adminContextFromProfile(flagProfile))
+	adminURL := buildAdminURL(opts.dashboardURL, adminContextFromOptions(opts, adminContextFromProfile(flagProfile)))
 	fmt.Printf("meshd admin:\n  %s\n", adminURL)
 	if opts.printOnly || !stdinIsTerminal() {
 		return nil
@@ -823,6 +849,17 @@ func cmdAdmin(ctx context.Context, args []string, flagProfile string) error {
 type adminContext struct {
 	OwnerDID        string
 	NetworkRecordID string
+}
+
+func adminContextFromOptions(opts adminOptions, fallback adminContext) adminContext {
+	ctx := fallback
+	if opts.ownerDID != "" {
+		ctx.OwnerDID = opts.ownerDID
+	}
+	if opts.networkRecordID != "" {
+		ctx.NetworkRecordID = opts.networkRecordID
+	}
+	return ctx
 }
 
 func adminContextFromProfile(flagProfile string) adminContext {
@@ -864,6 +901,24 @@ func buildAdminURL(walletURL string, ctx adminContext) string {
 		adminURL += "?" + encoded
 	}
 	return adminURL
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}
+
+func adminDashboardCommand(ctx adminContext, printOnly bool) string {
+	args := []string{"meshd", "admin"}
+	if ctx.OwnerDID != "" {
+		args = append(args, "--owner", shellQuote(ctx.OwnerDID))
+	}
+	if ctx.NetworkRecordID != "" {
+		args = append(args, "--network", shellQuote(ctx.NetworkRecordID))
+	}
+	if printOnly {
+		args = append(args, "--print")
+	}
+	return strings.Join(args, " ")
 }
 
 func startWalletResponseCallback() (*walletResponseCallback, error) {
@@ -4392,8 +4447,8 @@ func setupOwnerNodeRequest(ctx context.Context, f upFlags, stateDir string, iden
 		NodeKeyDelivery: nodeKeyDelivery,
 	})
 	if err != nil {
-		adminURL := buildAdminURL(defaultAdminDashboardURL, adminContext{OwnerDID: ownerDID})
-		return nil, fmt.Errorf("submitting owner approval request: %w\nOpen the dashboard once to initialize meshd for this owner: %s", err, adminURL)
+		ctx := adminContext{OwnerDID: ownerDID}
+		return nil, fmt.Errorf("submitting owner approval request: %w\nOpen the dashboard once to initialize meshd for this owner:\n  %s\n  %s", err, adminDashboardCommand(ctx, true), buildAdminURL(defaultAdminDashboardURL, ctx))
 	}
 
 	ns := &state.NetworkState{
@@ -4415,7 +4470,9 @@ func setupOwnerNodeRequest(ctx context.Context, f upFlags, stateDir string, iden
 	fmt.Printf("  Owner DWN: %s\n", endpoint)
 	fmt.Printf("  Node DID:  %s\n", identity.URI)
 	fmt.Printf("  Request:   %s\n", requestID)
-	fmt.Printf("  Dashboard: %s\n", buildAdminURL(defaultAdminDashboardURL, adminContext{OwnerDID: ownerDID}))
+	adminCtx := adminContext{OwnerDID: ownerDID}
+	fmt.Printf("  Dashboard: %s\n", buildAdminURL(defaultAdminDashboardURL, adminCtx))
+	fmt.Printf("  Admin command: %s\n", adminDashboardCommand(adminCtx, true))
 	fmt.Printf("\nApprove this device in the dashboard, then run 'meshd up' again.\n")
 	return ns, nil
 }
@@ -4520,7 +4577,9 @@ func printPendingOwnerApproval(ns *state.NetworkState) {
 	fmt.Printf("Node approval is still pending.\n")
 	if ownerDID != "" {
 		fmt.Printf("  Owner DID: %s\n", ownerDID)
-		fmt.Printf("  Dashboard: %s\n", buildAdminURL(defaultAdminDashboardURL, adminContext{OwnerDID: ownerDID}))
+		adminCtx := adminContext{OwnerDID: ownerDID, NetworkRecordID: ns.NetworkRecordID}
+		fmt.Printf("  Dashboard: %s\n", buildAdminURL(defaultAdminDashboardURL, adminCtx))
+		fmt.Printf("  Admin command: %s\n", adminDashboardCommand(adminCtx, true))
 	}
 	fmt.Printf("\nApprove this device in the dashboard, then run 'meshd up' again.\n")
 }

--- a/cmd/meshd/main_test.go
+++ b/cmd/meshd/main_test.go
@@ -249,18 +249,31 @@ func TestBuildAdminURL(t *testing.T) {
 	if got := buildAdminURL("", adminContext{}); got != "https://meshd-admin.pages.dev" {
 		t.Fatalf("default admin URL = %q", got)
 	}
+	if got := adminDashboardCommand(adminContext{OwnerDID: "did:example:own'er", NetworkRecordID: "network-1"}, true); got != "meshd admin --owner 'did:example:own'\\''er' --network 'network-1' --print" {
+		t.Fatalf("admin dashboard command = %q", got)
+	}
 }
 
 func TestParseAdminArgs(t *testing.T) {
-	opts, err := parseAdminArgs([]string{"--dashboard", "http://127.0.0.1:5173", "--print"})
+	opts, err := parseAdminArgs([]string{"--dashboard", "http://127.0.0.1:5173", "--owner", "did:example:owner", "--network", "network-1", "--print"})
 	if err != nil {
 		t.Fatalf("parseAdminArgs: %v", err)
 	}
-	if opts.dashboardURL != "http://127.0.0.1:5173" || !opts.printOnly {
+	if opts.dashboardURL != "http://127.0.0.1:5173" || opts.ownerDID != "did:example:owner" || opts.networkRecordID != "network-1" || !opts.printOnly {
 		t.Fatalf("admin opts = %+v", opts)
+	}
+	ctx := adminContextFromOptions(opts, adminContext{OwnerDID: "did:example:fallback", NetworkRecordID: "fallback-network"})
+	if ctx.OwnerDID != "did:example:owner" || ctx.NetworkRecordID != "network-1" {
+		t.Fatalf("admin context = %+v", ctx)
 	}
 	if _, err := parseAdminArgs([]string{"--wallet"}); err == nil {
 		t.Fatal("expected missing wallet URL to fail")
+	}
+	if _, err := parseAdminArgs([]string{"--owner"}); err == nil {
+		t.Fatal("expected missing owner DID to fail")
+	}
+	if _, err := parseAdminArgs([]string{"--network", "  "}); err == nil {
+		t.Fatal("expected blank network ID to fail")
 	}
 	if _, err := parseAdminArgs([]string{"--unknown"}); err == nil {
 		t.Fatal("expected unknown flag to fail")

--- a/docs/smoke-test-mac-linux.md
+++ b/docs/smoke-test-mac-linux.md
@@ -43,13 +43,26 @@ If your shell has not picked up the installer PATH update yet, run:
 Use the deployed dashboard:
 
 ```bash
+meshd admin
+```
+
+If you only want the URL, for example over SSH, use:
+
+```bash
 meshd admin --print
 ```
 
-Open the printed URL. It should use:
+The dashboard URL should use:
 
 ```text
 https://meshd-admin.pages.dev
+```
+
+If you are opening the dashboard from a machine without the owner profile,
+target the owner explicitly:
+
+```bash
+meshd admin --owner '<OWNER_DID>' --print
 ```
 
 Connect the owner wallet and approve meshd Admin. Create a network if one does


### PR DESCRIPTION
## Summary
- add `meshd admin --owner` and `--network` targeting for owner-wallet and network-specific dashboard URLs
- print paste-safe admin commands when node owner approval is pending or dashboard initialization is needed
- document local/open versus print/SSH admin dashboard usage

## Verification
- `go test -count=1 ./...`
- `npm test -- --run` in `admin-dapp`
- `npm run build` in `admin-dapp` (passes; existing local Node/Vite version warning only)
- `rg -n "enbox\.org" README.md docs cmd internal admin-dapp/src .github protocols` (no matches)
- runtime smoke: `ENBOX_HOME="$tmp" MESHD_STATE_DIR= go run ./cmd/meshd admin --owner did:example:owner --network network-1 --print`

## Deploy note
- admin dapp was manually deployed with authenticated Wrangler: `wrangler pages deploy dist --project-name=meshd-admin --branch=main`
- canonical page responded 200 at `https://meshd-admin.pages.dev`
