### PR TITLE
fix(admin): refresh node approval on expiry changes

### DIFF
--- a/admin-dapp/README.md
+++ b/admin-dapp/README.md
@@ -7,6 +7,11 @@ account. This dapp connects to that wallet, receives delegated DWN grants, and
 then manages networks, invites, pending node approvals, and removals on behalf
 of the owner.
 
+When a node membership expiry is renewed or cleared, the dashboard updates the
+encrypted node record and writes a fresh owner-scoped approval record for that
+node. This lets a CLI device recover with `meshd up` even if it was still
+pending, expired locally, or had stale approval metadata.
+
 Production dashboard:
 
 ```text

--- a/admin-dapp/src/meshd/admin.test.ts
+++ b/admin-dapp/src/meshd/admin.test.ts
@@ -327,12 +327,13 @@ describe("meshd admin DWN operations", () => {
     });
   });
 
-  it("updates node expiry while preserving the existing node payload", async () => {
-    const { session, requests } = createFakeSession({ delegate: true, recordIds: ["node-record"] });
+  it("updates node expiry while preserving the existing node payload and refreshing node approval", async () => {
+    const { session, requests } = createFakeSession({ delegate: true, recordIds: ["node-record", "approval-record"] });
     const network: MeshdNetworkSummary = {
       recordId: "network-record",
       name: "Home mesh",
-      meshCIDR: "10.200.0.0/16"
+      meshCIDR: "10.200.0.0/16",
+      anchorEndpoint: "https://owner.dwn.example"
     };
 
     const node = await updateMeshdNodeExpiry(session, network, {
@@ -394,10 +395,35 @@ describe("meshd admin DWN operations", () => {
         }
       }
     });
+    expect(requests[1]).toMatchObject({
+      messageType: DwnInterface.RecordsWrite,
+      messageParams: {
+        protocol: MESHD_PROTOCOL_URI,
+        protocolPath: "nodeApproval",
+        schema: "https://enbox.id/schemas/wireguard-mesh/node-approval",
+        dataFormat: "application/json",
+        recipient: "did:example:node"
+      }
+    });
+    await expect(blobJson(requests[1].dataStream)).resolves.toMatchObject({
+      ownerDID: "did:example:owner",
+      nodeDID: "did:example:node",
+      networkRecordId: "network-record",
+      networkName: "Home mesh",
+      meshCIDR: "10.200.0.0/16",
+      meshIP: "10.200.0.10",
+      anchorEndpoint: "https://owner.dwn.example",
+      memberRecordId: "member-record",
+      nodeRecordId: "node-record",
+      nodeDateCreated: "2026-06-24T00:00:00Z",
+      label: "server",
+      expiresAt: "2026-07-01T00:00:00Z",
+      approvedAt: expect.any(String)
+    });
   });
 
-  it("clears node expiry when renewing to never", async () => {
-    const { session, requests } = createFakeSession({ recordIds: ["node-record"] });
+  it("clears node expiry when renewing to never and refreshes node approval without expiry", async () => {
+    const { session, requests } = createFakeSession({ recordIds: ["node-record", "approval-record"] });
     const network: MeshdNetworkSummary = {
       recordId: "network-record",
       name: "Home mesh",
@@ -422,6 +448,18 @@ describe("meshd admin DWN operations", () => {
       }
     });
     await expect(blobJson(requests[0].dataStream)).resolves.not.toHaveProperty("expiresAt");
+    await expect(blobJson(requests[1].dataStream)).resolves.toMatchObject({
+      ownerDID: "did:example:owner",
+      nodeDID: "did:example:node",
+      networkRecordId: "network-record",
+      networkName: "Home mesh",
+      meshCIDR: "10.200.0.0/16",
+      meshIP: "10.200.0.10",
+      nodeRecordId: "node-record",
+      nodeDateCreated: "2026-06-24T00:00:00Z",
+      approvedAt: expect.any(String)
+    });
+    await expect(blobJson(requests[1].dataStream)).resolves.not.toHaveProperty("expiresAt");
   });
 
   it("updates node label while preserving expiry and membership metadata", async () => {

--- a/admin-dapp/src/meshd/admin.ts
+++ b/admin-dapp/src/meshd/admin.ts
@@ -1272,7 +1272,9 @@ export async function updateMeshdNodeExpiry(
   expiresAt?: string
 ): Promise<MeshdNodeSummary> {
   const nextExpiresAt = expiresAt?.trim();
-  return writeUpdatedMeshdNode(session, network, node, { expiresAt: nextExpiresAt });
+  const nextNode = await writeUpdatedMeshdNode(session, network, node, { expiresAt: nextExpiresAt });
+  await writeNodeApprovalRefresh(session, network, nextNode);
+  return nextNode;
 }
 
 export async function updateMeshdNodeLabel(
@@ -1346,6 +1348,43 @@ async function writeUpdatedMeshdNode(
     }
   }
   return nextNode;
+}
+
+async function writeNodeApprovalRefresh(
+  session: MeshdAdminSession,
+  network: MeshdNetworkSummary,
+  node: MeshdNodeSummary
+): Promise<void> {
+  if (!node.meshIP) {
+    throw new Error("Cannot refresh node approval without a mesh IP.");
+  }
+
+  await writeRecord(
+    session,
+    MESHD_PROTOCOL_URI,
+    {
+      protocol: MESHD_PROTOCOL_URI,
+      protocolPath: "nodeApproval",
+      schema: "https://enbox.id/schemas/wireguard-mesh/node-approval",
+      dataFormat: "application/json",
+      recipient: node.did
+    },
+    {
+      ownerDID: session.ownerDid,
+      nodeDID: node.did,
+      networkRecordId: network.recordId,
+      networkName: network.name,
+      meshCIDR: network.meshCIDR,
+      meshIP: node.meshIP,
+      ...(network.anchorEndpoint ? { anchorEndpoint: network.anchorEndpoint } : {}),
+      ...(node.memberRecordId ? { memberRecordId: node.memberRecordId } : {}),
+      nodeRecordId: node.recordId,
+      ...(node.createdAt ? { nodeDateCreated: node.createdAt } : {}),
+      ...(node.label ? { label: node.label } : {}),
+      ...(node.expiresAt ? { expiresAt: node.expiresAt } : {}),
+      approvedAt: new Date().toISOString()
+    }
+  );
 }
 
 function getRecordIdFromEntry(rawEntry: unknown): string | undefined {


### PR DESCRIPTION
## Summary
- refresh owner-scoped node approval records after node expiry changes
- preserve CLI recovery when a node was pending, expired locally, or has stale approval metadata
- document the expiry-renewal recovery behavior in the admin dapp README

## Verification
- `npm test -- --run` in `admin-dapp`
- `npm run build` in `admin-dapp` (passes; existing local Node/Vite version warning only)
- `go test -count=1 ./...`
- `rg -n "enbox\.org" README.md docs cmd internal admin-dapp/src admin-dapp/README.md .github protocols` (no matches)
- Cloudflare Pages deploy: `wrangler pages deploy dist --project-name=meshd-admin --branch=main`
- `curl -I https://meshd-admin.pages.dev` returned 200
