### PR TITLE
feat(cli): accept pasted owner DID or invite in up wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,16 @@ meshd --version
 
 ```bash
 # On your first machine
-meshd up --create my-network --endpoint https://dwn.example.com
-# prompts once to create a local vault password, creates the network, then starts meshd
+meshd up
+# choose "Create a new local-vault network", then enter the DWN endpoint and network name
 
 # In another terminal on the first machine, create an invite URL
 meshd invite create
 # prints: meshd://invite/eyJ...
 
 # On your second machine, join from the invite
-meshd join meshd://invite/eyJ...
-# prompts once to create a local vault password and submits a join request
-
-# Start meshd on the second machine
 meshd up
+# paste the meshd://invite/... URL at the setup prompt
 
 # That's it. After the anchor approves the invite, the machines can reach each other at 10.200.x.x
 # through encrypted WireGuard tunnels. NAT traversal is automatic.
@@ -56,6 +53,9 @@ meshd admin
 # In the dashboard, copy the setup command from the target network.
 # On a new device, run it to request approval from that owner.
 meshd up --owner did:example:owner
+
+# Or run the wizard and paste the owner DID at the setup prompt.
+meshd up
 
 # Approve the pending device in the dashboard, then start it.
 meshd up
@@ -160,6 +160,9 @@ an interactive terminal and meshd will prompt for the missing values.
 `meshd up` also acts as the first-run wizard: it can create a local node DID,
 request access from a wallet owner DID, create a local-vault network, or join
 with an invite URL.
+At the first setup prompt you can press Enter for owner approval, paste a
+wallet owner DID, paste a `meshd://invite/...` URL, or choose create/join
+manually.
 The join path asks for a `meshd://invite/...` URL first and only falls back to
 manual DWN endpoint, anchor DID, and network ID prompts if you leave it blank.
 For wallet-connected profiles, creating a network opens the wallet approval

--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -94,11 +94,9 @@ Admin flags:
   --print           Print the dashboard URL without opening a browser
 
 Quick start:
-  meshd auth connect
   meshd up
-  meshd up --create my-network --endpoint https://dwn.example.com
   meshd invite create
-  meshd join meshd://invite/<token>
+  meshd up meshd://invite/<token>
 
 Global flags:
   --profile <name>  Use a specific identity profile
@@ -4630,30 +4628,70 @@ func refreshPendingJoin(ctx context.Context, stateDir string, ns *state.NetworkS
 func setupInteractive(ctx context.Context, f upFlags, stateDir string, identity *did.DID, flagProfile string) (*state.NetworkState, error) {
 	fmt.Println("No network configured. What would you like to do?")
 	fmt.Println()
+	fmt.Println("  Paste an owner DID or invite URL, or choose:")
+	fmt.Println()
 	fmt.Println("  1) Request access from an owner DID")
 	fmt.Println("  2) Create a new local-vault network")
 	fmt.Println("  3) Join with an invite URL")
 	fmt.Println()
-	fmt.Print("Choice [1/2/3]: ")
+	fmt.Print("Setup [owner DID/invite URL/1/2/3, default 1]: ")
 
 	scanner := bufio.NewScanner(os.Stdin)
 	if !scanner.Scan() {
 		return nil, fmt.Errorf("no input received")
 	}
-	choice := strings.TrimSpace(scanner.Text())
+	choice, pastedValue, err := parseInteractiveSetupChoice(scanner.Text())
+	if err != nil {
+		return nil, err
+	}
 
 	fmt.Println()
 
 	switch choice {
-	case "1":
+	case interactiveSetupOwner:
+		if pastedValue != "" {
+			f.ownerDID = pastedValue
+		}
 		return setupOwnerNodeRequest(ctx, f, stateDir, identity, scanner)
-	case "2":
+	case interactiveSetupCreate:
 		return interactiveCreate(ctx, f, stateDir, identity, flagProfile, scanner)
-	case "3":
+	case interactiveSetupJoin:
+		if pastedValue != "" {
+			f.inviteURL = pastedValue
+			return setupJoinInvite(ctx, f, stateDir, identity, flagProfile)
+		}
 		return interactiveJoin(ctx, f, stateDir, identity, flagProfile, scanner)
 	default:
-		return nil, fmt.Errorf("invalid choice %q (expected 1, 2, or 3)", choice)
+		return nil, fmt.Errorf("invalid setup choice %q", choice)
 	}
+}
+
+type interactiveSetupChoice string
+
+const (
+	interactiveSetupOwner  interactiveSetupChoice = "owner"
+	interactiveSetupCreate interactiveSetupChoice = "create"
+	interactiveSetupJoin   interactiveSetupChoice = "join"
+)
+
+func parseInteractiveSetupChoice(input string) (interactiveSetupChoice, string, error) {
+	value := strings.TrimSpace(input)
+	lower := strings.ToLower(value)
+	switch lower {
+	case "", "1", "owner", "request", "access":
+		return interactiveSetupOwner, "", nil
+	case "2", "create", "new":
+		return interactiveSetupCreate, "", nil
+	case "3", "join", "invite":
+		return interactiveSetupJoin, "", nil
+	}
+	if strings.HasPrefix(value, invite.SchemePrefix) {
+		return interactiveSetupJoin, value, nil
+	}
+	if strings.HasPrefix(lower, "did:") {
+		return interactiveSetupOwner, value, nil
+	}
+	return "", "", fmt.Errorf("invalid choice %q (paste an owner DID, paste a meshd://invite URL, or choose 1, 2, or 3)", value)
 }
 
 func stdinIsTerminal() bool {

--- a/cmd/meshd/main_test.go
+++ b/cmd/meshd/main_test.go
@@ -82,6 +82,45 @@ func TestPromptInteractiveJoinFallsBackToManualDetails(t *testing.T) {
 	}
 }
 
+func TestParseInteractiveSetupChoice(t *testing.T) {
+	u, err := invite.Encode(invite.New("https://dwn.example.com", "did:jwk:anchor", "net", "home", "", "", ""))
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		input     string
+		want      interactiveSetupChoice
+		wantValue string
+	}{
+		{name: "default", input: "", want: interactiveSetupOwner},
+		{name: "owner number", input: "1", want: interactiveSetupOwner},
+		{name: "owner word", input: "owner", want: interactiveSetupOwner},
+		{name: "owner DID", input: " did:jwk:owner ", want: interactiveSetupOwner, wantValue: "did:jwk:owner"},
+		{name: "create number", input: "2", want: interactiveSetupCreate},
+		{name: "create word", input: "create", want: interactiveSetupCreate},
+		{name: "join number", input: "3", want: interactiveSetupJoin},
+		{name: "join word", input: "invite", want: interactiveSetupJoin},
+		{name: "invite URL", input: u, want: interactiveSetupJoin, wantValue: u},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, value, err := parseInteractiveSetupChoice(tt.input)
+			if err != nil {
+				t.Fatalf("parseInteractiveSetupChoice: %v", err)
+			}
+			if got != tt.want || value != tt.wantValue {
+				t.Fatalf("choice = %q value = %q, want %q/%q", got, value, tt.want, tt.wantValue)
+			}
+		})
+	}
+
+	if _, _, err := parseInteractiveSetupChoice("wat"); err == nil {
+		t.Fatal("expected invalid setup choice to fail")
+	}
+}
+
 func TestDefaultTUNName(t *testing.T) {
 	if got := defaultTUNName("darwin"); got != "utun" {
 		t.Fatalf("defaultTUNName(darwin) = %q, want utun", got)

--- a/docs/smoke-test-mac-linux.md
+++ b/docs/smoke-test-mac-linux.md
@@ -87,6 +87,9 @@ meshd down || true
 meshd up --owner '<OWNER_DID>'
 ```
 
+You can also run `meshd up` without flags and paste the owner DID at the setup
+prompt.
+
 Expected result:
 
 - If the node has no local identity, meshd creates one and asks for a vault
@@ -174,6 +177,9 @@ meshd up
 meshd status
 meshd peer list
 ```
+
+You can also run `meshd up` without flags and paste the `meshd://invite/...`
+URL at the setup prompt.
 
 If the invite request appears pending in the dashboard, approve it and run
 `meshd up` again on the joining node.


### PR DESCRIPTION
## Summary
- make the flagless `meshd up` wizard accept pasted owner DIDs and `meshd://invite/...` URLs at the first prompt
- default Enter to the owner-approval path, while keeping numbered create/join choices
- update README and Mac/Linux smoke docs to recommend the wizard-first flow

## Verification
- `go test -count=1 ./cmd/meshd`
- `go test -count=1 ./...`
- `npm test -- --run` in `admin-dapp`
- `npm run build` in `admin-dapp` (passes; existing local Node/Vite warning only)
- `go run ./cmd/meshd --help`
- `rg -n "enbox\.org" README.md docs cmd internal admin-dapp/src admin-dapp/README.md .github protocols` (no matches)
