### PR TITLE
feat(cli): accept owner DID as up argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ meshd admin
 
 # In the dashboard, copy the setup command from the target network.
 # On a new device, run it to request approval from that owner.
-meshd up --owner did:example:owner
+meshd up did:example:owner
 
 # Or run the wizard and paste the owner DID at the setup prompt.
 meshd up
@@ -177,7 +177,7 @@ simplest no-wallet path and is what `meshd auth login` creates today.
 
 **Wallet-owned node.** The wallet DID is the mesh member/owner DID, while each
 machine keeps its own local node DID. The default beta path is dashboard-owned:
-`meshd up --owner <did>` writes a signed node request to the owner's DWN, and
+`meshd up <owner-did>` writes a signed node request to the owner's DWN, and
 the meshd Admin dapp approves that node into a selected network. A separate
 delegate DID can still be used for wallet-issued grants, but it is not required
 for the normal enrollment path.

--- a/admin-dapp/src/meshd/commands.test.ts
+++ b/admin-dapp/src/meshd/commands.test.ts
@@ -4,11 +4,11 @@ import { ownerSetupCommand, shellQuote } from "./commands";
 
 describe("meshd admin command helpers", () => {
   it("builds the owner setup command", () => {
-    expect(ownerSetupCommand("did:example:owner")).toBe("meshd up --owner 'did:example:owner'");
+    expect(ownerSetupCommand("did:example:owner")).toBe("meshd up 'did:example:owner'");
   });
 
   it("trims the owner DID before building commands", () => {
-    expect(ownerSetupCommand("  did:example:owner  ")).toBe("meshd up --owner 'did:example:owner'");
+    expect(ownerSetupCommand("  did:example:owner  ")).toBe("meshd up 'did:example:owner'");
   });
 
   it("shell-quotes single quotes defensively", () => {

--- a/admin-dapp/src/meshd/commands.ts
+++ b/admin-dapp/src/meshd/commands.ts
@@ -7,5 +7,5 @@ export function ownerSetupCommand(ownerDID: string): string {
   if (!did) {
     throw new Error("Owner DID is required.");
   }
-  return `meshd up --owner ${shellQuote(did)}`;
+  return `meshd up ${shellQuote(did)}`;
 }

--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -75,6 +75,8 @@ Network:
   down              Stop the mesh agent daemon
 
 Up flags:
+  meshd up <owner-did>        Request access from a wallet owner DID
+  meshd up <meshd://invite>   Join from an invite URL
   --create <name>   Create a new network and start (anchor mode)
   --endpoint <url>  DWN endpoint override for create/join/owner requests
   --anchor <did>    Anchor DID when joining a network
@@ -3596,8 +3598,14 @@ func parseUpFlags(args []string) upFlags {
 		case "-v", "--verbose":
 			f.verbose = true
 		default:
-			if !strings.HasPrefix(args[i], "-") && strings.HasPrefix(strings.TrimSpace(args[i]), invite.SchemePrefix) {
-				f.inviteURL = args[i]
+			value := strings.TrimSpace(args[i])
+			if strings.HasPrefix(value, "-") {
+				continue
+			}
+			if strings.HasPrefix(value, invite.SchemePrefix) && f.inviteURL == "" {
+				f.inviteURL = value
+			} else if strings.HasPrefix(strings.ToLower(value), "did:") && f.ownerDID == "" {
+				f.ownerDID = value
 			}
 		}
 	}

--- a/cmd/meshd/main_test.go
+++ b/cmd/meshd/main_test.go
@@ -50,6 +50,24 @@ func TestParseUpFlagsInviteURL(t *testing.T) {
 	}
 }
 
+func TestParseUpFlagsPositionalOwnerDID(t *testing.T) {
+	flags := parseUpFlags([]string{"did:example:owner", "--no-tun"})
+	if flags.ownerDID != "did:example:owner" {
+		t.Fatalf("ownerDID = %q", flags.ownerDID)
+	}
+	if flags.inviteURL != "" {
+		t.Fatalf("inviteURL = %q, want empty", flags.inviteURL)
+	}
+	if !flags.noTun {
+		t.Fatal("expected --no-tun to be parsed")
+	}
+
+	overridden := parseUpFlags([]string{"did:example:pasted", "--owner", "did:example:explicit"})
+	if overridden.ownerDID != "did:example:explicit" {
+		t.Fatalf("explicit owner should win, got %q", overridden.ownerDID)
+	}
+}
+
 func TestPromptInteractiveJoinAcceptsInviteFirst(t *testing.T) {
 	u, err := invite.Encode(invite.New("https://dwn.example.com", "did:jwk:anchor", "net", "home", "", "", ""))
 	if err != nil {

--- a/docs/smoke-test-mac-linux.md
+++ b/docs/smoke-test-mac-linux.md
@@ -10,7 +10,7 @@ Assumptions:
 - Both machines may already run Tailscale. meshd uses `10.200.0.0/16`, so it
   should not overlap Tailscale's `100.64.0.0/10` address space.
 - The beta DWN endpoint is `https://dev.aws.dwn.enbox.id`.
-  `meshd up --owner` uses it automatically when the owner DID does not
+  `meshd up <owner-did>` uses it automatically when the owner DID does not
   advertise a DWN endpoint. The dashboard uses the same default when creating
   a network for that owner.
 - The released CLI is installed on both machines.
@@ -84,11 +84,11 @@ On the Linux server, paste the setup command copied from the dashboard:
 
 ```bash
 meshd down || true
-meshd up --owner '<OWNER_DID>'
+meshd up '<OWNER_DID>'
 ```
 
-You can also run `meshd up` without flags and paste the owner DID at the setup
-prompt.
+The older `meshd up --owner '<OWNER_DID>'` form still works. You can also run
+`meshd up` without arguments and paste the owner DID at the setup prompt.
 
 Expected result:
 


### PR DESCRIPTION
## Summary
- allow `meshd up <owner-did>` as the short dashboard-owned enrollment command
- keep `meshd up --owner <did>` compatible and explicitly tested
- update the admin dashboard copy command and smoke-test docs to use the shorter form
- deployed the updated admin dapp with Cloudflare Pages CLI

## Verification
- `go test -count=1 ./cmd/meshd`
- `go test -count=1 ./...`
- `npm test -- --run` in `admin-dapp`
- `npm run build` in `admin-dapp`
- `rg -n "enbox\.org" README.md docs cmd internal admin-dapp/src admin-dapp/README.md .github protocols` returned no matches
- `go run ./cmd/meshd --help | sed -n "/Up flags:/,/Admin flags:/p"`
- `wrangler pages deploy dist --project-name=meshd-admin --branch=main` -> https://2a6f4e50.meshd-admin.pages.dev
- `curl -I https://meshd-admin.pages.dev` -> HTTP 200