### PR TITLE
feat(cli): show dashboard node labels in status

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ pending nodes, and remove devices without copying record IDs by hand. Use
 machine or when approving a server from another device, target the owner
 explicitly with `meshd admin --owner <wallet-did>`; add `--network <record-id>`
 when you want the dashboard to preselect a specific network.
+Dashboard node label edits refresh into local CLI state on the next `meshd up`
+or `meshd peer list`, and `meshd status` prints the current `Node Label`.
 
 For manual admin onboarding, use `meshd peer add <node-did> --owner
 <wallet-or-owner-did>` when the device DID and owning wallet/member DID are

--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -2210,6 +2210,12 @@ func refreshLocalMembershipMetadataFromMap(stateDir string, ns *state.NetworkSta
 		changed = true
 	}
 
+	nodeLabel := strings.TrimSpace(resp.Node.Name)
+	if refreshed.NodeLabel != nodeLabel {
+		refreshed.NodeLabel = nodeLabel
+		changed = true
+	}
+
 	if resp.Node.MemberDID != "" && refreshed.OwnerDID != resp.Node.MemberDID {
 		refreshed.OwnerDID = resp.Node.MemberDID
 		refreshed.MemberDID = resp.Node.MemberDID
@@ -2969,6 +2975,9 @@ func cmdStatus(ctx context.Context, args []string, flagProfile string) error {
 	}
 	if ns.MeshIP != "" {
 		fmt.Printf("  Mesh IP: %s\n", ns.MeshIP)
+	}
+	if ns.NodeLabel != "" {
+		fmt.Printf("  Node Label: %s\n", ns.NodeLabel)
 	}
 	if ns.NodeExpiresAt != "" {
 		fmt.Printf("  Membership Expires: %s\n", ns.NodeExpiresAt)
@@ -4552,6 +4561,7 @@ func refreshPendingOwnerApproval(ctx context.Context, stateDir string, ns *state
 		MeshCIDR:          firstNonEmpty(approval.MeshCIDR, "10.200.0.0/16"),
 		MeshIP:            approval.MeshIP,
 		NodeExpiresAt:     approval.ExpiresAt,
+		NodeLabel:         approval.Label,
 		NodeDID:           nodeDID,
 		OwnerDID:          ownerDID,
 		MemberDID:         ownerDID,
@@ -4566,6 +4576,9 @@ func refreshPendingOwnerApproval(ctx context.Context, stateDir string, ns *state
 	fmt.Printf("Owner approval accepted.\n")
 	fmt.Printf("  Network: %s\n", refreshed.NetworkName)
 	fmt.Printf("  Mesh IP: %s\n", refreshed.MeshIP)
+	if refreshed.NodeLabel != "" {
+		fmt.Printf("  Node Label: %s\n", refreshed.NodeLabel)
+	}
 	if refreshed.NodeExpiresAt != "" {
 		fmt.Printf("  Membership Expires: %s\n", refreshed.NodeExpiresAt)
 	}

--- a/cmd/meshd/main_test.go
+++ b/cmd/meshd/main_test.go
@@ -402,6 +402,7 @@ func TestRefreshLocalMembershipMetadataFromMap(t *testing.T) {
 		MeshCIDR:        "10.200.0.0/16",
 		MeshIP:          "10.200.0.5",
 		NodeExpiresAt:   "2026-07-01T00:00:00Z",
+		NodeLabel:       "old-label",
 		NodeDID:         "did:jwk:node",
 		OwnerDID:        "did:jwk:old-owner",
 		MemberDID:       "did:jwk:old-owner",
@@ -415,6 +416,7 @@ func TestRefreshLocalMembershipMetadataFromMap(t *testing.T) {
 	refreshed, changed, err := refreshLocalMembershipMetadataFromMap(dir, ns, &control.MapResponse{
 		Node: &control.Node{
 			DID:            "did:jwk:node",
+			Name:           "server-01",
 			MeshIP:         netip.MustParseAddr("10.200.0.9"),
 			MemberDID:      "did:jwk:wallet",
 			MemberRecordID: "member-2",
@@ -426,7 +428,7 @@ func TestRefreshLocalMembershipMetadataFromMap(t *testing.T) {
 	if !changed {
 		t.Fatal("refreshLocalMembershipMetadataFromMap changed = false, want true")
 	}
-	if refreshed.MeshIP != "10.200.0.9" || refreshed.NodeExpiresAt != "" || refreshed.OwnerDID != "did:jwk:wallet" || refreshed.MemberRecordID != "member-2" {
+	if refreshed.MeshIP != "10.200.0.9" || refreshed.NodeExpiresAt != "" || refreshed.NodeLabel != "server-01" || refreshed.OwnerDID != "did:jwk:wallet" || refreshed.MemberRecordID != "member-2" {
 		t.Fatalf("refreshed state = %+v", refreshed)
 	}
 
@@ -434,7 +436,7 @@ func TestRefreshLocalMembershipMetadataFromMap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadNetworkState: %v", err)
 	}
-	if reloaded.MeshIP != "10.200.0.9" || reloaded.NodeExpiresAt != "" || reloaded.OwnerDID != "did:jwk:wallet" || reloaded.MemberDID != "did:jwk:wallet" || reloaded.MemberRecordID != "member-2" {
+	if reloaded.MeshIP != "10.200.0.9" || reloaded.NodeExpiresAt != "" || reloaded.NodeLabel != "server-01" || reloaded.OwnerDID != "did:jwk:wallet" || reloaded.MemberDID != "did:jwk:wallet" || reloaded.MemberRecordID != "member-2" {
 		t.Fatalf("persisted state = %+v", reloaded)
 	}
 }

--- a/docs/smoke-test-mac-linux.md
+++ b/docs/smoke-test-mac-linux.md
@@ -134,6 +134,8 @@ Expected result:
 - If an approval expiry was selected, the joining node's `meshd status` shows
   `Membership Expires`.
 - Both machines show the same network name.
+- The joining node's `meshd status` shows `Node Label` after approval if the
+  dashboard assigned or edited one.
 - `meshd peer list` shows both peers with `10.200.x.x` mesh IPs and an
   `EXPIRES` column. Non-expiring nodes show `never`.
 
@@ -141,6 +143,7 @@ If you renew a node or switch it to `Never` in the dashboard, run `meshd up` or
 `meshd peer list` on that node. Both commands refresh the local membership
 metadata from the DWN map, so `meshd status` should then show the updated
 `Membership Expires` value or omit it for non-expiring membership.
+The same refresh updates the local `Node Label` after dashboard label edits.
 
 ## 5. Ping both directions
 

--- a/internal/control/control_test.go
+++ b/internal/control/control_test.go
@@ -354,6 +354,26 @@ func TestNodeRecordToNode(t *testing.T) {
 	})
 }
 
+func TestNodeRecordToNodePrefersOwnerLabelOverHostname(t *testing.T) {
+	didURI, _ := testDIDJWK(t)
+	rec := &NodeRecord{
+		MeshIP: "10.200.0.5",
+		Label:  "server-01",
+		Info: &NodeInfoData{
+			Hostname: "old-hostname",
+			OS:       "linux",
+		},
+	}
+
+	node := nodeRecordToNodeWithThreshold(42, didURI, rec, DefaultPeerStaleThreshold, time.Now().UTC())
+	if node.Name != "server-01" {
+		t.Fatalf("Name = %q, want owner label", node.Name)
+	}
+	if node.OS != "linux" {
+		t.Fatalf("OS = %q, want nodeInfo OS preserved", node.OS)
+	}
+}
+
 func TestNodeOnlineStatus(t *testing.T) {
 	now := time.Date(2026, 2, 25, 12, 0, 0, 0, time.UTC)
 	threshold := 5 * time.Minute

--- a/internal/control/dwnclient.go
+++ b/internal/control/dwnclient.go
@@ -774,16 +774,17 @@ func nodeRecordToNodeWithThreshold(id int64, nodeDID string, rec *NodeRecord, st
 		KeyDelivery:    rec.NodeKeyDelivery,
 	}
 
-	// Populate operational fields from the nodeInfo child record if available.
-	if rec.Info != nil {
-		node.Name = rec.Info.Hostname
-		node.OS = rec.Info.OS
-		node.Capabilities = rec.Info.Capabilities
+	if rec.Label != "" {
+		node.Name = rec.Label
 	}
 
-	// Fall back to node label if no hostname from nodeInfo.
-	if node.Name == "" && rec.Label != "" {
-		node.Name = rec.Label
+	// Populate operational fields from the nodeInfo child record if available.
+	if rec.Info != nil {
+		if node.Name == "" {
+			node.Name = rec.Info.Hostname
+		}
+		node.OS = rec.Info.OS
+		node.Capabilities = rec.Info.Capabilities
 	}
 
 	// Derive WireGuard public key from did:jwk.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -69,6 +69,9 @@ type NetworkState struct {
 	// Empty means the membership does not expire.
 	NodeExpiresAt string `json:"nodeExpiresAt,omitempty"`
 
+	// NodeLabel is the human-readable owner/dashboard label for this node.
+	NodeLabel string `json:"nodeLabel,omitempty"`
+
 	// NodeDID is this machine's device DID. It is the DID used for WireGuard
 	// key derivation, node records, endpoint writes, and "this device" UI.
 	// Older state files omit it; callers should fall back to the local profile

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -15,6 +15,7 @@ func TestNetworkStateOwnerDIDCompatibility(t *testing.T) {
 			OwnerDID:        "did:dht:wallet",
 			NodeDID:         "did:jwk:node",
 			NodeExpiresAt:   "2026-07-01T00:00:00Z",
+			NodeLabel:       "server-01",
 		}); err != nil {
 			t.Fatalf("SaveNetworkState: %v", err)
 		}
@@ -32,6 +33,9 @@ func TestNetworkStateOwnerDIDCompatibility(t *testing.T) {
 		}
 		if raw["nodeExpiresAt"] != "2026-07-01T00:00:00Z" {
 			t.Fatalf("raw nodeExpiresAt = %v", raw["nodeExpiresAt"])
+		}
+		if raw["nodeLabel"] != "server-01" {
+			t.Fatalf("raw nodeLabel = %v", raw["nodeLabel"])
 		}
 	})
 


### PR DESCRIPTION
## Summary
- persist the local node label in network state after owner approval and DWN map refreshes
- print `Node Label` in `meshd status`
- prefer owner/dashboard labels over device hostnames for control-map display names
- document label refresh behavior in the smoke test and README

## Verification
- `go test -count=1 ./internal/state ./internal/control ./cmd/meshd`
- `go test -count=1 ./...`
- `rg -n "enbox\.org" README.md docs cmd internal admin-dapp/src admin-dapp/README.md .github protocols` returned no matches
- `go run ./cmd/meshd --help | sed -n "/Network:/,/Up flags:/p"`