### PR TITLE
fix(control): keep hostnames distinct from node labels

### DIFF
--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -2210,7 +2210,7 @@ func refreshLocalMembershipMetadataFromMap(stateDir string, ns *state.NetworkSta
 		changed = true
 	}
 
-	nodeLabel := strings.TrimSpace(resp.Node.Name)
+	nodeLabel := strings.TrimSpace(resp.Node.Label)
 	if refreshed.NodeLabel != nodeLabel {
 		refreshed.NodeLabel = nodeLabel
 		changed = true
@@ -2269,7 +2269,7 @@ func peerListRowsFromMapResponse(ns *state.NetworkState, resp *control.MapRespon
 			MeshIP:  peerListMeshIP(ns.MeshCIDR, node.DID, meshIP),
 			Device:  peerListDevice(node.DID, selfNodeDID),
 			Owner:   peerListOwner(node.DID, node.MemberDID, selfNodeDID, selfOwnerDID),
-			Label:   node.Name,
+			Label:   firstNonEmpty(node.Label, node.Name),
 			Expires: node.ExpiresAt,
 			Path:    peerListPath(node),
 		})

--- a/cmd/meshd/main_test.go
+++ b/cmd/meshd/main_test.go
@@ -361,6 +361,7 @@ func TestPeerListRowsFromMapResponse(t *testing.T) {
 			DID:       "did:jwk:self",
 			MemberDID: "did:jwk:wallet",
 			Name:      "laptop",
+			Label:     "macbook",
 			MeshIP:    netip.MustParseAddr("10.200.0.5"),
 			ExpiresAt: "2026-07-01T00:00:00Z",
 		},
@@ -370,6 +371,7 @@ func TestPeerListRowsFromMapResponse(t *testing.T) {
 				MemberDID:      "did:jwk:wallet",
 				MemberRecordID: "member-record",
 				Name:           "server",
+				Label:          "server-label",
 				MeshIP:         netip.MustParseAddr("10.200.0.8"),
 				ExpiresAt:      "2026-07-02T00:00:00Z",
 			},
@@ -386,8 +388,8 @@ func TestPeerListRowsFromMapResponse(t *testing.T) {
 	if rows[1].Device != "peer" || rows[1].Owner != "did:jwk:wallet" || rows[1].Path != "network/member/node" {
 		t.Fatalf("peer row = %+v", rows[1])
 	}
-	if rows[1].MeshIP != "10.200.0.8" || rows[1].Label != "server" {
-		t.Fatalf("peer row data = %+v", rows[1])
+	if rows[0].Label != "macbook" || rows[1].MeshIP != "10.200.0.8" || rows[1].Label != "server-label" {
+		t.Fatalf("peer row data = %+v", rows)
 	}
 	if rows[0].Expires != "2026-07-01T00:00:00Z" || rows[1].Expires != "2026-07-02T00:00:00Z" {
 		t.Fatalf("peer row expiry = %+v", rows)
@@ -416,7 +418,8 @@ func TestRefreshLocalMembershipMetadataFromMap(t *testing.T) {
 	refreshed, changed, err := refreshLocalMembershipMetadataFromMap(dir, ns, &control.MapResponse{
 		Node: &control.Node{
 			DID:            "did:jwk:node",
-			Name:           "server-01",
+			Name:           "server-host",
+			Label:          "server-01",
 			MeshIP:         netip.MustParseAddr("10.200.0.9"),
 			MemberDID:      "did:jwk:wallet",
 			MemberRecordID: "member-2",

--- a/internal/control/control_test.go
+++ b/internal/control/control_test.go
@@ -354,7 +354,7 @@ func TestNodeRecordToNode(t *testing.T) {
 	})
 }
 
-func TestNodeRecordToNodePrefersOwnerLabelOverHostname(t *testing.T) {
+func TestNodeRecordToNodePreservesOwnerLabelWithHostname(t *testing.T) {
 	didURI, _ := testDIDJWK(t)
 	rec := &NodeRecord{
 		MeshIP: "10.200.0.5",
@@ -366,8 +366,11 @@ func TestNodeRecordToNodePrefersOwnerLabelOverHostname(t *testing.T) {
 	}
 
 	node := nodeRecordToNodeWithThreshold(42, didURI, rec, DefaultPeerStaleThreshold, time.Now().UTC())
-	if node.Name != "server-01" {
-		t.Fatalf("Name = %q, want owner label", node.Name)
+	if node.Name != "old-hostname" {
+		t.Fatalf("Name = %q, want nodeInfo hostname", node.Name)
+	}
+	if node.Label != "server-01" {
+		t.Fatalf("Label = %q, want owner label", node.Label)
 	}
 	if node.OS != "linux" {
 		t.Fatalf("OS = %q, want nodeInfo OS preserved", node.OS)

--- a/internal/control/dwnclient.go
+++ b/internal/control/dwnclient.go
@@ -771,20 +771,20 @@ func nodeRecordToNodeWithThreshold(id int64, nodeDID string, rec *NodeRecord, st
 		MemberDID:      rec.EffectiveOwnerDID(),
 		MemberRecordID: rec.MemberRecordID,
 		ExpiresAt:      rec.ExpiresAt,
+		Label:          rec.Label,
 		KeyDelivery:    rec.NodeKeyDelivery,
-	}
-
-	if rec.Label != "" {
-		node.Name = rec.Label
 	}
 
 	// Populate operational fields from the nodeInfo child record if available.
 	if rec.Info != nil {
-		if node.Name == "" {
-			node.Name = rec.Info.Hostname
-		}
+		node.Name = rec.Info.Hostname
 		node.OS = rec.Info.OS
 		node.Capabilities = rec.Info.Capabilities
+	}
+
+	// Fall back to node label if no hostname from nodeInfo.
+	if node.Name == "" && rec.Label != "" {
+		node.Name = rec.Label
 	}
 
 	// Derive WireGuard public key from did:jwk.

--- a/internal/control/types.go
+++ b/internal/control/types.go
@@ -25,6 +25,9 @@ type Node struct {
 	// Name is the hostname or label for this node.
 	Name string
 
+	// Label is the owner/dashboard label for this node, when one is set.
+	Label string
+
 	// DID is the node's DID URI.
 	DID string
 


### PR DESCRIPTION
## Summary
- add a separate control `Node.Label` field for owner/dashboard labels
- keep `Node.Name` hostname-first so engine and lifecycle behavior stay stable
- use owner labels for CLI label display and local node-label refresh

## Verification
- `go test -count=1 ./internal/control ./cmd/meshd ./internal/mesh`
- `go test -count=1 ./...`
- `rg -n "enbox\.org" README.md docs cmd internal admin-dapp/src admin-dapp/README.md .github protocols` returned no matches