### PR TITLE
test: add installer release smoke e2e

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,3 +97,19 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.tag || github.event.release.tag_name }}
           files: ${{ env.artifact }}
+
+  install-smoke:
+    name: Smoke test public installer
+    needs: build-and-upload
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Install latest release via meshd.sh
+        env:
+          MESHD_INSTALL_REQUESTED_VERSION: ${{ github.event.inputs.tag }}
+          MESHD_INSTALL_EXPECTED_VERSION: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+        run: ./scripts/e2e/install-smoke.sh

--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -108,10 +108,34 @@ the remote dwn-server with derived `$keyAgreement` keys on every
 `encryptionRequired` path (no placeholders left), and a stable owner DID
 across rounds. `--keep` preserves the temp data dir for inspection.
 
+## `install-smoke.sh` — public installer release smoke
+
+Exercises the same public install path users run:
+
+```sh
+scripts/e2e/install-smoke.sh
+```
+
+The script curls `https://meshd.sh/install`, runs it with a temporary HOME and
+`--no-modify-path`, asserts that `~/.meshd/bin/meshd` exists, and checks that
+`meshd --help` starts. Release CI sets `MESHD_INSTALL_EXPECTED_VERSION` to the
+published tag, so the smoke also proves the installer resolved and unpacked the
+new release artifact.
+
+Useful environment variables:
+
+| Variable                         | Default                  | Meaning                                         |
+| -------------------------------- | ------------------------ | ----------------------------------------------- |
+| `MESHD_INSTALL_URL`              | `https://meshd.sh/install` | Installer URL to curl.                        |
+| `MESHD_INSTALL_REQUESTED_VERSION` | (empty)                 | Optional `--version` argument for the installer. |
+| `MESHD_INSTALL_EXPECTED_VERSION` | (empty)                  | Expected `meshd --version` value (`v` optional). |
+| `MESHD_INSTALL_TMP_DIR`          | auto-created             | Keep temp install state for debugging.          |
+
 ## Files
 
 - `approver.ts` — the headless approver CLI.
 - `selfcheck.ts` — end-to-end validation of the approver (client role).
+- `install-smoke.sh` — public curl installer smoke test.
 - `enbox-repo.ts` — resolves `ENBOX_REPO` and imports the monorepo packages.
 - `definition-utils.ts` — pure protocol-definition helpers (placeholder
   stripping, definition matching, structure walking).

--- a/scripts/e2e/install-smoke.sh
+++ b/scripts/e2e/install-smoke.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+INSTALL_URL="${MESHD_INSTALL_URL:-https://meshd.sh/install}"
+REQUESTED_VERSION="${MESHD_INSTALL_REQUESTED_VERSION:-}"
+EXPECTED_VERSION="${MESHD_INSTALL_EXPECTED_VERSION:-}"
+TMP_DIR="${MESHD_INSTALL_TMP_DIR:-}"
+CLEANUP_TMP=false
+
+fail() {
+  printf 'install-smoke: error: %s\n' "$*" >&2
+  exit 1
+}
+
+has_command() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+cleanup() {
+  if [ "$CLEANUP_TMP" = true ] && [ -n "$TMP_DIR" ] && [ -d "$TMP_DIR" ]; then
+    rm -rf "$TMP_DIR"
+  fi
+}
+trap cleanup EXIT INT TERM
+
+if ! has_command curl; then
+  fail 'curl is required'
+fi
+
+if ! has_command bash; then
+  fail 'bash is required'
+fi
+
+if [ -z "$TMP_DIR" ]; then
+  TMP_DIR="$(mktemp -d)"
+  CLEANUP_TMP=true
+fi
+
+HOME_DIR="${TMP_DIR}/home"
+mkdir -p "$HOME_DIR"
+
+args=(--no-modify-path)
+if [ -n "$REQUESTED_VERSION" ]; then
+  args+=(--version "$REQUESTED_VERSION")
+fi
+
+if [ -z "$EXPECTED_VERSION" ] && [ -n "$REQUESTED_VERSION" ]; then
+  EXPECTED_VERSION="$REQUESTED_VERSION"
+fi
+
+printf '==> Fetching installer from %s\n' "$INSTALL_URL"
+curl -fsSL "$INSTALL_URL" | HOME="$HOME_DIR" bash -s -- "${args[@]}"
+
+bin="${HOME_DIR}/.meshd/bin/meshd"
+if [ ! -x "$bin" ]; then
+  fail "expected installed binary at ${bin}"
+fi
+
+version_output="$("$bin" --version)"
+printf '==> Installed binary reports: %s\n' "$version_output"
+
+if [ -n "$EXPECTED_VERSION" ]; then
+  expected="${EXPECTED_VERSION#v}"
+  case "$version_output" in
+    "meshd ${expected}"*) ;;
+    *) fail "expected meshd ${expected}, got: ${version_output}" ;;
+  esac
+fi
+
+"$bin" --help >/dev/null
+printf '==> Installer smoke test passed\n'


### PR DESCRIPTION
Adds a release-time installer smoke test that curls https://meshd.sh/install into a temporary HOME, verifies the installed binary exists, checks the version against the release tag, and runs meshd --help.\n\nThe release workflow runs it after all release artifacts upload, so a published release now proves the public curl install path can fetch and unpack the new Linux artifact.