### PR TITLE
ci: smoke test release-please installer

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -108,3 +108,21 @@ jobs:
         with:
           tag_name: ${{ needs.release-please.outputs.tag_name }}
           files: ${{ env.artifact }}
+
+  install-smoke:
+    name: Smoke test public installer
+    needs:
+      - release-please
+      - build-artifacts
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - name: Install latest release via meshd.sh
+        env:
+          MESHD_INSTALL_EXPECTED_VERSION: ${{ needs.release-please.outputs.tag_name }}
+        run: ./scripts/e2e/install-smoke.sh


### PR DESCRIPTION
Runs the public installer smoke after release-please creates a release and all release assets upload. This covers the automated release path that actually published v0.14.0.