### PR TITLE
fix(connect): carry wallet URI request_uri + encryption_key in the fragment

### DIFF
--- a/internal/enboxconnect/connect_test.go
+++ b/internal/enboxconnect/connect_test.go
@@ -161,8 +161,13 @@ func (wlt *testWallet) handle(t *testing.T, walletURI string) {
 	if err != nil {
 		t.Fatalf("parsing wallet URI: %v", err)
 	}
-	requestURI := u.Query().Get("request_uri")
-	encryptionKey, err := base64.RawURLEncoding.DecodeString(u.Query().Get("encryption_key"))
+	// The relay pointer and key ride in the fragment, not the query.
+	frag, err := url.ParseQuery(u.EscapedFragment())
+	if err != nil {
+		t.Fatalf("parsing wallet URI fragment: %v", err)
+	}
+	requestURI := frag.Get("request_uri")
+	encryptionKey, err := base64.RawURLEncoding.DecodeString(frag.Get("encryption_key"))
 	if err != nil {
 		t.Fatalf("decoding encryption_key: %v", err)
 	}

--- a/internal/enboxconnect/enboxconnect.go
+++ b/internal/enboxconnect/enboxconnect.go
@@ -83,7 +83,7 @@ type Options struct {
 	RequestedTTLSeconds int
 
 	// OnWalletURI receives the wallet URI (with request_uri and
-	// encryption_key query parameters) to hand to the user. Required.
+	// encryption_key in the URI fragment) to hand to the user. Required.
 	OnWalletURI func(string)
 
 	// PINPrompt collects the PIN the wallet displays after approval.

--- a/internal/enboxconnect/relay.go
+++ b/internal/enboxconnect/relay.go
@@ -201,7 +201,15 @@ func DiscoverConnectServerURL(ctx context.Context, walletOrigin string) (string,
 // buildWalletURI builds the URI handed to the user's wallet: the wallet URL
 // (with /connect/app appended when it has no path, per cli-connect-handler.ts
 // buildWalletUri) carrying the relay request_uri and the base64url-encoded
-// request encryption key as query parameters.
+// request encryption key.
+//
+// Both values ride in the URI *fragment*, never the query string. A fragment
+// is not sent to the wallet's web server on the deep-link path, so the
+// single-use symmetric encryption key cannot surface in server or CDN access
+// logs. This conforms to the monorepo wire format defined by
+// EnboxConnectProtocol.buildWalletConnectUri (request_uri first, then
+// encryption_key, form-encoded). Any existing query on the wallet URL is left
+// untouched.
 func buildWalletURI(walletURL, requestURI string, encryptionKey []byte) (string, error) {
 	u, err := normalizeURL(walletURL)
 	if err != nil {
@@ -211,11 +219,9 @@ func buildWalletURI(walletURL, requestURI string, encryptionKey []byte) (string,
 		u.Path = defaultWalletConnectPath
 	}
 
-	q := u.Query()
-	q.Set("request_uri", requestURI)
-	q.Set("encryption_key", base64.RawURLEncoding.EncodeToString(encryptionKey))
-	u.RawQuery = q.Encode()
-	return u.String(), nil
+	fragment := "request_uri=" + url.QueryEscape(requestURI) +
+		"&encryption_key=" + url.QueryEscape(base64.RawURLEncoding.EncodeToString(encryptionKey))
+	return u.String() + "#" + fragment, nil
 }
 
 // normalizeURL validates a URL, defaulting the scheme to https when absent

--- a/internal/enboxconnect/relay_test.go
+++ b/internal/enboxconnect/relay_test.go
@@ -55,6 +55,24 @@ func TestDiscoverConnectServerURLErrors(t *testing.T) {
 func TestBuildWalletURI(t *testing.T) {
 	key := []byte{1, 2, 3, 4}
 
+	// fragmentParams parses the wallet URI fragment (request_uri +
+	// encryption_key), mirroring how the wallet reads the deep-link.
+	fragmentParams := func(t *testing.T, walletURI string) url.Values {
+		t.Helper()
+		before, frag, ok := strings.Cut(walletURI, "#")
+		if !ok {
+			t.Fatalf("wallet URI has no fragment: %q", walletURI)
+		}
+		if strings.Contains(before, "request_uri=") || strings.Contains(before, "encryption_key=") {
+			t.Errorf("connect params leaked into the query/path: %q", walletURI)
+		}
+		values, err := url.ParseQuery(frag)
+		if err != nil {
+			t.Fatalf("parsing fragment %q: %v", frag, err)
+		}
+		return values
+	}
+
 	t.Run("bare origin gets the default connect path", func(t *testing.T) {
 		got, err := buildWalletURI("https://wallet.example", "https://relay.example/authorize/abc.jwt", key)
 		if err != nil {
@@ -67,10 +85,11 @@ func TestBuildWalletURI(t *testing.T) {
 		if u.Path != defaultWalletConnectPath {
 			t.Errorf("path = %q, want %q", u.Path, defaultWalletConnectPath)
 		}
-		if q := u.Query().Get("request_uri"); q != "https://relay.example/authorize/abc.jwt" {
+		frag := fragmentParams(t, got)
+		if q := frag.Get("request_uri"); q != "https://relay.example/authorize/abc.jwt" {
 			t.Errorf("request_uri = %q", q)
 		}
-		if q := u.Query().Get("encryption_key"); q != base64.RawURLEncoding.EncodeToString(key) {
+		if q := frag.Get("encryption_key"); q != base64.RawURLEncoding.EncodeToString(key) {
 			t.Errorf("encryption_key = %q", q)
 		}
 	})
@@ -90,7 +109,7 @@ func TestBuildWalletURI(t *testing.T) {
 		if q := u.Query().Get("theme"); q != "dark" {
 			t.Errorf("theme = %q, want dark", q)
 		}
-		if q := u.Query().Get("request_uri"); q != "req-uri" {
+		if q := fragmentParams(t, got).Get("request_uri"); q != "req-uri" {
 			t.Errorf("request_uri = %q", q)
 		}
 	})
@@ -100,7 +119,7 @@ func TestBuildWalletURI(t *testing.T) {
 		if err != nil {
 			t.Fatalf("buildWalletURI: %v", err)
 		}
-		if !strings.HasPrefix(got, "https://wallet.example/connect/app?") {
+		if !strings.HasPrefix(got, "https://wallet.example/connect/app#") {
 			t.Errorf("got %q", got)
 		}
 	})

--- a/internal/enboxconnect/testdata/connect_request.json
+++ b/internal/enboxconnect/testdata/connect_request.json
@@ -567,9 +567,9 @@
       "did:jwk"
     ]
   },
-  "walletUriExample": "https://wallet.example.com/connect/app?request_uri=https%3A%2F%2Frelay.example.com%2Fconnect%2Fauthorize%2FREQUEST_ID.jwt&encryption_key=btTo8_ISg5caisZXDFgcI3OyHwCcfXA4Rmi4Nt7QbvA",
+  "walletUriExample": "https://wallet.example.com/connect/app#request_uri=https%3A%2F%2Frelay.example.com%2Fconnect%2Fauthorize%2FREQUEST_ID.jwt&encryption_key=btTo8_ISg5caisZXDFgcI3OyHwCcfXA4Rmi4Nt7QbvA",
   "_fields": {
-    "encryptionKey_b64u": "fresh random 32-byte symmetric key; travels to the wallet in the wallet URI query (encryption_key)",
+    "encryptionKey_b64u": "fresh random 32-byte symmetric key; travels to the wallet in the wallet URI fragment (encryption_key)",
     "protectedHeaderJson": "EXACT UTF-8 bytes of the JWE protected header; also the AAD",
     "expectedRequestPayload": "the EnboxConnectRequest JWT payload (nonce/state are random base64url(16 bytes))"
   }

--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -45,7 +45,7 @@ bun scripts/e2e/approver.ts --uri '<wallet URI>' \
 
 | Flag           | Default              | Meaning                                                        |
 | -------------- | -------------------- | -------------------------------------------------------------- |
-| `--uri`        | (required)           | Wallet URI with `request_uri` + `encryption_key` query params. Any scheme works (`https://…`, `enbox://connect?…`). |
+| `--uri`        | (required)           | Wallet URI with `request_uri` + `encryption_key` in the URI fragment. Any scheme works (`https://…`, `enbox://connect#…`). |
 | `--data`       | `.e2e-approver`      | Agent data directory. Persistent: reusing it approves as the **same owner** (two devices, one owner). |
 | `--password`   | `meshd-e2e-approver` | Vault password protecting the data directory.                  |
 | `--endpoint`   | `http://localhost:3000` | DWN server / relay endpoint the owner tenant lives on.      |

--- a/scripts/e2e/approver.ts
+++ b/scripts/e2e/approver.ts
@@ -125,29 +125,6 @@ function parseCli(argv: string[]): Cli {
   };
 }
 
-// ─── wallet URI parsing ─────────────────────────────────────────────
-
-/**
- * Extract `request_uri` and `encryption_key` from a wallet URI. Parses the
- * query string manually so custom schemes (`enbox://connect?...`) work the
- * same as https wallet URLs.
- */
-function parseWalletUri(uri: string): { requestUri: string; encryptionKey: string } {
-  const queryIndex = uri.indexOf('?');
-  if (queryIndex === -1) {
-    throw new Error(`wallet URI has no query string: ${uri}`);
-  }
-
-  const params = new URLSearchParams(uri.slice(queryIndex + 1));
-  const requestUri = params.get('request_uri');
-  const encryptionKey = params.get('encryption_key');
-
-  if (!requestUri || !encryptionKey) {
-    throw new Error('wallet URI is missing request_uri and/or encryption_key');
-  }
-
-  return { requestUri, encryptionKey };
-}
 
 // ─── wallet-side protocol install ───────────────────────────────────
 
@@ -333,10 +310,16 @@ async function main(): Promise<void> {
       await dwnClients.DwnRegistrar.registerTenant(cli.endpoint, ownerDid);
     }
 
-    // 5. Fetch, decrypt, and verify the connect request.
-    const { requestUri, encryptionKey } = parseWalletUri(cli.uri);
+    // 5. Fetch, decrypt, and verify the connect request. The relay pointer and
+    // the single-use encryption key ride in the wallet URI fragment; parse them
+    // with the monorepo's canonical helper.
+    const connectParams = EnboxConnectProtocol.parseWalletConnectUri(cli.uri);
+    if (connectParams === undefined) {
+      throw new Error(`wallet URI is missing request_uri and/or encryption_key: ${cli.uri}`);
+    }
+    const { requestUri, encryptionKeyBase64Url } = connectParams;
     console.error(`approver: fetching connect request from ${requestUri}`);
-    const request = await EnboxConnectProtocol.getConnectRequest(requestUri, encryptionKey);
+    const request = await EnboxConnectProtocol.getConnectRequest(requestUri, encryptionKeyBase64Url);
     console.error(
       `approver: request from app '${request.appName}' (client ${request.clientDid}), ` +
       `${request.permissionRequests.length} protocol(s), delegate ${request.delegateDid ?? '<wallet-minted>'}`,

--- a/scripts/e2e/selfcheck.ts
+++ b/scripts/e2e/selfcheck.ts
@@ -133,7 +133,7 @@ async function runConnectRound(params: {
     clientMetadata       : { origin: 'meshd-e2e-selfcheck' },
     preSupplyDelegateDid : true,
     connectServerUrl     : `${endpoint}/connect`,
-    // Only the query params matter to the approver; the wallet page itself
+    // Only the fragment params matter to the approver; the wallet page itself
     // is never fetched.
     walletUri            : 'https://wallet.invalid/connect/app',
     permissionRequests,

--- a/scripts/gen-crypto-fixtures/generate.ts
+++ b/scripts/gen-crypto-fixtures/generate.ts
@@ -669,9 +669,13 @@ async function generateConnectFixtures(): Promise<void> {
     requestJwe,
     expectedRequestJwt         : requestJwt,
     expectedRequestPayload     : request,
-    walletUriExample           : `https://wallet.example.com/connect/app?request_uri=${encodeURIComponent(`${connectServerUrl}/authorize/REQUEST_ID.jwt`)}&encryption_key=${h.b64u(encryptionKey)}`,
+    walletUriExample           : P.buildWalletConnectUri({
+      walletUri     : 'https://wallet.example.com/connect/app',
+      requestUri    : `${connectServerUrl}/authorize/REQUEST_ID.jwt`,
+      encryptionKey,
+    }),
     _fields: {
-      encryptionKey_b64u     : 'fresh random 32-byte symmetric key; travels to the wallet in the wallet URI query (encryption_key)',
+      encryptionKey_b64u     : 'fresh random 32-byte symmetric key; travels to the wallet in the wallet URI fragment (encryption_key)',
       protectedHeaderJson    : 'EXACT UTF-8 bytes of the JWE protected header; also the AAD',
       expectedRequestPayload : 'the EnboxConnectRequest JWT payload (nonce/state are random base64url(16 bytes))',
     },


### PR DESCRIPTION
## Summary

meshd's enbox-connect client built the wallet deep-link URI with the relay `request_uri` and the **single-use symmetric `encryption_key`** (which protects the pushed authorization request) in the **query string**:

```
https://wallet.example/connect/app?request_uri=…&encryption_key=…
```

On the deep-link path a query string is transmitted to the wallet's web server, so that key could surface in server and CDN access logs. This moves both values into the URI **fragment** — never sent to the server, so the key stays on the local channel (QR camera scan or the opening browser):

```
https://wallet.example/connect/app#request_uri=…&encryption_key=…
```

This conforms to the monorepo's canonical wire-format helpers `EnboxConnectProtocol.buildWalletConnectUri` / `parseWalletConnectUri` (enboxorg/enbox#1202) — the format is defined once in the monorepo and consumed/conformed-to here.

## Changes

- **`internal/enboxconnect/relay.go`** — `buildWalletURI` emits `request_uri` + `encryption_key` in the fragment (request_uri first, form-encoded), leaving any existing wallet-URL query untouched.
- **`internal/enboxconnect/{relay,connect}_test.go`** — assert/parse the fragment; a regression check asserts the params never leak into the query/path.
- **`internal/enboxconnect/enboxconnect.go`** — `OnWalletURI` doc comment.
- **`scripts/gen-crypto-fixtures/generate.ts`** + **`internal/enboxconnect/testdata/connect_request.json`** — `walletUriExample` now built via `EnboxConnectProtocol.buildWalletConnectUri` (fixture updated to the fragment form using its existing key, so the crypto fixtures are otherwise unchanged).
- **`scripts/e2e/approver.ts`** — parses the wallet URI via `EnboxConnectProtocol.parseWalletConnectUri` instead of hand-rolled query parsing.
- **`scripts/e2e/selfcheck.ts`**, **`scripts/e2e/README.md`** — doc/comment updates.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./... -count=1 -race` — all pass.
- **Live two-node e2e** (`TestE2EEnboxConnectTwoNodeMesh`, `DWN_ENDPOINT=http://localhost:3000`, `ENBOX_REPO` on the enbox#1202 branch): passes end-to-end — both devices onboard via relay + PIN using the fragment-form wallet URI, delegate-direct network create/join, sealed-encrypted coordination, bidirectional WireGuard TCP echo.
- Fixture generator re-run and self-verified against the enbox#1202 branch; `walletUriExample` emitted in fragment form.

## Dependency

The TS tooling (`generate.ts`, `approver.ts`) consumes `buildWalletConnectUri` / `parseWalletConnectUri` from a local enbox monorepo checkout, so it needs **enboxorg/enbox#1202** merged + built. Go build/vet/test are independent of the monorepo (the e2e/generator are not part of the Go gate), so CI is green now.

Closes #173