### PR TITLE
fix(install): add PATH for fish shells

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -130,6 +130,25 @@ add_to_path() {
   local shell_name
   shell_name="$(basename "${SHELL:-bash}")"
 
+  # fish does not use POSIX `export` syntax and does not source ~/.profile.
+  # Drop an auto-sourced conf.d snippet using fish's own idempotent helper.
+  if [ "$shell_name" = "fish" ]; then
+    local fish_dir="${XDG_CONFIG_HOME:-$HOME/.config}/fish/conf.d"
+    local fish_file="${fish_dir}/meshd.fish"
+    local fish_line="fish_add_path ${INSTALL_DIR}"
+    if [ -f "$fish_file" ] && grep -Fxq "$fish_line" "$fish_file"; then
+      return
+    fi
+    if mkdir -p "$fish_dir" 2>/dev/null && [ -w "$fish_dir" ]; then
+      printf '# meshd\n%s\n' "$fish_line" >> "$fish_file"
+      printf 'Updated PATH in %s\n' "$fish_file"
+      return
+    fi
+    printf 'Add this to your fish config:\n'
+    printf '  %s\n' "$fish_line"
+    return
+  fi
+
   local line
   line="export PATH=${INSTALL_DIR}:\$PATH"
 


### PR DESCRIPTION
## Summary

`install.sh` only added the meshd bin dir to PATH for **bash** and **zsh**. Fish shells fell through to the default branch, which appended POSIX `export PATH=…` to `~/.profile` — a file fish does not source, and syntax fish cannot parse. Result: `meshd` was installed to `~/.meshd/bin` but never on PATH, so the command wasn't runnable after install (reported on fish).

## What changed

- Detect `fish` in `add_to_path` and write an auto-sourced snippet to `$XDG_CONFIG_HOME/fish/conf.d/meshd.fish` (defaults to `~/.config/fish/conf.d/meshd.fish`) using fish's own idempotent `fish_add_path`.
- conf.d snippets are loaded automatically on every fish startup — the standard mechanism mainstream installers use for fish.
- Idempotent: re-running the installer does not duplicate the entry.
- bash/zsh behavior is unchanged.

## Testing

- `bash -n install.sh` — syntax OK.
- Simulated the fish branch against a sandbox `HOME`/`XDG_CONFIG_HOME`: writes the expected `conf.d/meshd.fish`; running twice leaves a single entry (idempotent).
- Verified the generated snippet parses under `fish --no-execute`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)