### PR TITLE
fix(admin-dapp): build service worker as classic iife

### DIFF
--- a/admin-dapp/vite.config.ts
+++ b/admin-dapp/vite.config.ts
@@ -36,6 +36,14 @@ export default defineConfig({
       },
 
       injectManifest: {
+        // Build the worker as a classic IIFE, not an ES module. The default
+        // "es" format leaves `import.meta.url` (from a dependency's own
+        // registration helper) in the bundle; the injected registerSW.js
+        // registers sw.js as a *classic* worker, and `import.meta` in a
+        // classic script is a SyntaxError that aborts registration. iife
+        // strips import.meta and also gives the widest browser support
+        // (module service workers are unsupported in Firefox).
+        rollupFormat: "iife",
         maximumFileSizeToCacheInBytes: 5000000,
         globPatterns: ["**/*.{js,css,html,json,svg,png,ico}"]
       },


### PR DESCRIPTION
## Summary

Service worker registration was failing in the browser with:

```
Uncaught SyntaxError: Cannot use 'import.meta' outside a module (at sw.js:1)
Failed to register a ServiceWorker for scope ('https://meshd-admin.pages.dev/')
```

**Cause:** `vite-plugin-pwa` (injectManifest) built `sw.js` in the default **`es`** format, which left an `import.meta.url` (from a dependency's own registration helper) in the bundle. The injected `registerSW.js` registers `sw.js` as a **classic** worker (`register('/sw.js')`, no `{ type: 'module' }`), and `import.meta` inside a classic script is a hard `SyntaxError` that aborts registration.

## Fix

Set `injectManifest.rollupFormat: "iife"` — matching the reference `dapp-demo` config — so the worker is bundled as a classic IIFE with no `import.meta`. This is also the widest-support option (module service workers are unsupported in Firefox).

## Testing

- `bun run build` → `format: iife`.
- `grep -c import.meta dist/sw.js` → **0**.
- `node --check dist/sw.js` → parses cleanly as a classic script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)