### PR TITLE
fix(admin-dapp): decrypt encrypted DWN query replies

### DIFF
--- a/admin-dapp/src/meshd/admin.test.ts
+++ b/admin-dapp/src/meshd/admin.test.ts
@@ -164,6 +164,23 @@ describe("meshd admin DWN operations", () => {
     expect(pushes).toEqual(["push"]);
   });
 
+  it("requests reply decryption on record queries so encrypted payloads decode", async () => {
+    // Mesh records (preAuthKey, member/node) are written encrypted. The agent
+    // only auto-decrypts query replies when the query itself carries
+    // encryption: true; without it, encrypted payloads return as ciphertext and
+    // preAuthKey lookups (approval) and the invite list silently fail.
+    const { session, requests } = createFakeSession({ delegate: true });
+
+    await fetchMeshdNetworks(session);
+
+    const query = requests.find((request) => request.messageType === DwnInterface.RecordsQuery);
+    expect(query).toBeDefined();
+    expect(query).toMatchObject({
+      messageType: DwnInterface.RecordsQuery,
+      encryption: true
+    });
+  });
+
   it("uses the beta DWN endpoint when the owner does not publish one", async () => {
     const { session, requests } = createFakeSession({
       endpoints: ["", "   "],

--- a/admin-dapp/src/meshd/admin.ts
+++ b/admin-dapp/src/meshd/admin.ts
@@ -398,7 +398,16 @@ async function queryRecords(
           ...extraFilter
         },
         dateSort: "createdAscending"
-      }
+      },
+      // Mesh records (preAuthKey, member/node payloads) are written with
+      // encryption: true. The agent only auto-decrypts reply data when the
+      // *query* also carries this flag (maybeDecryptReply early-returns
+      // otherwise), so without it encrypted records come back as ciphertext
+      // that decodeRecordPayload cannot parse — leaving preAuthKey lookups and
+      // the topology invite list silently empty. Plaintext records (e.g.
+      // network) are unaffected: decryption only touches entries whose own
+      // encryption descriptor is set.
+      encryption: true
     },
     protocol
   );


### PR DESCRIPTION
## Summary

Approving a pre-auth node join request in the dashboard failed with **"The preauth key for this request was not found."** Root cause: the dapp could not read back its own **encrypted** `network/preAuthKey` record.

Mesh records (`network/preAuthKey`, `network/member`, `network/member/node` payloads) are written with `encryption: true`, but `queryRecords` never set that flag on the `RecordsQuery`. The agent's `maybeDecryptReply` early-returns unless the query itself carries `encryption`, so encrypted records came back as **ciphertext** that `decodeRecordPayload` could not `JSON.parse` — `parseMeshdPreAuthKeyRecord` (and siblings) returned `undefined`, and `readPreAuthKey`'s `.find(...)` matched nothing.

Blast radius beyond the approval error:
- The topology **invite list** was silently empty (encrypted preAuthKeys never decoded).
- Member **labels** were silently dropped (member `did` survives because it comes from the record's `recipient` descriptor, not the encrypted payload).

## Fix

Set `encryption: true` on the shared `queryRecords` `RecordsQuery` request — the same flag `writeRecord` already sets. `processDwnRequest` spreads `...request`, so it passes straight through to `agent.processDwnRequest`, which then runs `maybeDecryptReply`. Fixing the shared helper repairs the preAuthKey approval lookup, the invite list, and encrypted member/node payloads in one place.

Safe for plaintext records: `maybeDecryptReply` only touches entries whose own `encryption` descriptor is set, so unencrypted records (e.g. `network`) pass through untouched.

## How it was found

Built a live reproduction against the real `@enbox/agent` (`PlatformAgentTestHarness` + `EnboxUserAgent`), configured the actual `wireguard-mesh.json` protocol with encryption, wrote an encrypted `network/preAuthKey`, and queried it back. Result:
- Without the flag: query returns the record (status 200, 1 entry) but `encodedData` is ciphertext → decode fails → "not found".
- With the flag: same query decodes to `key="test-secret"`.

This also disproved the initial suspicion that combining a `contextId` prefix filter with an exact `recordId` filter dropped the record — it does not.

## Testing

- New regression test asserts `RecordsQuery` requests carry `encryption: true`.
- `bun run test` → 31 passed. `bun run build` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)