### PR TITLE
fix(cli): member-associated nodes read the peer map with the network/member role

### DIFF
--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -2004,12 +2004,8 @@ func cmdPeerList(ctx context.Context, args []string, flagProfile string) error {
 		return err
 	}
 	// Determine protocol role for queries. Delegated sessions read as the
-	// owner (no role).
-	queryRole := ""
-	if ns.AnchorDID != identity.URI {
-		queryRole = "network/node"
-	}
-	queryRole = protocolRoleForAuth(readAuth, queryRole)
+	// owner (no role); member-associated nodes read as network/member.
+	queryRole := protocolRoleForAuth(readAuth, readProtocolRole(ns.AnchorDID, identity.URI, ns.MemberRecordID))
 	delegateSession := delegateSessionForCLIBestEffort(ctx, stateDir, meta, ns, operationIdentity, readAuth)
 	encMgr := newEncryptionKeyManager(identity)
 	if resp, err := loadControlStateForCLI(ctx, ns, identity, operationIdentity, encMgr, readAuth, delegateSession); err == nil {
@@ -2126,11 +2122,7 @@ func loadControlStateForCLI(ctx context.Context, ns *state.NetworkState, identit
 		signerIdentity = identity
 	}
 	selfNodeDID := networkNodeDID(ns, identity.URI)
-	protocolRole := ""
-	if ns.AnchorDID != selfNodeDID {
-		protocolRole = "network/node"
-	}
-	protocolRole = protocolRoleForAuth(readAuth, protocolRole)
+	protocolRole := protocolRoleForAuth(readAuth, readProtocolRole(ns.AnchorDID, selfNodeDID, ns.MemberRecordID))
 	signer := dwnSigner(signerIdentity)
 	opts := []control.Option{
 		control.WithEncryptionKeyManager(encMgr),
@@ -2507,10 +2499,7 @@ func cmdPeerRemove(ctx context.Context, args []string, flagProfile string) error
 	}
 	signer := dwnSigner(operationIdentity)
 	api := dwn.NewDwnAPI(dwn.NewSimpleAgent(ns.AnchorEndpoint, signer))
-	protocolRole := ""
-	if ns.AnchorDID != selfNodeDID {
-		protocolRole = "network/node"
-	}
+	protocolRole := readProtocolRole(ns.AnchorDID, selfNodeDID, ns.MemberRecordID)
 
 	candidates, err := queryPeerRemoveCandidates(ctx, api, ns, peerDID, readAuth, protocolRoleForAuth(readAuth, protocolRole))
 	if err != nil {
@@ -3880,13 +3869,10 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 	}
 
 	// Determine the protocol role for DWN queries. The anchor reads as
-	// author (no role needed). Non-anchor nodes use their node role, except
+	// author (no role needed). Non-anchor nodes use their node role
+	// (network/member when member-associated, else network/node), except
 	// delegated sessions, which read as the owner via their grants.
-	protocolRole := ""
-	if ns.AnchorDID != nodeIdentity.URI {
-		protocolRole = "network/node"
-	}
-	protocolRole = protocolRoleForAuth(readAuth, protocolRole)
+	protocolRole := protocolRoleForAuth(readAuth, readProtocolRole(ns.AnchorDID, nodeIdentity.URI, ns.MemberRecordID))
 	discoRegistry := engine.NewInMemoryDiscoRegistry()
 
 	engCfg := engine.Config{
@@ -4867,6 +4853,30 @@ func protocolRoleForAuth(auth dwn.MessageAuth, role string) string {
 		return ""
 	}
 	return role
+}
+
+// readProtocolRole returns the DWN protocol role a node presents on
+// control-plane read/query operations.
+//
+//   - The anchor (network owner) reads as author of the network record — no role.
+//   - A member-associated node (joined via invite/preauth, so MemberRecordID is
+//     set) is the recipient of a network/member record for its own DID and holds
+//     the network/member role, which is granted read on the node/nodeInfo/endpoint
+//     records it needs. It does NOT hold a top-level network/node role, so it must
+//     present network/member, not network/node.
+//   - An owner-provisioned node (no MemberRecordID) holds a top-level network/node
+//     role and presents network/node.
+//
+// Delegated/enbox-connect sessions are zeroed separately by protocolRoleForAuth,
+// which callers apply on top of this value.
+func readProtocolRole(anchorDID, selfNodeDID, memberRecordID string) string {
+	if anchorDID == selfNodeDID {
+		return ""
+	}
+	if memberRecordID != "" {
+		return "network/member"
+	}
+	return "network/node"
 }
 
 func walletSessionGrantGranteeDID(session *state.WalletSession, meta identityMetadata) (string, bool) {
@@ -6034,11 +6044,8 @@ func cmdACLShow(ctx context.Context, args []string, flagProfile string) error {
 	encMgr := newEncryptionKeyManager(identity)
 
 	// Determine protocol role for queries. Delegated sessions read as the
-	// owner (no role).
-	aclQueryRole := ""
-	if ns.AnchorDID != identity.URI {
-		aclQueryRole = "network/node"
-	}
+	// owner (no role); member-associated nodes read as network/member.
+	aclQueryRole := readProtocolRole(ns.AnchorDID, identity.URI, ns.MemberRecordID)
 	readAuth, err := walletDWNAuthForOperation(stateDir, meta, dwn.InterfaceRecordsQuery, protocols.MeshProtocolURI, "", ns.NetworkRecordID, false)
 	if err != nil {
 		return err

--- a/cmd/meshd/main_test.go
+++ b/cmd/meshd/main_test.go
@@ -2064,3 +2064,53 @@ func TestNodeRuntimeProtocolPaths(t *testing.T) {
 		t.Fatalf("member endpoint path = %q", got)
 	}
 }
+
+func TestReadProtocolRole(t *testing.T) {
+	const anchorDID = "did:dht:anchor"
+	const nodeDID = "did:jwk:node"
+
+	tests := []struct {
+		name           string
+		anchorDID      string
+		selfNodeDID    string
+		memberRecordID string
+		want           string
+	}{
+		{
+			name:        "anchor reads as author",
+			anchorDID:   anchorDID,
+			selfNodeDID: anchorDID,
+			want:        "",
+		},
+		{
+			name:           "member-associated node reads as network/member",
+			anchorDID:      anchorDID,
+			selfNodeDID:    nodeDID,
+			memberRecordID: "member-1",
+			want:           "network/member",
+		},
+		{
+			name:        "owner-provisioned node reads as network/node",
+			anchorDID:   anchorDID,
+			selfNodeDID: nodeDID,
+			want:        "network/node",
+		},
+		{
+			// The anchor short-circuit wins even if a member record is present.
+			name:           "anchor with member record still reads as author",
+			anchorDID:      anchorDID,
+			selfNodeDID:    anchorDID,
+			memberRecordID: "member-1",
+			want:           "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := readProtocolRole(tt.anchorDID, tt.selfNodeDID, tt.memberRecordID); got != tt.want {
+				t.Fatalf("readProtocolRole(%q, %q, %q) = %q, want %q",
+					tt.anchorDID, tt.selfNodeDID, tt.memberRecordID, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -110,7 +110,8 @@ type Config struct {
 
 	// ProtocolRole is the DWN protocol role used for read queries.
 	// The anchor (network owner) leaves this empty (reads as author).
-	// Non-anchor nodes use "network/node".
+	// Member-associated nodes (MemberRecordID set) use "network/member";
+	// owner-provisioned nodes use "network/node".
 	ProtocolRole string
 
 	// PermissionGrantID invokes a DWN permission grant for control-plane


### PR DESCRIPTION
## Summary

An invite-joined node running `meshd peer list` (and `doctor`, the `up` daemon poll, `acl show`, `peer remove`) fails with:

```
401 ProtocolAuthorizationMatchingRoleRecordNotFound:
    No matching role record found for protocol path network/node
```

**Root cause.** A node that joins via invite/preauth is provisioned as a **member-associated** device — the approver (dapp or CLI anchor) writes it under `network/member/node` and makes it the recipient of a `network/member` record for its own DID (in the walletless invite flow `owner == node`). It therefore holds the `network/member` and `network/member/node` roles, but **not** a top-level `network/node` role.

Every non-anchor control-plane read hardcoded `ProtocolRole = "network/node"` regardless of `MemberRecordID`, so the node presented a role it doesn't hold → 401.

## Fix

Add a single `readProtocolRole(anchorDID, selfNodeDID, memberRecordID)` helper:
- anchor → `""` (reads as author of the network record)
- `MemberRecordID` set → `"network/member"`
- else → `"network/node"` (owner-provisioned)

Applied at all **5** selection sites in `cmd/meshd/main.go` (`cmdPeerList` fallback, `loadControlStateForCLI`, `cmdPeerRemove`, `cmdUp` engine cfg, `cmdACLShow`), each still wrapped in `protocolRoleForAuth` so delegated/enbox-connect sessions keep reading as owner. Corrected the now-stale `ProtocolRole` doc comment in `internal/engine/engine.go`.

## Why `network/member` is correct (not `network/member/node`)

`protocols/wireguard-mesh.json` grants the `read` action to only two roles — `network/member` and `network/node` — on every readable record type. `network/member/node` is a `$role: true` bearer path with **zero** read actions, so presenting it would clear the role-holder check but fail the action check. `network/member` also aligns with decryption: the `network/member` audience key is delivered to the member DID.

Keying on `MemberRecordID != ""` is self-consistent — that field is only ever populated by a successful `network/member` role query at join time, so it's non-empty only for nodes that provably hold the role.

## How it was verified

- **Live node state** (`~/.enbox/profiles/personal/meshd/network.json`): `ownerDid == nodeDid == memberDid`, `memberRecordId` set — confirming the node holds `network/member`, and that the failing path was only the hardcoded `network/node` read role.
- **Adversarial multi-lens review** (correctness / completeness / regression) against the actual code: confirmed the fix value, that all 5 sites are covered, and that the change is non-regressive for the anchor, owner-provisioned nodes, ACL reads, and endpoint-write auth (writes use recipient-based auth, not this read role). Owner-provisioned nodes provably never carry a non-empty `MemberRecordID`, so they stay on `network/node`.

## Known follow-up (not in this PR)

A residual bootstrap window exists for the **async-approval** case: a member node approved *after* joining but before its first `meshd up`, or a migrated state, could have an empty persisted `MemberRecordID` and would still select `network/node`. Closing it (run join discovery before the first read, or retry once on a role 401 with the alternate role) is a follow-up. It does not affect the normal invite→join→approve flow, where `MemberRecordID` is populated at join time.

## Testing

- New `TestReadProtocolRole` (anchor / member-associated / owner-provisioned / anchor-with-member).
- `go build ./...`, `go vet ./...`, `go test ./... -count=1 -race` — all pass (22 packages), existing `network/node` role tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)