### PR TITLE
fix(release): ad-hoc code-sign macOS binaries so they run on Apple Silicon

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,7 +26,10 @@ jobs:
     name: Build ${{ matrix.os }}-${{ matrix.arch }}
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
-    runs-on: ubuntu-latest
+    # darwin targets build on a macOS runner so the Mach-O binaries are ad-hoc
+    # code-signed; Apple Silicon SIGKILLs unsigned binaries. Everything else
+    # cross-compiles on Linux.
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
@@ -36,36 +39,43 @@ jobs:
             goos: linux
             goarch: amd64
             ext: tar.gz
+            runner: ubuntu-latest
           - os: linux
             arch: arm64
             goos: linux
             goarch: arm64
             ext: tar.gz
+            runner: ubuntu-latest
           - os: darwin
             arch: x64
             goos: darwin
             goarch: amd64
             ext: tar.gz
+            runner: macos-latest
           - os: darwin
             arch: arm64
             goos: darwin
             goarch: arm64
             ext: tar.gz
+            runner: macos-latest
           - os: windows
             arch: x64
             goos: windows
             goarch: amd64
             ext: zip
+            runner: ubuntu-latest
           - os: windows
             arch: arm64
             goos: windows
             goarch: arm64
             ext: zip
+            runner: ubuntu-latest
           - os: freebsd
             arch: x64
             goos: freebsd
             goarch: amd64
             ext: tar.gz
+            runner: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -92,6 +102,12 @@ jobs:
           version="${{ needs.release-please.outputs.tag_name }}"
           version="${version#v}"
           go build -trimpath -ldflags="-s -w -X main.version=${version}" -o "$out" ./cmd/meshd
+
+      - name: Ad-hoc code-sign (macOS)
+        if: matrix.os == 'darwin'
+        run: |
+          codesign --force --sign - dist/release/meshd
+          codesign --verify --verbose dist/release/meshd
 
       - name: Package artifact
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,10 @@ permissions:
 jobs:
   build-and-upload:
     name: Build ${{ matrix.os }}-${{ matrix.arch }}
-    runs-on: ubuntu-latest
+    # darwin targets build on a macOS runner so the Mach-O binaries are ad-hoc
+    # code-signed; Apple Silicon SIGKILLs unsigned binaries. Everything else
+    # cross-compiles on Linux.
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
@@ -25,36 +28,43 @@ jobs:
             goos: linux
             goarch: amd64
             ext: tar.gz
+            runner: ubuntu-latest
           - os: linux
             arch: arm64
             goos: linux
             goarch: arm64
             ext: tar.gz
+            runner: ubuntu-latest
           - os: darwin
             arch: x64
             goos: darwin
             goarch: amd64
             ext: tar.gz
+            runner: macos-latest
           - os: darwin
             arch: arm64
             goos: darwin
             goarch: arm64
             ext: tar.gz
+            runner: macos-latest
           - os: windows
             arch: x64
             goos: windows
             goarch: amd64
             ext: zip
+            runner: ubuntu-latest
           - os: windows
             arch: arm64
             goos: windows
             goarch: arm64
             ext: zip
+            runner: ubuntu-latest
           - os: freebsd
             arch: x64
             goos: freebsd
             goarch: amd64
             ext: tar.gz
+            runner: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -81,6 +91,12 @@ jobs:
           tag="${{ github.event.inputs.tag || github.event.release.tag_name }}"
           version="${tag#v}"
           go build -trimpath -ldflags="-s -w -X main.version=${version}" -o "$out" ./cmd/meshd
+
+      - name: Ad-hoc code-sign (macOS)
+        if: matrix.os == 'darwin'
+        run: |
+          codesign --force --sign - dist/release/meshd
+          codesign --verify --verbose dist/release/meshd
 
       - name: Package artifact
         run: |


### PR DESCRIPTION
## Summary

`meshd` installed via `install.sh` on an Apple Silicon Mac dies instantly with `SIGKILL` ("Killed: 9") on any command, including `meshd --version`.

**Root cause:** the darwin release binaries are cross-compiled on `ubuntu-latest` (`GOOS=darwin GOARCH=arm64`) and **never code-signed** (`git log -S codesign`/`-S macos-latest` on the workflows returns nothing — it was never signed). Apple Silicon's kernel refuses to execute unsigned Mach-O binaries and kills them on `exec`. So the released macOS binary never actually ran on Apple Silicon; any previously-working `meshd` on such a Mac was a native `go build` (Go ad-hoc-signs arm64 binaries when building on macOS).

## Fix

- Build the **darwin** matrix entries on **`macos-latest`** (arm64 runner) instead of `ubuntu-latest`, via a per-entry `runner` field and `runs-on: ${{ matrix.runner }}`. Linux/Windows/FreeBSD keep cross-compiling on `ubuntu-latest`.
- Add an **ad-hoc code-sign** step for darwin (`codesign --force --sign -`), then `codesign --verify` before packaging, so both `darwin/arm64` and `darwin/amd64` ship signed.
- Applied to **both** release paths — `release.yml` (on release publish) and `release-please.yml` (automated release) — so whichever builds the assets, they're signed.

### Why ad-hoc is enough here

`install.sh` downloads via `curl`, which does **not** set the `com.apple.quarantine` attribute, so Gatekeeper never gates execution. The only barrier on Apple Silicon was the missing signature; an ad-hoc signature clears it. Result: `curl … | bash` installs a `meshd` that runs with **no** user-side `xattr`/`codesign` steps.

## Testing / validation

- Both workflow files parse as valid YAML; verified the build job resolves `runs-on: ${{ matrix.runner }}`, darwin → `macos-latest`, all other targets → `ubuntu-latest`, and the new sign step sits between "Build binary" and "Package artifact".
- Full CI runs on PRs; the real validation is the next release producing a runnable macOS asset. (Can't fully exercise a release workflow pre-merge.)

## Follow-ups (intentionally out of scope)

- **Notarization:** Developer ID signing + Apple notarization for a quarantine-clean experience on browser/GUI downloads (needs Apple certs as CI secrets). Ad-hoc covers the `curl` installer path today.
- **Smoke coverage:** `install-smoke.sh` runs only on `ubuntu-latest`, so it never exercised the macOS path. Adding a `macos-latest` leg would have caught this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)