### PR TITLE
feat(mesh): emit node role-path public keys in join requests (#187)

### DIFF
--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -1913,13 +1913,14 @@ func cmdJoin(ctx context.Context, args []string, flagProfile string) error {
 		label, _ := os.Hostname()
 		signer := &dwn.Signer{DID: identity.URI, PrivateKey: identity.SigningKey}
 		if err := mesh.WritePreAuthNodeRequest(ctx, mesh.WritePreAuthNodeRequestParams{
-			Invite:      payload,
-			NodeDID:     nodeDID,
-			MemberDID:   ownerDID,
-			DelegateDID: meta.DelegateDID,
-			RequestedBy: identity.URI,
-			Signer:      signer,
-			Label:       label,
+			Invite:            payload,
+			NodeDID:           nodeDID,
+			MemberDID:         ownerDID,
+			DelegateDID:       meta.DelegateDID,
+			RequestedBy:       identity.URI,
+			Signer:            signer,
+			Label:             label,
+			NodeEncryptionKey: identity.EncryptionPrivateKey,
 		}); err != nil {
 			return err
 		}
@@ -4190,12 +4191,13 @@ func setupOwnerNodeRequest(ctx context.Context, f upFlags, stateDir string, iden
 
 	label, _ := os.Hostname()
 	requestID, err := mesh.WriteOwnerNodeRequest(ctx, mesh.OwnerNodeRequestParams{
-		OwnerEndpoint: endpoint,
-		OwnerDID:      ownerDID,
-		NodeDID:       identity.URI,
-		Signer:        dwnSigner(identity),
-		Label:         label,
-		SourceDWN:     endpoint,
+		OwnerEndpoint:     endpoint,
+		OwnerDID:          ownerDID,
+		NodeDID:           identity.URI,
+		Signer:            dwnSigner(identity),
+		Label:             label,
+		SourceDWN:         endpoint,
+		NodeEncryptionKey: identity.EncryptionPrivateKey,
 	})
 	if err != nil {
 		ctx := adminContext{OwnerDID: ownerDID}

--- a/internal/control/dwnclient.go
+++ b/internal/control/dwnclient.go
@@ -10,6 +10,7 @@ import (
 	"net/netip"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/enboxorg/meshd/internal/dwn"
@@ -150,6 +151,17 @@ type DWNClient struct {
 
 	// peerEndpoints caches resolved DID → DWN endpoint mappings.
 	peerEndpoints map[string]*PeerEndpointInfo
+
+	// undecryptablePeers counts (cumulatively, across all state loads) node
+	// records whose data payload could not be decrypted — the visible symptom
+	// of a missing role-audience key delivery (issue #187). Tracked separately
+	// from droppedPeers because a record can fail to decrypt yet still surface a
+	// mesh IP via fallback, or decrypt yet lack a usable IP.
+	undecryptablePeers atomic.Int64
+
+	// droppedPeers counts (cumulatively) peers omitted from the network map
+	// because no mesh IP could be read or derived for them.
+	droppedPeers atomic.Int64
 }
 
 // NewDWNClient creates a new DWN-based control client.
@@ -195,6 +207,20 @@ func NewDWNClient(
 		nodes:           make(map[string]*NodeRecord),
 		peerEndpoints:   make(map[string]*PeerEndpointInfo),
 	}
+}
+
+// UndecryptablePeerCount returns the cumulative number of node records this
+// client has failed to decrypt since it was created. A non-zero, growing value
+// means role-audience keys are not reaching this node (issue #187): its peers
+// exist in the DWN but cannot be read, so they never enter the mesh map.
+func (c *DWNClient) UndecryptablePeerCount() int64 {
+	return c.undecryptablePeers.Load()
+}
+
+// DroppedPeerCount returns the cumulative number of peers omitted from the
+// network map because no mesh IP could be read or derived for them.
+func (c *DWNClient) DroppedPeerCount() int64 {
+	return c.droppedPeers.Load()
 }
 
 // readAuth builds the message auth for read queries at the given role. A
@@ -482,9 +508,16 @@ func (c *DWNClient) loadNodeEntry(ctx context.Context, entry json.RawMessage, de
 
 	var node NodeRecord
 	if err := ParseEntryData(entry, &node, decryptor); err != nil {
-		c.logger.DebugContext(ctx, "parsing node entry",
+		// An undecryptable peer node record is the visible symptom of a
+		// missing role-audience key delivery (issue #187): the record exists
+		// but this node was never handed the key to read it. Surface it at
+		// Warn (not Debug) and count it so operators can see peers silently
+		// dropping out of the mesh.
+		c.undecryptablePeers.Add(1)
+		c.logger.WarnContext(ctx, "node record could not be decrypted; peer will be invisible until a role-audience key is delivered",
 			slog.Any("error", err),
 			slog.String("nodeDID", nodeDID),
+			slog.String("memberRecordId", memberRecordID),
 		)
 		// Even if we can't decrypt the data payload, track the node DID
 		// from the unencrypted recipient field. This allows peer discovery
@@ -743,9 +776,12 @@ func (c *DWNClient) buildMapResponse() *MapResponse {
 
 		// Skip peers whose mesh IP cannot be read or derived. These
 		// "ghost" nodes are still tracked in c.nodes for auto key delivery
-		// purposes, but should not be injected into the network map.
+		// purposes, but should not be injected into the network map. A peer
+		// reaching here typically failed to decrypt (issue #187), so surface
+		// it at Warn and count it rather than swallowing at Debug.
 		if did != c.selfDID && !node.MeshIP.IsValid() {
-			c.logger.Debug("skipping undecryptable peer in network map",
+			c.droppedPeers.Add(1)
+			c.logger.Warn("dropping peer from network map: no mesh IP (record likely undecryptable — missing role-audience key)",
 				slog.String("did", did),
 			)
 			continue

--- a/internal/control/observability_test.go
+++ b/internal/control/observability_test.go
@@ -1,0 +1,135 @@
+package control
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
+)
+
+// captureHandler records the slog records emitted during a test so assertions
+// can check both the level and the attributes of a specific log line.
+type captureHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(string) slog.Handler       { return h }
+
+// warnFor reports whether a WARN record was emitted whose attributes include
+// nodeDID/did == wantDID.
+func (h *captureHandler) warnFor(wantDID string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, r := range h.records {
+		if r.Level != slog.LevelWarn {
+			continue
+		}
+		match := false
+		r.Attrs(func(a slog.Attr) bool {
+			if (a.Key == "nodeDID" || a.Key == "did") && a.Value.String() == wantDID {
+				match = true
+				return false
+			}
+			return true
+		})
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// An undecryptable node record is the visible symptom of a missing
+// role-audience key delivery (issue #187). loadNodeEntry must count it, warn
+// with the peer's DID, and still track the DID so key delivery can retry.
+func TestLoadNodeEntryCountsUndecryptablePeer(t *testing.T) {
+	handler := &captureHandler{}
+	c := &DWNClient{
+		nodes:  map[string]*NodeRecord{},
+		logger: slog.New(handler),
+	}
+
+	const peerDID = "did:jwk:peer-undecryptable"
+	entry := json.RawMessage(`{"recordsWrite":{"recordId":"peer-record",` +
+		`"descriptor":{"recipient":"` + peerDID + `"},` +
+		`"encodedData":"AAAA","encryption":{}}}`)
+	failing := func([]byte, *dwncrypto.Encryption) ([]byte, error) {
+		return nil, errors.New("no key material")
+	}
+
+	c.loadNodeEntry(context.Background(), entry, failing, "member-1")
+
+	if got := c.UndecryptablePeerCount(); got != 1 {
+		t.Fatalf("UndecryptablePeerCount = %d, want 1", got)
+	}
+	if !handler.warnFor(peerDID) {
+		t.Fatalf("expected a WARN log naming %q, got none", peerDID)
+	}
+	// The DID is still tracked (from the unencrypted recipient) so auto key
+	// delivery can target it on the next pass.
+	rec, ok := c.nodes[peerDID]
+	if !ok {
+		t.Fatalf("undecryptable peer %q was not tracked", peerDID)
+	}
+	if rec.RecordID != "peer-record" || rec.MemberRecordID != "member-1" {
+		t.Fatalf("tracked record = %+v, want recordId/memberRecordId set", rec)
+	}
+
+	// The counter is cumulative across loads.
+	c.loadNodeEntry(context.Background(), entry, failing, "member-1")
+	if got := c.UndecryptablePeerCount(); got != 2 {
+		t.Fatalf("UndecryptablePeerCount after second load = %d, want 2", got)
+	}
+}
+
+// A peer with no readable/derivable mesh IP is dropped from the network map.
+// buildMapResponse must count and warn instead of swallowing at Debug.
+func TestBuildMapResponseCountsDroppedPeer(t *testing.T) {
+	handler := &captureHandler{}
+	const selfDID = "did:jwk:self"
+	const peerDID = "did:jwk:ghost-peer"
+	c := &DWNClient{
+		selfDID: selfDID,
+		logger:  slog.New(handler),
+		// Empty MeshCIDR: no deterministic fallback IP can be derived, so a peer
+		// without a decrypted MeshIP has no valid address and must be dropped.
+		network: &NetworkConfig{Name: "test"},
+		nodes: map[string]*NodeRecord{
+			selfDID: {DID: selfDID, MeshIP: "10.200.0.2", RecordID: "self-record"},
+			peerDID: {DID: peerDID, RecordID: "ghost-record"},
+		},
+	}
+
+	resp := c.buildMapResponse()
+	if resp == nil {
+		t.Fatal("buildMapResponse returned nil")
+	}
+	if len(resp.Peers) != 0 {
+		t.Fatalf("peers = %d, want 0 (ghost peer dropped)", len(resp.Peers))
+	}
+	if got := c.DroppedPeerCount(); got != 1 {
+		t.Fatalf("DroppedPeerCount = %d, want 1", got)
+	}
+	if !handler.warnFor(peerDID) {
+		t.Fatalf("expected a WARN log naming dropped peer %q, got none", peerDID)
+	}
+	if !strings.HasPrefix(resp.Node.DID, "did:jwk:self") {
+		t.Fatalf("self node = %+v, want self retained", resp.Node)
+	}
+}

--- a/internal/dwn/crypto/roleaudience.go
+++ b/internal/dwn/crypto/roleaudience.go
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -18,6 +19,35 @@ func DeriveRolePathKey(rootPrivateKey []byte, protocol, rolePath string) (privat
 	segments := splitProtocolPath(rolePath)
 	path := BuildProtocolPathDerivation(protocol, segments...)
 	return DeriveKeyBytes(rootPrivateKey, path)
+}
+
+// RolePathPublicKeyJWK derives the PUBLIC half of a role-path X25519 key from a
+// root #enc key and returns it as a PublicKeyJWK. It is the public counterpart of
+// DeriveRolePathKey and is byte-identical to the `$keyAgreement.publicKeyJwk` that
+// InjectEncryptionDirectives publishes at the same protocol/rolePath (both walk
+// the same HKDF chain via BuildProtocolPathDerivation).
+//
+// A role holder emits this so an owner can wrap an `$encryption/delivery` record
+// to it WITHOUT resolving the holder's DWN — the delivery is key transport to an
+// already role-authorized reader, so a self-asserted key grants no new authority.
+// The `kid` member is intentionally omitted to match the injected wire shape
+// ({kty, crv, x} only); consumers recompute the thumbprint from `x`.
+func RolePathPublicKeyJWK(rootPrivateKey []byte, protocol, rolePath string) (PublicKeyJWK, error) {
+	priv, err := DeriveRolePathKey(rootPrivateKey, protocol, rolePath)
+	if err != nil {
+		return PublicKeyJWK{}, err
+	}
+	defer clear(priv) // Only the public half is published; zero the derived private key.
+
+	pub, err := X25519PublicKey(priv)
+	if err != nil {
+		return PublicKeyJWK{}, err
+	}
+	return PublicKeyJWK{
+		KTY: "OKP",
+		CRV: "X25519",
+		X:   base64.RawURLEncoding.EncodeToString(pub),
+	}, nil
 }
 
 // RoleAudienceDecrypter decrypts roleAudience-encrypted records with a fixed

--- a/internal/dwn/crypto/roleaudience_publickey_test.go
+++ b/internal/dwn/crypto/roleaudience_publickey_test.go
@@ -1,0 +1,119 @@
+package crypto
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestRolePathPublicKeyJWKMatchesInjectedKeyAgreement is the load-bearing guard
+// for issue #187: the PUBLIC role-path key a node emits in its join request must
+// be byte-identical to the `$keyAgreement.publicKeyJwk` that
+// InjectEncryptionDirectives publishes at the same path. If the two diverge, an
+// owner wraps the `$encryption/delivery` record to the wrong key and the node
+// silently fails to decrypt — the exact failure mode #187 exists to remove.
+func TestRolePathPublicKeyJWKMatchesInjectedKeyAgreement(t *testing.T) {
+	root, _, err := GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("GenerateX25519KeyPair: %v", err)
+	}
+	const protocol = "https://example.com/p"
+	// Mirrors the wireguard-mesh hierarchy for the node-held role paths.
+	definition := json.RawMessage(`{
+		"protocol": "https://example.com/p",
+		"structure": { "network": { "member": { "node": {} }, "node": {} } }
+	}`)
+
+	out, err := InjectEncryptionDirectives(definition, root)
+	if err != nil {
+		t.Fatalf("InjectEncryptionDirectives: %v", err)
+	}
+	var def map[string]any
+	if err := json.Unmarshal(out, &def); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	for _, rolePath := range []string{"network/node", "network/member/node"} {
+		injected := injectedKeyAgreementX(t, def, rolePath)
+
+		jwk, err := RolePathPublicKeyJWK(root, protocol, rolePath)
+		if err != nil {
+			t.Fatalf("RolePathPublicKeyJWK(%s): %v", rolePath, err)
+		}
+		if jwk.KTY != "OKP" || jwk.CRV != "X25519" {
+			t.Fatalf("%s: jwk kty/crv = %s/%s, want OKP/X25519", rolePath, jwk.KTY, jwk.CRV)
+		}
+		if jwk.KID != "" {
+			t.Fatalf("%s: jwk must omit kid to match the injected wire shape, got %q", rolePath, jwk.KID)
+		}
+		if jwk.X != injected {
+			t.Fatalf("%s: RolePathPublicKeyJWK x = %s, want injected %s", rolePath, jwk.X, injected)
+		}
+		raw, err := base64.RawURLEncoding.DecodeString(jwk.X)
+		if err != nil || len(raw) != 32 {
+			t.Fatalf("%s: x is not a 32-byte base64url key (len=%d err=%v)", rolePath, len(raw), err)
+		}
+	}
+}
+
+// TestRolePathPublicKeyJWKIsContextIndependent proves a node can precompute the
+// network/member/node key before any approval assigns a member layer: the public
+// key depends only on protocol + rolePath, never on a record/context id.
+func TestRolePathPublicKeyJWKIsContextIndependent(t *testing.T) {
+	root, _, err := GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("GenerateX25519KeyPair: %v", err)
+	}
+	const protocol = "https://example.com/p"
+	a, err := RolePathPublicKeyJWK(root, protocol, "network/member/node")
+	if err != nil {
+		t.Fatalf("RolePathPublicKeyJWK a: %v", err)
+	}
+	b, err := RolePathPublicKeyJWK(root, protocol, "network/member/node")
+	if err != nil {
+		t.Fatalf("RolePathPublicKeyJWK b: %v", err)
+	}
+	if a.X != b.X {
+		t.Fatalf("role-path key is not deterministic: %s vs %s", a.X, b.X)
+	}
+	// A different rolePath yields a different key (no accidental collision).
+	other, err := RolePathPublicKeyJWK(root, protocol, "network/node")
+	if err != nil {
+		t.Fatalf("RolePathPublicKeyJWK other: %v", err)
+	}
+	if other.X == a.X {
+		t.Fatalf("network/node and network/member/node derived the same key: %s", a.X)
+	}
+}
+
+// injectedKeyAgreementX walks an injected definition to the
+// $keyAgreement.publicKeyJwk.x at a slash-delimited role path.
+func injectedKeyAgreementX(t *testing.T, def map[string]any, rolePath string) string {
+	t.Helper()
+	node, ok := def["structure"].(map[string]any)
+	if !ok {
+		t.Fatalf("definition missing structure")
+	}
+	segs := strings.Split(rolePath, "/")
+	for i, seg := range segs {
+		child, ok := node[seg].(map[string]any)
+		if !ok {
+			t.Fatalf("path %s: missing segment %q", rolePath, seg)
+		}
+		if i == len(segs)-1 {
+			ka, ok := child["$keyAgreement"].(map[string]any)
+			if !ok {
+				t.Fatalf("path %s: missing $keyAgreement", rolePath)
+			}
+			pub, ok := ka["publicKeyJwk"].(map[string]any)
+			if !ok {
+				t.Fatalf("path %s: $keyAgreement missing publicKeyJwk", rolePath)
+			}
+			x, _ := pub["x"].(string)
+			return x
+		}
+		node = child
+	}
+	return ""
+}

--- a/internal/mesh/owner_request.go
+++ b/internal/mesh/owner_request.go
@@ -21,6 +21,10 @@ type OwnerNodeRequestParams struct {
 	Signer        *dwn.Signer
 	Label         string
 	SourceDWN     string
+	// NodeEncryptionKey is the node's root #enc X25519 private key. When set, the
+	// node's role-path public keys are derived and emitted so a DWN-less owner can
+	// deliver role-audience keys to it (see issue #187). Never leaves the node.
+	NodeEncryptionKey []byte
 }
 
 // NodeApprovalData is the root nodeApproval payload written by the owner
@@ -92,6 +96,11 @@ func ownerNodeRequestData(params OwnerNodeRequestParams) (NodeRequestData, error
 		return NodeRequestData{}, fmt.Errorf("node signer DID %s does not match node DID %s", params.Signer.DID, params.NodeDID)
 	}
 
+	roleKeys, err := nodeRoleKeys(params.NodeEncryptionKey)
+	if err != nil {
+		return NodeRequestData{}, err
+	}
+
 	requestedAt := time.Now().UTC().Format(time.RFC3339)
 	return NodeRequestData{
 		NodeDID:     params.NodeDID,
@@ -103,6 +112,7 @@ func ownerNodeRequestData(params OwnerNodeRequestParams) (NodeRequestData, error
 		SourceDWN:   params.SourceDWN,
 		Label:       params.Label,
 		RequestedAt: requestedAt,
+		RoleKeys:    roleKeys,
 	}, nil
 }
 

--- a/internal/mesh/preauth.go
+++ b/internal/mesh/preauth.go
@@ -45,6 +45,15 @@ type NodeRequestData struct {
 	PreAuthProof    string `json:"preAuthProof,omitempty"`
 	RequestedAt     string `json:"requestedAt,omitempty"`
 	ExpiresAt       string `json:"expiresAt,omitempty"`
+
+	// RoleKeys carries the PUBLIC halves of the node's own role-path X25519 keys,
+	// keyed by full protocol role path (e.g. "network/node"). A did:jwk node
+	// publishes no DWN endpoint, so an owner/dashboard cannot resolve these keys by
+	// DID; the node supplies them here so the owner can wrap each
+	// $encryption/delivery record to the recipient node without a DWN lookup. Each
+	// value is byte-identical to the $keyAgreement.publicKeyJwk the node injects
+	// into its own protocol definition (see dwncrypto.RolePathPublicKeyJWK).
+	RoleKeys map[string]dwncrypto.PublicKeyJWK `json:"roleKeys,omitempty"`
 }
 
 func (r NodeRequestData) EffectiveOwnerDID() string {
@@ -55,6 +64,33 @@ func (r NodeRequestData) EffectiveOwnerDID() string {
 		return r.MemberDID
 	}
 	return r.NodeDID
+}
+
+// nodeRoleKeyPaths are the mesh $role paths a node HOLDS (their delivery recipient
+// is the node itself). "network/member" is deliberately excluded: its recipient is
+// the member/owner DID, a different identity whose key the node cannot assert. The
+// node cannot know at join time whether approval places it under a member layer
+// (network/member/node) or directly (network/node) — deliverJoinerAudienceKeys
+// decides per-approval — so it publishes both candidate public keys.
+var nodeRoleKeyPaths = []string{"network/node", "network/member/node"}
+
+// nodeRoleKeys derives the PUBLIC halves of the node's own role-path keys from its
+// root #enc key, for delivery to it without a DWN lookup. Returns nil (field
+// omitted) when no encryption key is available, so nodes/paths that don't emit keys
+// stay wire-compatible.
+func nodeRoleKeys(encryptionKey []byte) (map[string]dwncrypto.PublicKeyJWK, error) {
+	if len(encryptionKey) == 0 {
+		return nil, nil
+	}
+	keys := make(map[string]dwncrypto.PublicKeyJWK, len(nodeRoleKeyPaths))
+	for _, rolePath := range nodeRoleKeyPaths {
+		jwk, err := dwncrypto.RolePathPublicKeyJWK(encryptionKey, protocols.MeshProtocolURI, rolePath)
+		if err != nil {
+			return nil, fmt.Errorf("deriving role-path public key for %q: %w", rolePath, err)
+		}
+		keys[rolePath] = jwk
+	}
+	return keys, nil
 }
 
 // CreatePreAuthKeyParams configures preauth token creation.
@@ -175,6 +211,10 @@ type WritePreAuthNodeRequestParams struct {
 	Signer      *dwn.Signer
 	Label       string
 	SourceDWN   string
+	// NodeEncryptionKey is the node's root #enc X25519 private key, used to derive
+	// the PUBLIC role-path keys published in the request's roleKeys. Optional: when
+	// empty, roleKeys is omitted (older behavior).
+	NodeEncryptionKey []byte
 }
 
 // WritePreAuthNodeRequest writes a network/nodeRequest claim to the anchor DWN.
@@ -230,6 +270,11 @@ func preAuthNodeRequestData(params WritePreAuthNodeRequestParams) (NodeRequestDa
 		nodeProof = SignNodeJoinProof(params.Signer, params.Invite.NetworkID, params.NodeDID, memberDID, params.Invite.TokenID)
 	}
 
+	roleKeys, err := nodeRoleKeys(params.NodeEncryptionKey)
+	if err != nil {
+		return NodeRequestData{}, err
+	}
+
 	return NodeRequestData{
 		NodeDID:         params.NodeDID,
 		MemberDID:       memberDID,
@@ -245,6 +290,7 @@ func preAuthNodeRequestData(params WritePreAuthNodeRequestParams) (NodeRequestDa
 		PreAuthKeyID:    params.Invite.TokenID,
 		PreAuthProof:    invite.Proof(params.Invite.Secret, params.Invite.NetworkID, params.NodeDID),
 		RequestedAt:     time.Now().UTC().Format(time.RFC3339),
+		RoleKeys:        roleKeys,
 	}, nil
 }
 

--- a/internal/mesh/rolekeys_test.go
+++ b/internal/mesh/rolekeys_test.go
@@ -1,0 +1,257 @@
+package mesh
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/enboxorg/meshd/internal/dwn"
+	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
+	"github.com/enboxorg/meshd/internal/invite"
+	"github.com/enboxorg/meshd/protocols"
+)
+
+// A did:jwk node publishes no DWN endpoint, so the owner cannot resolve its
+// role-path keys by DID. The node must therefore emit exactly the role paths it
+// HOLDS — network/node and network/member/node — and never network/member,
+// whose recipient is a different identity (the member/owner DID).
+func TestNodeRoleKeysEmitsExactlyNodeHeldPaths(t *testing.T) {
+	root, _, err := dwncrypto.GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("GenerateX25519KeyPair: %v", err)
+	}
+
+	keys, err := nodeRoleKeys(root)
+	if err != nil {
+		t.Fatalf("nodeRoleKeys: %v", err)
+	}
+
+	want := map[string]bool{"network/node": true, "network/member/node": true}
+	if len(keys) != len(want) {
+		t.Fatalf("nodeRoleKeys returned %d paths (%v), want exactly %v", len(keys), keysOf(keys), keysOf(mapKeys(want)))
+	}
+	if _, bad := keys["network/member"]; bad {
+		t.Fatal("nodeRoleKeys must not emit network/member: its recipient is the member DID, not the node")
+	}
+	for path := range want {
+		jwk, ok := keys[path]
+		if !ok {
+			t.Fatalf("nodeRoleKeys missing required path %q", path)
+		}
+		if jwk.KTY != "OKP" || jwk.CRV != "X25519" {
+			t.Fatalf("%s: kty/crv = %s/%s, want OKP/X25519", path, jwk.KTY, jwk.CRV)
+		}
+		if jwk.KID != "" {
+			t.Fatalf("%s: kid must be empty to match the injected wire shape, got %q", path, jwk.KID)
+		}
+		raw, err := base64.RawURLEncoding.DecodeString(jwk.X)
+		if err != nil || len(raw) != 32 {
+			t.Fatalf("%s: x is not a 32-byte base64url key (len=%d err=%v)", path, len(raw), err)
+		}
+	}
+}
+
+// Nodes without an encryption key (or callers that opt out) must omit roleKeys
+// entirely so the request stays wire-compatible with older readers.
+func TestNodeRoleKeysEmptyKeyOmitsField(t *testing.T) {
+	for _, key := range [][]byte{nil, {}} {
+		keys, err := nodeRoleKeys(key)
+		if err != nil {
+			t.Fatalf("nodeRoleKeys(%v): %v", key, err)
+		}
+		if keys != nil {
+			t.Fatalf("nodeRoleKeys(%v) = %v, want nil", key, keys)
+		}
+	}
+}
+
+// The public key a node emits per role path must be byte-identical to the
+// $keyAgreement.publicKeyJwk the same node injects into the REAL mesh protocol
+// definition — otherwise the owner wraps the delivery to the wrong key and the
+// node silently fails to decrypt (issue #187).
+func TestNodeRoleKeysMatchInjectedMeshProtocol(t *testing.T) {
+	root, _, err := dwncrypto.GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("GenerateX25519KeyPair: %v", err)
+	}
+
+	injected, err := dwncrypto.InjectEncryptionDirectives(protocols.MeshProtocolJSON, root)
+	if err != nil {
+		t.Fatalf("InjectEncryptionDirectives: %v", err)
+	}
+	var def map[string]any
+	if err := json.Unmarshal(injected, &def); err != nil {
+		t.Fatalf("unmarshal injected definition: %v", err)
+	}
+
+	keys, err := nodeRoleKeys(root)
+	if err != nil {
+		t.Fatalf("nodeRoleKeys: %v", err)
+	}
+	for path, jwk := range keys {
+		want := injectedKeyAgreementX(t, def, path)
+		if want == "" {
+			t.Fatalf("real mesh protocol has no $keyAgreement at %q", path)
+		}
+		if jwk.X != want {
+			t.Fatalf("%s: emitted x = %s, want injected %s", path, jwk.X, want)
+		}
+	}
+}
+
+func TestPreAuthNodeRequestDataPopulatesRoleKeys(t *testing.T) {
+	node := preAuthTestDID(t)
+	base := WritePreAuthNodeRequestParams{
+		Invite:  invite.Payload{NetworkID: "net-1", TokenID: "tok-1"},
+		NodeDID: node.URI,
+		Signer:  &dwn.Signer{DID: node.URI, PrivateKey: node.SigningKey},
+	}
+
+	withKey := base
+	withKey.NodeEncryptionKey = node.EncryptionPrivateKey
+	data, err := preAuthNodeRequestData(withKey)
+	if err != nil {
+		t.Fatalf("preAuthNodeRequestData(with key): %v", err)
+	}
+	assertNodeHeldRoleKeys(t, node.EncryptionPrivateKey, data.RoleKeys)
+
+	data, err = preAuthNodeRequestData(base)
+	if err != nil {
+		t.Fatalf("preAuthNodeRequestData(no key): %v", err)
+	}
+	if data.RoleKeys != nil {
+		t.Fatalf("RoleKeys = %v, want nil when no encryption key supplied", data.RoleKeys)
+	}
+}
+
+func TestOwnerNodeRequestDataPopulatesRoleKeys(t *testing.T) {
+	node := preAuthTestDID(t)
+	owner := preAuthTestDID(t)
+	base := OwnerNodeRequestParams{
+		OwnerEndpoint: "https://owner.example",
+		OwnerDID:      owner.URI,
+		NodeDID:       node.URI,
+		Signer:        &dwn.Signer{DID: node.URI, PrivateKey: node.SigningKey},
+	}
+
+	withKey := base
+	withKey.NodeEncryptionKey = node.EncryptionPrivateKey
+	data, err := ownerNodeRequestData(withKey)
+	if err != nil {
+		t.Fatalf("ownerNodeRequestData(with key): %v", err)
+	}
+	assertNodeHeldRoleKeys(t, node.EncryptionPrivateKey, data.RoleKeys)
+
+	data, err = ownerNodeRequestData(base)
+	if err != nil {
+		t.Fatalf("ownerNodeRequestData(no key): %v", err)
+	}
+	if data.RoleKeys != nil {
+		t.Fatalf("RoleKeys = %v, want nil when no encryption key supplied", data.RoleKeys)
+	}
+}
+
+// RoleKeys must survive a JSON round-trip (the record is marshaled to the DWN
+// and re-read by the owner), and must be omitted from the wire when empty.
+func TestNodeRequestDataRoleKeysJSONRoundTrip(t *testing.T) {
+	root, _, err := dwncrypto.GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("GenerateX25519KeyPair: %v", err)
+	}
+	keys, err := nodeRoleKeys(root)
+	if err != nil {
+		t.Fatalf("nodeRoleKeys: %v", err)
+	}
+
+	in := NodeRequestData{NodeDID: "did:jwk:node", RoleKeys: keys}
+	blob, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out NodeRequestData
+	if err := json.Unmarshal(blob, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for path, want := range keys {
+		got, ok := out.RoleKeys[path]
+		if !ok {
+			t.Fatalf("round-trip lost path %q", path)
+		}
+		if got != want {
+			t.Fatalf("%s: round-trip = %+v, want %+v", path, got, want)
+		}
+	}
+
+	// Empty RoleKeys must be omitted (omitempty) so the field is absent on the wire.
+	empty, err := json.Marshal(NodeRequestData{NodeDID: "did:jwk:node"})
+	if err != nil {
+		t.Fatalf("marshal empty: %v", err)
+	}
+	if strings.Contains(string(empty), "roleKeys") {
+		t.Fatalf("empty NodeRequestData emitted roleKeys: %s", empty)
+	}
+}
+
+func assertNodeHeldRoleKeys(t *testing.T, root []byte, got map[string]dwncrypto.PublicKeyJWK) {
+	t.Helper()
+	want, err := nodeRoleKeys(root)
+	if err != nil {
+		t.Fatalf("nodeRoleKeys: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("role keys = %v, want %v", keysOf(got), keysOf(want))
+	}
+	for path, wantJWK := range want {
+		if got[path] != wantJWK {
+			t.Fatalf("%s: got %+v, want %+v", path, got[path], wantJWK)
+		}
+	}
+}
+
+func keysOf(m map[string]dwncrypto.PublicKeyJWK) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func mapKeys(m map[string]bool) map[string]dwncrypto.PublicKeyJWK {
+	out := make(map[string]dwncrypto.PublicKeyJWK, len(m))
+	for k := range m {
+		out[k] = dwncrypto.PublicKeyJWK{}
+	}
+	return out
+}
+
+// injectedKeyAgreementX walks an injected mesh definition to the
+// $keyAgreement.publicKeyJwk.x at a slash-delimited role path.
+func injectedKeyAgreementX(t *testing.T, def map[string]any, rolePath string) string {
+	t.Helper()
+	node, ok := def["structure"].(map[string]any)
+	if !ok {
+		t.Fatalf("definition missing structure")
+	}
+	segs := strings.Split(rolePath, "/")
+	for i, seg := range segs {
+		child, ok := node[seg].(map[string]any)
+		if !ok {
+			return ""
+		}
+		if i == len(segs)-1 {
+			ka, ok := child["$keyAgreement"].(map[string]any)
+			if !ok {
+				return ""
+			}
+			pub, ok := ka["publicKeyJwk"].(map[string]any)
+			if !ok {
+				return ""
+			}
+			x, _ := pub["x"].(string)
+			return x
+		}
+		node = child
+	}
+	return ""
+}

--- a/schemas/node-request.json
+++ b/schemas/node-request.json
@@ -81,6 +81,30 @@
         }
       }
     },
+    "roleKeys": {
+      "type": "object",
+      "description": "PUBLIC halves of the node's own role-path X25519 keys, keyed by full protocol role path (e.g. \"network/node\"). A did:jwk node publishes no DWN endpoint, so the owner/dashboard cannot resolve these keys by DID; the node supplies them here so each $encryption/delivery record can be wrapped to the recipient node without a DWN lookup. Each value is byte-identical to the $keyAgreement.publicKeyJwk the node injects at the same role path.",
+      "propertyNames": {
+        "pattern": "^[A-Za-z0-9]+(/[A-Za-z0-9]+)*$"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "required": ["kty", "crv", "x"],
+        "additionalProperties": true,
+        "properties": {
+          "kty": { "type": "string", "const": "OKP" },
+          "crv": { "type": "string", "const": "X25519" },
+          "x": {
+            "type": "string",
+            "description": "Base64url-encoded X25519 public key derived at this role path"
+          },
+          "kid": {
+            "type": "string",
+            "description": "Optional key ID; omitted to match the injected $keyAgreement wire shape"
+          }
+        }
+      }
+    },
     "preAuthKeyId": {
       "type": "string",
       "description": "Record ID of the encrypted pre-auth key used for this request"


### PR DESCRIPTION
## Summary

Producer half of #187 — *Deliver role-audience keys to endpoint-less `did:jwk` nodes.*

A `did:jwk` node publishes **no DWN endpoint**, so an owner/dashboard cannot resolve that node's role-path X25519 keys by DID and cannot wrap its `$encryption/delivery` records to the correct recipient key. The delivery is silently skipped, and the joined node can never decrypt its peers — it sees only itself in `meshd peer list`.

This PR makes the node **carry the PUBLIC halves of the role paths it holds** in its signed join request, so a DWN-less owner can hand them to the SDK's `recipientRolePublicKey` when writing deliveries (the SDK consumer half shipped in `@enbox/agent` and is release-gated on the dashboard side).

## What changed

- **`dwncrypto.RolePathPublicKeyJWK`** — public counterpart of `DeriveRolePathKey`. Byte-identical to the `$keyAgreement.publicKeyJwk` that `InjectEncryptionDirectives` publishes at the same protocol/rolePath (both walk the same HKDF chain). Emits `{kty, crv, x}` with **no `kid`** to match the injected wire shape.
- **`NodeRequestData.RoleKeys`** (`map[rolePath]PublicKeyJWK`, `omitempty`) — populated by **both** request builders (`preAuthNodeRequestData` for preauth joins, `ownerNodeRequestData` for owner-node) from the node's root `#enc` key, threaded through from both `cmd/meshd` call sites.
  - Emits exactly the **node-held** paths `network/node` and `network/member/node`. `network/member` is deliberately excluded — its recipient is the member/owner DID, a different identity whose key the node cannot assert.
  - The node can't know at join time whether approval places it under a member layer, so it publishes both candidate keys; the approver picks per-approval.
  - **Absent encryption key ⇒ field omitted**, so older readers stay wire-compatible (inert-safe: there is no Go-side JSON-Schema validator, and the field is `omitempty`).
- **`schemas/node-request.json`** — documents the `roleKeys` contract (the top-level `additionalProperties:false` means it must be declared).
- **Observability (`internal/control`)** — the DWN control client now counts undecryptable node records and peers dropped from the network map (cumulative `atomic.Int64` + `UndecryptablePeerCount()` / `DroppedPeerCount()` accessors), and logs **both at `Warn` instead of `Debug`** so the #187 failure mode is visible instead of silently swallowed.

## Testing

New tests:
- **crypto**: role-path public key matches the injected `$keyAgreement` at `network/node` and `network/member/node`; context-independence.
- **mesh**: emits exactly the node-held path set (not `network/member`); empty key omits the field; equivalence against the **real** mesh protocol; both builders populate `RoleKeys`; JSON round-trip preserves keys and omits when empty.
- **control**: `loadNodeEntry` counts + `Warn`s undecryptable peers (and still tracks the DID for retry); `buildMapResponse` counts + `Warn`s dropped ghost peers; counters are cumulative.

All green:

```
go build ./...            # zero errors
go vet ./...              # zero warnings
go test ./... -count=1 -race   # all pass
```

## Scope / follow-ups (not in this PR)

- Dashboard admin-dapp consuming `roleKeys` + supplying `recipientRolePublicKey` + hard-fail on approve — release-gated on the `@enbox/agent` publish, then re-vendor + e2e.
- rolePath reconciliation (which candidate key the dashboard selects), and binding `roleKeys` into the signed `nodeProof`.

Closes #187 (producer side; tracks remaining consumer/dashboard work in the issue).