### PR TITLE
fix(mesh): deliver the network/member reading-role audience to did:jwk nodes

### DIFF
--- a/admin-dapp/src/meshd/admin.test.ts
+++ b/admin-dapp/src/meshd/admin.test.ts
@@ -693,13 +693,26 @@ describe("meshd node role-audience key delivery (#187)", () => {
     expect(parseMeshdNodeRequestRecord(raw)?.roleKeys).toBeUndefined();
   });
 
-  it("supplies the node's role-audience key on the member/node write and approves", async () => {
+  it("delivers the network/member reading-role audience to the node and approves", async () => {
     const { session, requests } = createFakeSession({ recordIds: ["member-rec", "node-rec", "approval-rec"] });
-    const request = await signedOwnerNodeRequest({ ownerDID: "did:example:owner", roleKeys: { "network/member/node": VALID_X25519_KEY } });
+    const request = await signedOwnerNodeRequest({
+      ownerDID: "did:example:owner",
+      roleKeys: { "network/member": VALID_X25519_KEY, "network/member/node": VALID_X25519_KEY }
+    });
 
     const result = await approveMeshdNodeRequest(session, network, request);
     expect(result.nodeRecordId).toBe("node-rec");
 
+    // The network/member role record — the reading-role audience peer records are
+    // encrypted to — is written with the node's supplied key so its delivery reaches
+    // the node (#192).
+    const memberWrite = requests.find(
+      (r) => r.messageType === DwnInterface.RecordsWrite && r.messageParams?.protocolPath === "network/member"
+    );
+    expect(memberWrite).toBeDefined();
+    expect(memberWrite!.recipientRolePublicKey).toEqual(VALID_X25519_KEY);
+
+    // The network/member/node role record is still written with its own key.
     const nodeWrite = requests.find(
       (r) => r.messageType === DwnInterface.RecordsWrite && r.messageParams?.protocolPath === "network/member/node"
     );
@@ -707,39 +720,66 @@ describe("meshd node role-audience key delivery (#187)", () => {
     expect(nodeWrite!.recipientRolePublicKey).toEqual(VALID_X25519_KEY);
     expect(nodeWrite!.messageParams.recipient).toBe(request.nodeDID);
 
-    // The node record is NOT rolled back on a successful delivery.
-    const nodeDeletes = requests.filter(
-      (r) => r.messageType === DwnInterface.RecordsDelete && r.messageParams?.recordId === "node-rec"
+    // Neither role record is rolled back on successful delivery (the original
+    // nodeRequest record is still cleaned up, so only the role records are checked).
+    const roleDeletes = requests.filter(
+      (r) => r.messageType === DwnInterface.RecordsDelete &&
+        (r.messageParams?.recordId === "member-rec" || r.messageParams?.recordId === "node-rec")
     );
-    expect(nodeDeletes).toHaveLength(0);
+    expect(roleDeletes).toHaveLength(0);
   });
 
-  it("refuses to approve a node that did not supply role keys (fail-fast)", async () => {
+  it("refuses to approve a node that supplied no role keys (fail-fast)", async () => {
     const { session, requests } = createFakeSession();
     const request = await signedOwnerNodeRequest({ ownerDID: "did:example:owner" }); // no roleKeys
 
-    await expect(approveMeshdNodeRequest(session, network, request)).rejects.toThrow(/did not include.*role-audience key|#187/i);
+    await expect(approveMeshdNodeRequest(session, network, request)).rejects.toThrow(/did not include.*role-audience key/i);
 
-    // The node record write is never reached.
-    const nodeWrite = requests.find(
-      (r) => r.messageType === DwnInterface.RecordsWrite && r.messageParams?.protocolPath === "network/member/node"
+    // No role record is written.
+    const roleWrite = requests.find(
+      (r) => r.messageType === DwnInterface.RecordsWrite &&
+        (r.messageParams?.protocolPath === "network/member" || r.messageParams?.protocolPath === "network/member/node")
     );
-    expect(nodeWrite).toBeUndefined();
+    expect(roleWrite).toBeUndefined();
   });
 
-  it("rolls back the node record and fails when the key could not be delivered", async () => {
+  it("refuses to approve when the network/member reading-role key is missing (fail-fast)", async () => {
+    const { session, requests } = createFakeSession();
+    // Supplies only the held-role key, not the reading-role key it decrypts peers with.
+    const request = await signedOwnerNodeRequest({
+      ownerDID: "did:example:owner",
+      roleKeys: { "network/member/node": VALID_X25519_KEY }
+    });
+
+    await expect(approveMeshdNodeRequest(session, network, request)).rejects.toThrow(/network\/member role-audience key/i);
+
+    const memberWrite = requests.find(
+      (r) => r.messageType === DwnInterface.RecordsWrite && r.messageParams?.protocolPath === "network/member"
+    );
+    expect(memberWrite).toBeUndefined();
+  });
+
+  it("rolls back the member record and fails when the reading-role audience could not be delivered", async () => {
     const { session, requests } = createFakeSession({
       recordIds: ["member-rec", "node-rec", "approval-rec"],
       audienceKeyDelivery: { delivered: false, recipientDid: "did:jwk:node", reason: "no seal coverage" }
     });
-    const request = await signedOwnerNodeRequest({ ownerDID: "did:example:owner", roleKeys: { "network/member/node": VALID_X25519_KEY } });
+    const request = await signedOwnerNodeRequest({
+      ownerDID: "did:example:owner",
+      roleKeys: { "network/member": VALID_X25519_KEY, "network/member/node": VALID_X25519_KEY }
+    });
 
     await expect(approveMeshdNodeRequest(session, network, request)).rejects.toThrow(/could not deliver.*rolled back|no seal coverage/i);
 
-    // The just-written node record is deleted with the dashboard's own delete grant.
-    const nodeDeletes = requests.filter(
-      (r) => r.messageType === DwnInterface.RecordsDelete && r.messageParams?.recordId === "node-rec"
+    // The network/member record — written first — is rolled back with the dashboard's
+    // own delete grant; the node record write is never reached.
+    const memberDeletes = requests.filter(
+      (r) => r.messageType === DwnInterface.RecordsDelete && r.messageParams?.recordId === "member-rec"
     );
-    expect(nodeDeletes).toHaveLength(1);
+    expect(memberDeletes).toHaveLength(1);
+    const nodeWrite = requests.find(
+      (r) => r.messageType === DwnInterface.RecordsWrite && r.messageParams?.protocolPath === "network/member/node"
+    );
+    expect(nodeWrite).toBeUndefined();
   });
 });

--- a/admin-dapp/src/meshd/admin.ts
+++ b/admin-dapp/src/meshd/admin.ts
@@ -1085,6 +1085,7 @@ async function ensureMemberRecord(
   session: MeshdAdminSession,
   network: MeshdNetworkSummary,
   nodeOwnerDID: string,
+  recipientRolePublicKey: RolePublicKeyJwk,
   label?: string
 ): Promise<AuthoredRecord> {
   const existingEntries = await queryRecords(
@@ -1098,13 +1099,24 @@ async function ensureMemberRecord(
     .map(parseMeshdMemberRecord)
     .find((member) => member?.did === nodeOwnerDID);
   if (existing) {
+    // The network/member role record — and its network/member `$encryption/delivery`
+    // to this recipient — already exists from a prior approval. For a self-owned node
+    // the member DID is the node DID, so that delivery already reached the node; nothing
+    // to re-provision. (A distinct-human-member layer delivering to a NEW node under an
+    // existing member is a separate case — see #192.)
     return {
       recordId: existing.recordId,
       dateCreated: existing.createdAt
     };
   }
 
-  return writeRecord(
+  // Peer node records grant can:read to network/member (and network/node); a
+  // member-invited did:jwk node authorizes as network/member, so it must recover the
+  // network/member audience to decrypt its peers. Writing the network/member role
+  // record with the node's supplied network/member role-path key mints that audience
+  // and delivers it to the node — the reading-role audience, distinct from the
+  // network/member/node role the node merely holds (issue #192).
+  const memberRecord = await writeRecord(
     session,
     MESHD_PROTOCOL_URI,
     {
@@ -1119,8 +1131,24 @@ async function ensureMemberRecord(
       addedAt: new Date().toISOString(),
       ...(label ? { label } : {})
     },
-    true
+    true,
+    recipientRolePublicKey
   );
+
+  // Best-effort delivery is reported, not thrown (like the node record). Enforce it and
+  // roll back with the dashboard's own delete grant so the operator can retry cleanly —
+  // a member without its reading-role audience delivered can never see its peers.
+  if (!memberRecord.audienceKeyDelivery?.delivered) {
+    const reason = memberRecord.audienceKeyDelivery?.reason ?? "no delivery outcome was reported";
+    await deleteRecord(session, MESHD_PROTOCOL_URI, memberRecord.recordId, false);
+    throw new Error(
+      `Approved node ${nodeOwnerDID} but could not deliver its network/member reading-role ` +
+      `audience key (${reason}); the member record was rolled back so you can retry. The node ` +
+      "cannot decrypt its peers until this delivery succeeds."
+    );
+  }
+
+  return memberRecord;
 }
 
 export async function approveMeshdNodeRequest(
@@ -1140,7 +1168,23 @@ export async function approveMeshdNodeRequest(
 
   const preAuthKey = ownerScopedRequest ? undefined : await readPreAuthKey(session, network, request);
   const requestOwnerDID = nodeOwnerDID(request);
-  const member = await ensureMemberRecord(session, network, requestOwnerDID, request.label);
+
+  // The node authorizes as network/member and its peer records are encrypted to the
+  // network/member audience, so that reading-role audience must be delivered to it. A
+  // did:jwk node has no DWN endpoint to resolve its role-path key from, so it supplies
+  // the network/member key in its join request (#192); refuse to approve without it —
+  // the node would silently never decrypt its peers.
+  const MEMBER_ROLE_PATH = "network/member";
+  const memberRolePublicKey = request.roleKeys?.[MEMBER_ROLE_PATH];
+  if (!memberRolePublicKey) {
+    throw new Error(
+      `Node ${request.nodeDID} did not include its ${MEMBER_ROLE_PATH} role-audience key, so the ` +
+      "reading-role audience its peers are encrypted to cannot be delivered and it would never " +
+      "decrypt its peers. Upgrade the meshd node to a build that publishes the network/member " +
+      "roleKey in its join request (#192)."
+    );
+  }
+  const member = await ensureMemberRecord(session, network, requestOwnerDID, memberRolePublicKey, request.label);
   const meshIP = await allocateMeshIp(network.meshCIDR, request.nodeDID);
   const expiresAt = Object.prototype.hasOwnProperty.call(options, "expiresAt")
     ? options.expiresAt?.trim()

--- a/internal/control/dwnclient.go
+++ b/internal/control/dwnclient.go
@@ -1361,11 +1361,13 @@ func (c *DWNClient) makeDecryptor(ctx context.Context, protocolPath string) Entr
 			c.logger.Debug("grant-key decrypt failed, trying role audience",
 				slog.String("path", protocolPath), slog.Any("error", err))
 		}
+		var roleAudienceErr error
 		if infos := dwncrypto.RoleAudienceEntryInfos(enc); len(infos) > 0 {
 			plaintext, err := c.decryptRoleAudience(ctx, ciphertext, enc, infos)
 			if err == nil {
 				return plaintext, nil
 			}
+			roleAudienceErr = err
 			c.logger.Debug("role-audience decrypt failed",
 				slog.String("path", protocolPath), slog.Any("error", err))
 			if c.encManager == nil {
@@ -1375,9 +1377,16 @@ func (c *DWNClient) makeDecryptor(ctx context.Context, protocolPath string) Entr
 		if c.encManager == nil {
 			return nil, fmt.Errorf("no key material decrypts record at %s", protocolPath)
 		}
-		// No roleAudience entry — attempt protocolPath (e.g. records the
-		// reader authored and can re-derive).
-		return c.decryptWithProtocolPath(ciphertext, enc, protocolPath)
+		// protocolPath fallback: only succeeds for records this reader authored and
+		// can re-derive. For an owner-authored roleAudience record a non-owner derives
+		// the wrong KEK and fails with a misleading "AES Key Unwrap integrity check
+		// failed" — so when the record carried roleAudience entries, surface that real
+		// (missing role-audience key) failure instead of masking it with the fallback.
+		plaintext, err := c.decryptWithProtocolPath(ciphertext, enc, protocolPath)
+		if err != nil && roleAudienceErr != nil {
+			return nil, roleAudienceErr
+		}
+		return plaintext, err
 	}
 }
 

--- a/internal/mesh/preauth.go
+++ b/internal/mesh/preauth.go
@@ -66,13 +66,23 @@ func (r NodeRequestData) EffectiveOwnerDID() string {
 	return r.NodeDID
 }
 
-// nodeRoleKeyPaths are the mesh $role paths a node HOLDS (their delivery recipient
-// is the node itself). "network/member" is deliberately excluded: its recipient is
-// the member/owner DID, a different identity whose key the node cannot assert. The
-// node cannot know at join time whether approval places it under a member layer
-// (network/member/node) or directly (network/node) — deliverJoinerAudienceKeys
-// decides per-approval — so it publishes both candidate public keys.
-var nodeRoleKeyPaths = []string{"network/node", "network/member/node"}
+// nodeRoleKeyPaths are the mesh $role paths whose audience keys must reach the node
+// via `$encryption/delivery`, keyed under the node's own root. The node publishes the
+// PUBLIC half of each so a DWN-less did:jwk node can be delivered to without a lookup.
+//
+// "network/member" is the READING role a member-invited node authorizes as
+// (readProtocolRole -> "network/member"): peer node records grant can:read to
+// {network/member, network/node} only, so a node must recover the network/member
+// audience to see its peers. It derives that key from its own root at read time
+// (decryptViaDelivery), so it can and must advertise the public half — a self-asserted
+// role-path key is pure key transport and grants no new authority. Without it a node
+// silently decrypts nothing but its own record (issue #192).
+//
+// "network/node" (owner-provisioned nodes) and "network/member/node" (the node's own
+// $role path) are the roles a node HOLDS. The node cannot know at join time whether
+// approval places it under a member layer or directly, so it publishes all candidate
+// public keys and deliverJoinerAudienceKeys / the dashboard deliver the relevant ones.
+var nodeRoleKeyPaths = []string{"network/member", "network/node", "network/member/node"}
 
 // nodeRoleKeys derives the PUBLIC halves of the node's own role-path keys from its
 // root #enc key, for delivery to it without a DWN lookup. Returns nil (field

--- a/internal/mesh/rolekeys_test.go
+++ b/internal/mesh/rolekeys_test.go
@@ -13,10 +13,11 @@ import (
 )
 
 // A did:jwk node publishes no DWN endpoint, so the owner cannot resolve its
-// role-path keys by DID. The node must therefore emit exactly the role paths it
-// HOLDS — network/node and network/member/node — and never network/member,
-// whose recipient is a different identity (the member/owner DID).
-func TestNodeRoleKeysEmitsExactlyNodeHeldPaths(t *testing.T) {
+// role-path keys by DID. The node must therefore emit the public half of every
+// role-path key it needs delivered to it: the READING role a member-invited node
+// authorizes as (network/member — the audience its peer records are encrypted to,
+// issue #192) plus the roles it may HOLD (network/node, network/member/node).
+func TestNodeRoleKeysEmitsReadingAndHeldPaths(t *testing.T) {
 	root, _, err := dwncrypto.GenerateX25519KeyPair()
 	if err != nil {
 		t.Fatalf("GenerateX25519KeyPair: %v", err)
@@ -27,12 +28,12 @@ func TestNodeRoleKeysEmitsExactlyNodeHeldPaths(t *testing.T) {
 		t.Fatalf("nodeRoleKeys: %v", err)
 	}
 
-	want := map[string]bool{"network/node": true, "network/member/node": true}
+	want := map[string]bool{"network/member": true, "network/node": true, "network/member/node": true}
 	if len(keys) != len(want) {
 		t.Fatalf("nodeRoleKeys returned %d paths (%v), want exactly %v", len(keys), keysOf(keys), keysOf(mapKeys(want)))
 	}
-	if _, bad := keys["network/member"]; bad {
-		t.Fatal("nodeRoleKeys must not emit network/member: its recipient is the member DID, not the node")
+	if _, ok := keys["network/member"]; !ok {
+		t.Fatal("nodeRoleKeys must emit network/member: it is the reading-role audience the node decrypts its peers with (#192)")
 	}
 	for path := range want {
 		jwk, ok := keys[path]


### PR DESCRIPTION
Fixes #192. Follow-up to #187.

## Problem
Two invite-joined `did:jwk` mesh nodes can't decrypt each other — each shows only itself in `meshd peer list`, with a misleading `AES Key Unwrap integrity check failed`.

## Root cause (multi-agent crypto audit)
The Go/TS crypto primitives are **byte-identical** (HKDF, AES-KW, ECDH, thumbprint all match — the AES-KW error is a red herring from the protocolPath fallback). The real bug is a **wrong-audience delivery gap**:

- Peer node records (`network/member/node`, `network/node`, + `nodeInfo`/`endpoint`) grant `can:read` to roles **`network/member`** and **`network/node`** only — never `network/member/node`. So they're encrypted to those audiences.
- A member-invited node authorizes as **`network/member`** (`readProtocolRole`), so it must recover the `network/member` audience to see peers.
- But the dashboard delivered only the **`network/member/node`** audience — the role the node *holds*, which no record is encrypted to — and the node never published a `network/member` role-path key for a DWN-less delivery.
- Result: no route to the reading-role audience → `decryptRoleAudience` finds no delivery → falls through to the protocolPath fallback → misleading AES-KW error.

## Fix (no backwards-compat — fresh network / fresh identities)
1. **`internal/mesh/preauth.go`** — publish the node's own `network/member` role-path public key. It derives that key from its root at read time (`decryptViaDelivery`); a self-asserted role-path key is pure key transport and grants no new authority.
2. **`admin-dapp/src/meshd/admin.ts`** — deliver the `network/member` audience to the node by writing the member role record with the node's supplied `network/member` key; require it and enforce (+ roll back) delivery, mirroring the node write.
3. **`internal/control/dwnclient.go`** — stop the protocolPath fallback from masking the real role-audience failure, so the true error (`no delivery record … at network/member`) surfaces instead of the AES-KW red herring.

## Not covered (follow-up)
The meshd-native owner flow (`deliverJoinerAudienceKeys`) has the analogous `network/member`→member did:jwk gap; the dashboard path is fixed here since that's the deployed flow. A distinct-human-member layer delivering to a *new* node under a *pre-existing* member also needs a delivery-repair path (the self-owned join covered here writes the member record fresh).

## Verification
- `go build ./...` ✓ · `go vet ./...` ✓ · `go test ./... -count=1 -race` ✓
- admin-dapp `tsc && vite build` ✓ · `vitest` 37/37 ✓ (rewrote the delivery tests to assert the `network/member` reading-role delivery + fail-fast + member-record rollback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)