### PR TITLE
fix(state): keep network.json readable by the non-root CLI under sudo (#195)

### DIFF
--- a/internal/state/ownership.go
+++ b/internal/state/ownership.go
@@ -1,0 +1,34 @@
+package state
+
+// fileOwnerForDir decides whether a freshly written state file should be
+// chowned to the uid/gid that owns its state directory, and to which ids.
+//
+// Background: when `meshd up` re-execs under sudo to open the TUN device, the
+// root daemon persists network.json as root:root 0600. A later non-root
+// `meshd status` / `meshd peer list` then fails to read it with EACCES.
+// Aligning each freshly written state file to the directory owner keeps it
+// readable by the invoking user for the whole lifetime of a running daemon,
+// survives crashes (no deferred cleanup), and needs no SUDO_UID plumbing.
+//
+// Rules, in order:
+//   - dirStatOK false (owner unknown / unsupported platform): do nothing.
+//   - procEUID != 0: only root may hand a file to another uid, so a non-root
+//     process never chowns.
+//   - dirUID == 0: the directory is root-owned (e.g. a system service under
+//     /var/lib, or a direct `sudo meshd up` fresh install where the profile
+//     directory is created by root). A root-owned file is then expected; leave
+//     it. The exit-time restoreSudoUserOwnership safety net in cmd/meshd covers
+//     the direct-sudo fresh-install case for those who need the CLI afterwards.
+//   - otherwise: chown the file to the directory's uid/gid.
+func fileOwnerForDir(procEUID, dirUID, dirGID int, dirStatOK bool) (uid, gid int, chown bool) {
+	if !dirStatOK {
+		return 0, 0, false
+	}
+	if procEUID != 0 {
+		return 0, 0, false
+	}
+	if dirUID == 0 {
+		return 0, 0, false
+	}
+	return dirUID, dirGID, true
+}

--- a/internal/state/ownership_other.go
+++ b/internal/state/ownership_other.go
@@ -1,0 +1,8 @@
+//go:build !unix
+
+package state
+
+// alignOwnerToDir is a no-op on platforms without POSIX file ownership
+// (notably Windows, where os.Chown is unsupported and syscall.Stat_t exposes no
+// Uid/Gid). State files simply inherit the writing process's ownership there.
+func alignOwnerToDir(dir, path string) {}

--- a/internal/state/ownership_test.go
+++ b/internal/state/ownership_test.go
@@ -1,0 +1,42 @@
+package state
+
+import "testing"
+
+func TestFileOwnerForDir(t *testing.T) {
+	cases := []struct {
+		name                     string
+		procEUID, dirUID, dirGID int
+		statOK                   bool
+		wantUID, wantGID         int
+		wantChown                bool
+	}{
+		{"root process, user-owned dir", 0, 1000, 1000, true, 1000, 1000, true},
+		{"root process, distinct uid and gid", 0, 1000, 2000, true, 1000, 2000, true},
+		{"root process, root-owned dir", 0, 0, 0, true, 0, 0, false},
+		{"non-root process, user-owned dir", 1000, 1000, 1000, true, 0, 0, false},
+		{"non-root process, root-owned dir", 1000, 0, 0, true, 0, 0, false},
+		{"stat failed", 0, 1000, 1000, false, 0, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			uid, gid, chown := fileOwnerForDir(tc.procEUID, tc.dirUID, tc.dirGID, tc.statOK)
+			if uid != tc.wantUID || gid != tc.wantGID || chown != tc.wantChown {
+				t.Fatalf("fileOwnerForDir(%d,%d,%d,%v)=(%d,%d,%v) want (%d,%d,%v)",
+					tc.procEUID, tc.dirUID, tc.dirGID, tc.statOK, uid, gid, chown, tc.wantUID, tc.wantGID, tc.wantChown)
+			}
+		})
+	}
+}
+
+// TestSaveNetworkStatePreservesOwnerWhenNotRoot guards the common path: a normal
+// user must still be able to save and re-read state, and the ownership
+// realignment must be a no-op that never errors.
+func TestSaveNetworkStatePreservesOwnerWhenNotRoot(t *testing.T) {
+	dir := t.TempDir()
+	if err := SaveNetworkState(dir, &NetworkState{NetworkRecordID: "n1"}); err != nil {
+		t.Fatalf("SaveNetworkState: %v", err)
+	}
+	if _, err := LoadNetworkState(dir); err != nil {
+		t.Fatalf("LoadNetworkState: %v", err)
+	}
+}

--- a/internal/state/ownership_unix.go
+++ b/internal/state/ownership_unix.go
@@ -1,0 +1,37 @@
+//go:build unix
+
+package state
+
+import (
+	"os"
+	"syscall"
+)
+
+// alignOwnerToDir best-effort chowns path to the owner of dir so that a state
+// file written by the root daemon (after the sudo TUN re-exec) stays readable
+// by the non-root user who owns the profile directory. The decision is made by
+// fileOwnerForDir.
+//
+// It uses Lchown (not Chown) so it never follows a symlink: in a deployment
+// where the state directory is writable by an unprivileged user, that user
+// could otherwise unlink the root-written tmp file and plant a symlink between
+// the write and the chown, tricking root into chowning an attacker-chosen path
+// (a race-based local privilege escalation). Lchown on the regular tmp file we
+// just wrote behaves identically to Chown, and matches restoreSudoUserOwnership
+// in cmd/meshd. Any chown error is intentionally ignored: failing to realign
+// ownership must never block state persistence.
+func alignOwnerToDir(dir, path string) {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return
+	}
+	uid, gid, chown := fileOwnerForDir(os.Geteuid(), int(st.Uid), int(st.Gid), true)
+	if !chown {
+		return
+	}
+	_ = os.Lchown(path, uid, gid)
+}

--- a/internal/state/ownership_unix_test.go
+++ b/internal/state/ownership_unix_test.go
@@ -1,0 +1,36 @@
+//go:build unix
+
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// TestSaveNetworkStateChownsToDirOwner exercises the actual chown. It runs only
+// as root (the exact privilege the daemon holds after the sudo TUN re-exec);
+// non-root CI skips it. It creates a dir owned by nobody, saves state as root,
+// and asserts the file was handed to the dir's owner.
+func TestSaveNetworkStateChownsToDirOwner(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root to chown to another uid")
+	}
+	const wantUID, wantGID = 65534, 65534 // nobody/nogroup on most systems
+	dir := t.TempDir()
+	if err := os.Chown(dir, wantUID, wantGID); err != nil {
+		t.Fatalf("chown dir: %v", err)
+	}
+	if err := SaveNetworkState(dir, &NetworkState{NetworkRecordID: "n1"}); err != nil {
+		t.Fatalf("SaveNetworkState: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(dir, networkFile))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	st := info.Sys().(*syscall.Stat_t)
+	if int(st.Uid) != wantUID || int(st.Gid) != wantGID {
+		t.Fatalf("owner = %d:%d, want %d:%d", st.Uid, st.Gid, wantUID, wantGID)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -176,6 +176,11 @@ func SaveNetworkState(stateDir string, ns *NetworkState) error {
 	if err := os.WriteFile(tmp, data, 0600); err != nil {
 		return fmt.Errorf("write: %w", err)
 	}
+	// When `meshd up` re-execs under sudo for the TUN device, the root daemon
+	// writes this file. Align its ownership to the profile directory's owner
+	// before the atomic rename, so the non-root CLI can still read it while the
+	// daemon keeps running. No-op for normal user runs and on non-POSIX platforms.
+	alignOwnerToDir(stateDir, tmp)
 	if err := os.Rename(tmp, target); err != nil {
 		os.Remove(tmp)
 		return fmt.Errorf("rename: %w", err)


### PR DESCRIPTION
## Summary

Fixes #195. When `meshd up` re-execs itself with `sudo` to open the WireGuard TUN device, the **root daemon** writes `network.json` as `root:root 0600`. A subsequent non-root `meshd status` / `meshd peer list` then fails:

```
meshd: loading network state: read: open ~/.enbox/profiles/default/meshd/network.json: permission denied
```

The existing `restoreSudoUserOwnership()` only runs on **daemon exit**, and the daemon keeps rewriting `network.json` while alive (e.g. `refreshLocalMembershipMetadataFromMap` on every control-map refresh), so the CLI stays locked out for the entire session.

## Fix

Align each freshly written state file to the owner of its **profile directory** at write time. In `SaveNetworkState`, after writing the `.tmp` file and **before** the atomic rename, if the process is root and the state dir is owned by a non-root user, chown the tmp to the dir's owner. Because the chown happens before the rename, the durable `network.json` is never even briefly root-owned.

Why the directory owner (not `SUDO_UID`): the profile dir is created by the non-root user before the sudo re-exec, so it is a local, always-available ground truth — no dependence on `SUDO_UID` being present/plumbed, and it also covers non-sudo elevation paths.

### Details
- **`fileOwnerForDir`** — pure, unit-tested decision: only chowns when the process is root **and** the dir is user-owned (a root-owned dir, e.g. a `/var/lib` system service, is left alone).
- **Unix helper uses `Lchown`, not `Chown`** — never follows a symlink an unprivileged co-owner of the state dir could plant between the write and the chown (closes a race-based local-privilege-escalation vector); matches the existing `restoreSudoUserOwnership`.
- **No-op on non-POSIX platforms** (build-tagged) so Windows still compiles.
- `restoreSudoUserOwnership()` kept as a complementary exit-time safety net (also covers the direct `sudo meshd up` fresh-install case where the profile dir itself is root-owned).

Self-healing: a pre-existing root-owned `network.json` is replaced by a user-owned file on the next save.

## Tests
- `TestFileOwnerForDir` — 6 decision branches (root+user dir → chown; distinct uid/gid; root+root dir → no; non-root cases → no; stat-failed → no).
- `TestSaveNetworkStatePreservesOwnerWhenNotRoot` — normal-user save/load round-trip still works; realignment is a harmless no-op.
- `TestSaveNetworkStateChownsToDirOwner` — root-gated e2e of the real chown (auto-skips under non-root CI).

## Verification
- `go build ./...` — clean
- `go vet ./...` — clean
- `GOOS=windows go build ./internal/state/` — compiles (no-op fallback)
- `go test ./... -count=1 -race` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)