### PR TITLE
feat(admin-dapp): invite lifecycle — auto-remove used, carry label to node, keep created copyable

### DIFF
--- a/admin-dapp/src/App.tsx
+++ b/admin-dapp/src/App.tsx
@@ -197,7 +197,7 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
   const [topology, setTopology] = useState<MeshdNetworkTopology>();
   const [loadState, setLoadState] = useState<LoadState>("idle");
   const [error, setError] = useState<string>();
-  const [inviteResult, setInviteResult] = useState<CreateMeshdInviteResult>();
+  const [inviteResults, setInviteResults] = useState<CreateMeshdInviteResult[]>([]);
   const [inviteLabel, setInviteLabel] = useState("");
   const [inviteExpiry, setInviteExpiry] = useState<ExpiryValue>("24h");
   const [approvalExpiry, setApprovalExpiry] = useState<ExpiryValue>("never");
@@ -290,6 +290,12 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
     window.history.replaceState(null, "", `?${params.toString()}`);
   }, [did, selectedNetwork]);
 
+  // The freshly-created invite list is scoped to the selected network; reset it
+  // when the operator switches networks so stale URLs don't carry across.
+  useEffect(() => {
+    setInviteResults([]);
+  }, [selectedNetwork?.recordId]);
+
   async function runAction(label: string, action: () => Promise<void>) {
     setBusyAction(label);
     setError(undefined);
@@ -317,12 +323,14 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
     if (!session || !selectedNetwork) return;
     await runAction("create-invite", async () => {
       const result = await createMeshdInvite(session, selectedNetwork, {
-        label: inviteLabel.trim() || selectedNetwork.name,
+        label: inviteLabel.trim() || undefined,
         expiresAt: expiryTimestamp(inviteExpiry),
         reusable: inviteReusable
       });
       setInviteLabel("");
-      setInviteResult(result);
+      // Keep every invite created this session pinned and copyable, newest first,
+      // so several machines can be invited and copied without losing earlier URLs.
+      setInviteResults((prev) => [result, ...prev]);
       toast.success("Invite created");
       await refreshTopology();
     });
@@ -541,17 +549,17 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
               </div>
             </section>
 
-            {inviteResult ? (
-              <div className="invite-result">
+            {inviteResults.map((result) => (
+              <div className="invite-result" key={result.tokenId}>
                 <div>
-                  <strong>Invite URL</strong>
-                  <code>{inviteResult.url}</code>
+                  <strong>{result.label || "Invite URL"}</strong>
+                  <code>{result.url}</code>
                 </div>
-                <button className="icon-button" type="button" aria-label="Copy invite URL" title="Copy" onClick={() => void copyToClipboard(inviteResult.url)}>
+                <button className="icon-button" type="button" aria-label="Copy invite URL" title="Copy" onClick={() => void copyToClipboard(result.url)}>
                   <ClipboardIcon size={16} />
                 </button>
               </div>
-            ) : null}
+            ))}
 
             <section className="content-section">
               <div className="section-heading">

--- a/admin-dapp/src/meshd/admin.test.ts
+++ b/admin-dapp/src/meshd/admin.test.ts
@@ -12,6 +12,7 @@ import {
   DELEGATE_SESSION_REQUIRED_ERROR,
   fetchMeshdNetworks,
   parseMeshdNodeRequestRecord,
+  parseMeshdPreAuthKeyRecord,
   rejectMeshdNodeRequest,
   updateMeshdNodeExpiry,
   updateMeshdNodeLabel,
@@ -59,6 +60,50 @@ async function signedOwnerNodeRequest(opts: {
     requestKind: "owner-node",
     nodeProof: toBase64Url(signature),
     requestedAt,
+    ...(opts.roleKeys ? { roleKeys: opts.roleKeys } : {})
+  };
+}
+
+// Builds a real invite-based (non-owner-scoped) node request signed by a fresh
+// did:jwk, with a matching HMAC invite proof, so approve's proof checks pass and
+// the tests exercise the preAuthKey consumption + label-carry paths end to end.
+async function signedInviteNodeRequest(opts: {
+  networkId: string;
+  secret: string;
+  preAuthKeyId: string;
+  ownerDID: string;
+  label?: string;
+  roleKeys?: Record<string, RolePublicKeyJwk>;
+}): Promise<MeshdNodeRequestSummary> {
+  const privateKey = await Ed25519.generateKey();
+  const publicKey = await Ed25519.computePublicKey({ key: privateKey });
+  const nodeDID = `did:jwk:${toBase64Url(new TextEncoder().encode(JSON.stringify(publicKey)))}`;
+  const joinMessage = new TextEncoder().encode(
+    "meshd node join v1\n"
+    + `network=${opts.networkId}\n`
+    + `node=${nodeDID}\n`
+    + `member=${opts.ownerDID || nodeDID}\n`
+    + `preauth=${opts.preAuthKeyId}\n`
+  );
+  const nodeProof = toBase64Url(await Ed25519.sign({ key: privateKey, data: joinMessage }));
+  const hmacKey = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(opts.secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const mac = new Uint8Array(await crypto.subtle.sign("HMAC", hmacKey, new TextEncoder().encode(`${opts.networkId}\n${nodeDID}`)));
+  return {
+    recordId: "req-rec",
+    protocolPath: "network/nodeRequest",
+    nodeDID,
+    ownerDID: opts.ownerDID,
+    memberDID: opts.ownerDID,
+    preAuthKeyId: opts.preAuthKeyId,
+    preAuthProof: `hmac-sha256:${toBase64Url(mac)}`,
+    nodeProof,
+    ...(opts.label ? { label: opts.label } : {}),
     ...(opts.roleKeys ? { roleKeys: opts.roleKeys } : {})
   };
 }
@@ -781,5 +826,107 @@ describe("meshd node role-audience key delivery (#187)", () => {
       (r) => r.messageType === DwnInterface.RecordsWrite && r.messageParams?.protocolPath === "network/member/node"
     );
     expect(nodeWrite).toBeUndefined();
+  });
+});
+
+describe("meshd invite lifecycle", () => {
+  const network: MeshdNetworkSummary = { recordId: "net-1", name: "Test Net", meshCIDR: "10.200.0.0/16" };
+  const roleKeys = { "network/member": VALID_X25519_KEY, "network/member/node": VALID_X25519_KEY };
+  const secret = "invite-secret";
+
+  function inviteEntry(overrides: Record<string, unknown>) {
+    return recordEntry("invite-rec", "network/preAuthKey", {
+      key: secret,
+      createdAt: "2026-06-24T00:00:00Z",
+      usedBy: [],
+      ...overrides
+    });
+  }
+
+  // createMeshdInvite writes the label + expiresAt into the encrypted payload, and
+  // parseMeshdPreAuthKeyRecord must read them back — the round-trip that surfaces as
+  // the invite row's label and "Expires …" text (guards against silent "No expiry").
+  it("round-trips an invite's label and expiry through create and parse", async () => {
+    const { session, requests } = createFakeSession({ delegate: true, recordIds: ["invite-rec"] });
+    const result = await createMeshdInvite(session, network, {
+      label: "laptop-01",
+      expiresAt: "2026-06-25T00:00:00Z",
+      reusable: false
+    });
+    expect(result.label).toBe("laptop-01");
+
+    const written = await blobJson(requests[0].dataStream);
+    const parsed = parseMeshdPreAuthKeyRecord(recordEntry(result.tokenId, "network/preAuthKey", written));
+    expect(parsed?.label).toBe("laptop-01");
+    expect(parsed?.expiresAt).toBe("2026-06-25T00:00:00Z");
+  });
+
+  it("removes a single-use invite once it is consumed", async () => {
+    const { session, requests } = createFakeSession({
+      recordIds: ["member-rec", "node-rec"],
+      queryEntries: [inviteEntry({ reusable: false })]
+    });
+    const request = await signedInviteNodeRequest({
+      networkId: network.recordId, secret, preAuthKeyId: "invite-rec", ownerDID: "did:example:owner", roleKeys
+    });
+
+    await approveMeshdNodeRequest(session, network, request);
+
+    // The spent invite is deleted, not left as a dead "1 used" entry...
+    const inviteDeletes = requests.filter(
+      (r) => r.messageType === DwnInterface.RecordsDelete && r.messageParams?.recordId === "invite-rec"
+    );
+    expect(inviteDeletes).toHaveLength(1);
+    // ...and never rewritten with a usedBy entry.
+    const inviteRewrites = requests.filter(
+      (r) => r.messageType === DwnInterface.RecordsWrite && r.messageParams?.protocolPath === "network/preAuthKey"
+    );
+    expect(inviteRewrites).toHaveLength(0);
+  });
+
+  it("keeps a reusable invite and records the new consumer", async () => {
+    const { session, requests } = createFakeSession({
+      recordIds: ["member-rec", "node-rec"],
+      queryEntries: [inviteEntry({ reusable: true })]
+    });
+    const request = await signedInviteNodeRequest({
+      networkId: network.recordId, secret, preAuthKeyId: "invite-rec", ownerDID: "did:example:owner", roleKeys
+    });
+
+    await approveMeshdNodeRequest(session, network, request);
+
+    // A reusable invite survives...
+    const inviteDeletes = requests.filter(
+      (r) => r.messageType === DwnInterface.RecordsDelete && r.messageParams?.recordId === "invite-rec"
+    );
+    expect(inviteDeletes).toHaveLength(0);
+    // ...and records the consumer in usedBy.
+    const rewrite = requests.find(
+      (r) => r.messageType === DwnInterface.RecordsWrite && r.messageParams?.protocolPath === "network/preAuthKey"
+    );
+    expect(rewrite).toBeDefined();
+    const payload = await blobJson(rewrite!.dataStream);
+    expect(payload.reusable).toBe(true);
+    expect(payload.usedBy).toEqual([request.nodeDID]);
+  });
+
+  it("carries the invite label to the joined node when the request has none", async () => {
+    const { session, requests } = createFakeSession({
+      recordIds: ["member-rec", "node-rec"],
+      queryEntries: [inviteEntry({ reusable: false, label: "laptop-01" })]
+    });
+    const request = await signedInviteNodeRequest({
+      networkId: network.recordId, secret, preAuthKeyId: "invite-rec", ownerDID: "did:example:owner", roleKeys
+    });
+    expect(request.label).toBeUndefined();
+
+    await approveMeshdNodeRequest(session, network, request);
+
+    const nodeWrite = requests.find(
+      (r) => r.messageType === DwnInterface.RecordsWrite && r.messageParams?.protocolPath === "network/member/node"
+    );
+    expect(nodeWrite).toBeDefined();
+    const payload = await blobJson(nodeWrite!.dataStream);
+    expect(payload.label).toBe("laptop-01");
   });
 });

--- a/admin-dapp/src/meshd/admin.ts
+++ b/admin-dapp/src/meshd/admin.ts
@@ -147,6 +147,7 @@ export type CreateMeshdInviteResult = {
   tokenId: string;
   secret: string;
   expiresAt?: string;
+  label?: string;
 };
 
 export type ApproveMeshdNodeRequestResult = {
@@ -817,7 +818,8 @@ export async function createMeshdInvite(
     url: encodeMeshdInviteURL(endpoint, session.ownerDid, network, record.recordId, secret, expiresAt),
     tokenId: record.recordId,
     secret,
-    ...(expiresAt ? { expiresAt } : {})
+    ...(expiresAt ? { expiresAt } : {}),
+    ...(options.label?.trim() ? { label: options.label.trim() } : {})
   };
 }
 
@@ -993,6 +995,13 @@ async function markPreAuthKeyUsed(
   if (key.usedBy.includes(nodeDID)) {
     return;
   }
+  // A single-use invite is spent the moment it is consumed, so delete the
+  // record instead of leaving a dead "1 used" entry cluttering the admin list.
+  // Reusable invites persist and just record the new consumer.
+  if (!key.reusable) {
+    await deleteRecord(session, MESHD_PROTOCOL_URI, key.recordId, false);
+    return;
+  }
   await writeRecord(
     session,
     MESHD_PROTOCOL_URI,
@@ -1009,7 +1018,7 @@ async function markPreAuthKeyUsed(
       key: key.key,
       ...(key.createdAt ? { createdAt: key.createdAt } : {}),
       ...(key.expiresAt ? { expiresAt: key.expiresAt } : {}),
-      ...(key.reusable !== undefined ? { reusable: key.reusable } : {}),
+      reusable: true,
       ...(key.ephemeral !== undefined ? { ephemeral: key.ephemeral } : {}),
       ...(key.label ? { label: key.label } : {}),
       usedBy: [...key.usedBy, nodeDID]
@@ -1169,6 +1178,11 @@ export async function approveMeshdNodeRequest(
   const preAuthKey = ownerScopedRequest ? undefined : await readPreAuthKey(session, network, request);
   const requestOwnerDID = nodeOwnerDID(request);
 
+  // An invite can pre-name the machine that joins with it: when the node request
+  // carries no label of its own, fall back to the invite's label, so an invite
+  // labeled "laptop-01" makes the joined node show as "laptop-01".
+  const effectiveLabel = request.label?.trim() || preAuthKey?.label;
+
   // The node authorizes as network/member and its peer records are encrypted to the
   // network/member audience, so that reading-role audience must be delivered to it. A
   // did:jwk node has no DWN endpoint to resolve its role-path key from, so it supplies
@@ -1184,7 +1198,7 @@ export async function approveMeshdNodeRequest(
       "roleKey in its join request (#192)."
     );
   }
-  const member = await ensureMemberRecord(session, network, requestOwnerDID, memberRolePublicKey, request.label);
+  const member = await ensureMemberRecord(session, network, requestOwnerDID, memberRolePublicKey, effectiveLabel);
   const meshIP = await allocateMeshIp(network.meshCIDR, request.nodeDID);
   const expiresAt = Object.prototype.hasOwnProperty.call(options, "expiresAt")
     ? options.expiresAt?.trim()
@@ -1222,7 +1236,7 @@ export async function approveMeshdNodeRequest(
     {
       meshIP,
       addedAt: new Date().toISOString(),
-      ...(request.label ? { label: request.label } : {}),
+      ...(effectiveLabel ? { label: effectiveLabel } : {}),
       ownerDID: requestOwnerDID,
       memberDID: requestOwnerDID,
       ...(request.delegateDID ? { delegateDID: request.delegateDID } : {}),
@@ -1274,7 +1288,7 @@ export async function approveMeshdNodeRequest(
         ...(member.dateCreated ? { memberDateCreated: member.dateCreated } : {}),
         nodeRecordId: nodeRecord.recordId,
         ...(nodeRecord.dateCreated ? { nodeDateCreated: nodeRecord.dateCreated } : {}),
-        ...(request.label ? { label: request.label } : {}),
+        ...(effectiveLabel ? { label: effectiveLabel } : {}),
         ...(expiresAt ? { expiresAt } : {}),
         approvedAt: new Date().toISOString(),
         requestRecordId: request.recordId


### PR DESCRIPTION
## Summary

Closes #197. Three admin-dashboard invite improvements plus an expiry round-trip guard.

### 1. Auto-remove used invites
`markPreAuthKeyUsed` now **deletes** a single-use invite when it is consumed instead of rewriting it with a `usedBy` entry — spent invites no longer linger as dead "1 used" rows. Reusable invites still persist and record each consumer (the `reusable` flag is now written explicitly on rewrite).

### 2. Carry the invite label to the joined node
`approveMeshdNodeRequest` derives `effectiveLabel = request.label || preAuthKey.label` and threads it into the member record, node record, and node-approval writes. An invite labeled `laptop-01` now pre-names the machine that joins with it. Blank invite labels are stored as unset (no more network-name default) so the carry stays meaningful.

### 3. Keep every invite created this session copyable
`createMeshdInvite` returns the invite `label`; the composer accumulates each invite created this session (newest first), each pinned with its own Copy button, and resets the list when the selected network changes. Previously only the most-recent URL stayed visible.

### Expiry round-trip guard
Added a test proving `createMeshdInvite` → `parseMeshdPreAuthKeyRecord` preserves both `label` and `expiresAt` (the invite row's "Expires …" text). The code was already correct; this locks it against regression and addresses the "always No expiry" report — which, given the deployed build is current, points at a cached service-worker bundle rather than the code.

## Tests
- Round-trip: create → parse preserves label + expiresAt.
- Invite-path approve: single-use invite deleted on consumption; reusable invite kept + `usedBy` recorded; invite label carried to the node record.
- `bun run test` — 41/41 pass. `bun run build` — clean (tsc + vite + PWA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)