### PR TITLE
docs: document patch-only versioning policy; add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,3 +108,17 @@ to progressively decouple:
 - Keep PRs focused. One concern per PR.
 - Run `go mod tidy && go mod vendor` if dependencies change.
 - Never edit `vendor/` directly. Push changes to the upstream repo first.
+
+## Versioning
+
+**Patch-only for now.** This module is pre-release (`0.x`) and makes **no
+backwards-compatibility guarantees** until we cut a stable release. Every change
+ships as a **patch** bump — never minor, never major.
+
+- Breaking changes are acceptable and expected. Do **not** add compatibility
+  shims, migration paths, or deprecation cycles to preserve old behavior; just
+  change it. Callers are updated in lockstep.
+- The intended release cadence is patch-only, so don't lean on `feat:` commits
+  to force a minor bump. (release-please derives the bump from commit types; if
+  we want to hard-enforce patch-only, set `versioning: always-bump-patch` in the
+  release-please config.)


### PR DESCRIPTION
## Summary

Per maintainer direction: **this repo does patch-only releases for now** — it is pre-release (`0.x`) with **no backwards-compatibility guarantees** until we cut a stable release, so breaking changes are expected and no compat shims / deprecation cycles are needed.

- Adds a **Versioning** section to `CLAUDE.md` stating the patch-only, no-back-compat policy.
- Adds **`AGENTS.md`** as a symlink to `CLAUDE.md`, so agent tooling that looks for `AGENTS.md` (the emerging cross-tool standard) picks up the same instructions from a single source of truth — no content duplication/drift.

## Note (not in this PR)

The policy is currently documentation-only. `release-please` is configured `release-type: go`, which derives the bump from commit types (`feat:` → minor). To **enforce** patch-only, set `versioning: always-bump-patch` in a release-please config — happy to do that in a follow-up if you want it hard-enforced rather than by convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)