### PR TITLE
fix(ci): make the release installer smoke test resilient to Cloudflare edge blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Unit Tests
         run: go test ./... -count=1 -race -coverprofile=coverage.out -covermode=atomic
 
+      - name: Installer smoke fetch test
+        run: ./scripts/e2e/install-smoke.test.sh
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -141,4 +141,5 @@ jobs:
       - name: Install latest release via meshd.sh
         env:
           MESHD_INSTALL_EXPECTED_VERSION: ${{ needs.release-please.outputs.tag_name }}
+          MESHD_INSTALL_FALLBACK_URL: https://raw.githubusercontent.com/${{ github.repository }}/${{ needs.release-please.outputs.tag_name }}/install.sh
         run: ./scripts/e2e/install-smoke.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,4 +128,5 @@ jobs:
         env:
           MESHD_INSTALL_REQUESTED_VERSION: ${{ github.event.inputs.tag }}
           MESHD_INSTALL_EXPECTED_VERSION: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+          MESHD_INSTALL_FALLBACK_URL: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.event.inputs.tag || github.event.release.tag_name }}/install.sh
         run: ./scripts/e2e/install-smoke.sh

--- a/scripts/e2e/install-smoke.sh
+++ b/scripts/e2e/install-smoke.sh
@@ -3,6 +3,13 @@
 set -euo pipefail
 
 INSTALL_URL="${MESHD_INSTALL_URL:-https://meshd.sh/install}"
+# meshd.sh sits behind Cloudflare bot protection that returns 403 to datacenter
+# IPs such as CI runners, even though it serves fine to real users. When the
+# primary edge is unreachable, fall back to this source (e.g. the raw install.sh
+# at the release tag) so the smoke test still exercises the installer and the
+# published release binaries end to end instead of failing the release.
+INSTALL_FALLBACK_URL="${MESHD_INSTALL_FALLBACK_URL:-}"
+INSTALL_USER_AGENT="${MESHD_INSTALL_USER_AGENT:-meshd-install-smoke/1 (+https://github.com/enboxorg/meshd)}"
 REQUESTED_VERSION="${MESHD_INSTALL_REQUESTED_VERSION:-}"
 EXPECTED_VERSION="${MESHD_INSTALL_EXPECTED_VERSION:-}"
 TMP_DIR="${MESHD_INSTALL_TMP_DIR:-}"
@@ -49,8 +56,28 @@ if [ -z "$EXPECTED_VERSION" ] && [ -n "$REQUESTED_VERSION" ]; then
   EXPECTED_VERSION="$REQUESTED_VERSION"
 fi
 
-printf '==> Fetching installer from %s\n' "$INSTALL_URL"
-curl -fsSL "$INSTALL_URL" | HOME="$HOME_DIR" bash -s -- "${args[@]}"
+fetch_installer() {
+  # Write the installer script to $1, trying the primary URL then the fallback.
+  # A realistic User-Agent sidesteps UA-based edge rules and --retry rides out
+  # transient network errors; a persistent primary failure (e.g. a Cloudflare
+  # 403 to a CI runner) falls through to the fallback rather than failing.
+  local out="$1" url
+  for url in "$INSTALL_URL" "$INSTALL_FALLBACK_URL"; do
+    [ -n "$url" ] || continue
+    printf '==> Fetching installer from %s\n' "$url"
+    if curl -fsSL --retry 3 --retry-connrefused -A "$INSTALL_USER_AGENT" "$url" -o "$out"; then
+      return 0
+    fi
+    printf 'install-smoke: warning: could not fetch installer from %s\n' "$url" >&2
+  done
+  return 1
+}
+
+installer="${TMP_DIR}/install.sh"
+if ! fetch_installer "$installer"; then
+  fail "could not fetch the installer from any source (primary: ${INSTALL_URL}${INSTALL_FALLBACK_URL:+, fallback: ${INSTALL_FALLBACK_URL}})"
+fi
+HOME="$HOME_DIR" bash "$installer" "${args[@]}"
 
 bin="${HOME_DIR}/.meshd/bin/meshd"
 if [ ! -x "$bin" ]; then

--- a/scripts/e2e/install-smoke.test.sh
+++ b/scripts/e2e/install-smoke.test.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Unit test for install-smoke.sh's installer-fetch/fallback behavior. Runs fully
+# offline against a fake installer served over file:// URLs — no release, no
+# network — so it is safe to run on every CI push/PR.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SMOKE="${HERE}/install-smoke.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+# A stand-in for the real install.sh: it just drops an executable that reports
+# the version it was asked to install, which is all install-smoke.sh checks.
+FAKE="${WORK}/fake-install.sh"
+cat > "$FAKE" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+ver="test"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version) ver="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+mkdir -p "${HOME}/.meshd/bin"
+cat > "${HOME}/.meshd/bin/meshd" <<EOF
+#!/usr/bin/env bash
+[ "\$1" = "--version" ] && echo "meshd ${ver}" || true
+exit 0
+EOF
+chmod +x "${HOME}/.meshd/bin/meshd"
+FAKE
+
+fails=0
+check() { # check <name> <expected-rc> <actual-rc>
+  if [ "$2" -eq "$3" ]; then
+    printf 'ok   - %s\n' "$1"
+  else
+    printf 'FAIL - %s (want rc=%s, got rc=%s)\n' "$1" "$2" "$3"
+    fails=$((fails + 1))
+  fi
+}
+
+run() { # run with a clean env; echoes nothing, returns the smoke script's rc
+  MESHD_INSTALL_REQUESTED_VERSION="0.17.0" \
+  MESHD_INSTALL_EXPECTED_VERSION="v0.17.0" \
+  "$@" bash "$SMOKE" >/dev/null 2>&1
+}
+
+# Capture each run's exit code without tripping `set -e` on the expected failure.
+# 1. Primary reachable → installs from primary.
+rc=0; run env MESHD_INSTALL_URL="file://${FAKE}" || rc=$?
+check "primary reachable installs" 0 "$rc"
+
+# 2. Primary unreachable but fallback works → installs from fallback.
+rc=0; run env MESHD_INSTALL_URL="file://${WORK}/missing.sh" MESHD_INSTALL_FALLBACK_URL="file://${FAKE}" || rc=$?
+check "falls back when primary fails" 0 "$rc"
+
+# 3. Both sources unreachable → fails.
+rc=0; run env MESHD_INSTALL_URL="file://${WORK}/a.sh" MESHD_INSTALL_FALLBACK_URL="file://${WORK}/b.sh" || rc=$?
+check "fails when no source is reachable" 1 "$rc"
+
+if [ "$fails" -ne 0 ]; then
+  printf '%d test(s) failed\n' "$fails" >&2
+  exit 1
+fi
+printf 'all install-smoke fetch tests passed\n'


### PR DESCRIPTION
## Summary

Fixes the failing `Smoke test public installer` release job (e.g. run for v0.17.0).

**Root cause:** `meshd.sh` is behind Cloudflare bot protection that returns **403 to datacenter IPs** (GitHub Actions runners), regardless of User-Agent — the same URL returns **200** from a residential IP. So CI can never fetch the installer from the public edge. The release binaries and `install.sh` itself are healthy (`install.sh` downloads binaries from `github.com/.../releases`, which CI reaches fine).

**Fix:** keep `meshd.sh` as the primary target (still validated when reachable), and add a CI-reachable **fallback** — the raw `install.sh` at the release tag. The fallback serves the same script, which downloads the same published release binaries, so the smoke test still validates the installer + binaries end to end instead of red-X'ing the release.

### Changes
- `scripts/e2e/install-smoke.sh`: fetch the installer to a file, trying the primary URL then `MESHD_INSTALL_FALLBACK_URL`, with a realistic `User-Agent` and `--retry`. Behavior is unchanged when no fallback is set (just adds UA + retry). A persistent `403` fails fast and falls through (curl doesn't retry 403), rather than hanging.
- `release.yml` / `release-please.yml`: set `MESHD_INSTALL_FALLBACK_URL` to `raw.githubusercontent.com/<repo>/<tag>/install.sh`.
- `scripts/e2e/install-smoke.test.sh` (new): offline unit test using a `file://`-served fake installer, covering primary / fallback / both-fail. Wired into the CI `test` job.

## Verification
- New test passes locally (primary reachable, falls back when primary fails, fails when neither is reachable).
- `bash -n` clean on both scripts; all three workflow YAMLs parse.

## Note
This doesn't make the public `meshd.sh` edge reachable from CI (that needs a Cloudflare-side allowlist for the runner ranges / a bypass header, which is infra outside this repo). It makes the release gate reliable while still preferring the real edge when it is reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)