### PR TITLE
feat(admin): unify invite → node expiry and tighten the dashboard flow

### DIFF
--- a/admin-dapp/src/App.tsx
+++ b/admin-dapp/src/App.tsx
@@ -2,13 +2,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   CheckIcon,
   ClipboardIcon,
+  ClockIcon,
   KeyRoundIcon,
   Loader2Icon,
   LogOutIcon,
   NetworkIcon,
+  PencilIcon,
   PlusIcon,
   RefreshCwIcon,
-  SaveIcon,
   ServerIcon,
   ShieldCheckIcon,
   TerminalIcon,
@@ -48,6 +49,7 @@ import {
 
 type LoadState = "idle" | "loading" | "ready" | "error";
 type ExpiryValue = "1h" | "24h" | "7d" | "30d" | "never";
+type ExpiryTone = "none" | "active" | "soon" | "expired";
 
 const EXPIRY_OPTIONS: Array<{ value: ExpiryValue; label: string; durationMs?: number }> = [
   { value: "1h", label: "1 hour", durationMs: 60 * 60 * 1000 },
@@ -64,26 +66,24 @@ function truncateDid(did: string, head = 18, tail = 10) {
   return `${did.slice(0, head)}...${did.slice(-tail)}`;
 }
 
-function formatTime(value?: string) {
-  if (!value) return "";
-  const date = new Date(value);
-  if (!Number.isFinite(date.getTime())) return value;
-  return new Intl.DateTimeFormat(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit"
-  }).format(date);
+function formatDuration(ms: number): string {
+  const minutes = Math.round(ms / 60_000);
+  if (minutes < 60) return `${Math.max(1, minutes)} min`;
+  const hours = Math.round(ms / 3_600_000);
+  if (hours < 48) return `${hours} hr`;
+  return `${Math.round(ms / 86_400_000)} days`;
 }
 
-function expiryState(value?: string) {
-  if (!value) return "none";
+// A single human-readable expiry descriptor drives both the label text and the
+// colour tone, so the node card, invite composer, and invite rows all speak the
+// same language ("Expires in 6 days" / "Expired 2 days ago" / "No expiry").
+function describeExpiry(value?: string): { label: string; tone: ExpiryTone } {
+  if (!value) return { label: "No expiry", tone: "none" };
   const time = new Date(value).getTime();
-  if (!Number.isFinite(time)) return "unknown";
-  const remaining = time - Date.now();
-  if (remaining <= 0) return "expired";
-  if (remaining <= 24 * 60 * 60 * 1000) return "soon";
-  return "active";
+  if (!Number.isFinite(time)) return { label: value, tone: "none" };
+  const diff = time - Date.now();
+  if (diff <= 0) return { label: `Expired ${formatDuration(-diff)} ago`, tone: "expired" };
+  return { label: `Expires in ${formatDuration(diff)}`, tone: diff <= 24 * 60 * 60 * 1000 ? "soon" : "active" };
 }
 
 async function copyToClipboard(value: string) {
@@ -199,19 +199,46 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
   const [error, setError] = useState<string>();
   const [inviteResults, setInviteResults] = useState<CreateMeshdInviteResult[]>([]);
   const [inviteLabel, setInviteLabel] = useState("");
-  const [inviteExpiry, setInviteExpiry] = useState<ExpiryValue>("24h");
-  const [approvalExpiry, setApprovalExpiry] = useState<ExpiryValue>("never");
+  const [inviteExpiry, setInviteExpiry] = useState<ExpiryValue>("7d");
   const [inviteReusable, setInviteReusable] = useState(false);
   const [networkName, setNetworkName] = useState("");
   const [networkCIDR, setNetworkCIDR] = useState("10.200.0.0/16");
   const [busyAction, setBusyAction] = useState<string>();
   const [topologyRefreshing, setTopologyRefreshing] = useState(false);
   const topologyRefreshInFlight = useRef(false);
+  // Records the operator just approved/rejected/removed are dropped from the
+  // topology optimistically, then kept suppressed so a topology refetch that
+  // still reflects the pre-delete DWN state can't resurrect them until the
+  // delete has propagated (approvals used to linger until a later refresh).
+  const suppressed = useRef({
+    requests: new Set<string>(),
+    invites: new Set<string>(),
+    nodes: new Set<string>()
+  });
 
   const selectedNetwork = useMemo(() => {
     if (networks.length === 0) return undefined;
     return networks.find((network) => network.recordId === selectedNetworkId) ?? networks[0];
   }, [networks, selectedNetworkId]);
+
+  const applySuppression = useCallback((next: MeshdNetworkTopology): MeshdNetworkTopology => {
+    const { requests, invites, nodes } = suppressed.current;
+    if (requests.size === 0 && invites.size === 0 && nodes.size === 0) return next;
+    return {
+      ...next,
+      pendingRequests: next.pendingRequests.filter((request) => !requests.has(request.recordId)),
+      preAuthKeys: next.preAuthKeys.filter((key) => !invites.has(key.recordId)),
+      members: next.members.map((member) => ({
+        ...member,
+        nodes: member.nodes.filter((node) => !nodes.has(node.recordId))
+      })),
+      legacyNodes: next.legacyNodes.filter((node) => !nodes.has(node.recordId))
+    };
+  }, []);
+
+  const patchTopology = useCallback((update: (current: MeshdNetworkTopology) => MeshdNetworkTopology) => {
+    setTopology((current) => (current ? update(current) : current));
+  }, []);
 
   const refreshNetworks = useCallback(async () => {
     if (!session || !protocolsInitialized || !ownerMatchesDashboardContext(context, did)) return;
@@ -240,7 +267,7 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
     }
     try {
       const nextTopology = await fetchMeshdNetworkTopology(session, selectedNetwork);
-      setTopology(nextTopology);
+      setTopology(applySuppression(nextTopology));
       setError(undefined);
     } catch (err) {
       if (!options?.silent) {
@@ -250,7 +277,7 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
       topologyRefreshInFlight.current = false;
       setTopologyRefreshing(false);
     }
-  }, [context, did, protocolsInitialized, selectedNetwork, session]);
+  }, [applySuppression, context, did, protocolsInitialized, selectedNetwork, session]);
 
   useEffect(() => {
     void refreshNetworks();
@@ -290,10 +317,12 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
     window.history.replaceState(null, "", `?${params.toString()}`);
   }, [did, selectedNetwork]);
 
-  // The freshly-created invite list is scoped to the selected network; reset it
-  // when the operator switches networks so stale URLs don't carry across.
+  // Freshly-created invite URLs and optimistic suppressions are scoped to the
+  // selected network; reset them when the operator switches networks so nothing
+  // carries across.
   useEffect(() => {
     setInviteResults([]);
+    suppressed.current = { requests: new Set(), invites: new Set(), nodes: new Set() };
   }, [selectedNetwork?.recordId]);
 
   async function runAction(label: string, action: () => Promise<void>) {
@@ -339,11 +368,26 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
   async function handleApprove(request: MeshdNodeRequestSummary) {
     if (!session || !selectedNetwork) return;
     await runAction(`approve-${request.recordId}`, async () => {
-      const result = await approveMeshdNodeRequest(session, selectedNetwork, request, {
-        expiresAt: expiryTimestamp(approvalExpiry)
-      });
+      const result = await approveMeshdNodeRequest(session, selectedNetwork, request);
+      // Drop the approved request now, and drop the single-use invite it consumed,
+      // so both disappear immediately instead of lingering until the delete
+      // propagates back through a refetch.
+      suppressed.current.requests.add(request.recordId);
+      const consumedInvite = request.preAuthKeyId
+        ? topology?.preAuthKeys.find((key) => key.recordId === request.preAuthKeyId)
+        : undefined;
+      if (consumedInvite && !consumedInvite.reusable) {
+        suppressed.current.invites.add(consumedInvite.recordId);
+      }
+      patchTopology((current) => ({
+        ...current,
+        pendingRequests: current.pendingRequests.filter((item) => item.recordId !== request.recordId),
+        preAuthKeys: consumedInvite && !consumedInvite.reusable
+          ? current.preAuthKeys.filter((key) => key.recordId !== consumedInvite.recordId)
+          : current.preAuthKeys
+      }));
       toast.success(`Node approved at ${result.meshIP}`);
-      await refreshTopology();
+      await refreshTopology({ silent: true });
     });
   }
 
@@ -351,8 +395,13 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
     if (!session) return;
     await runAction(`reject-${request.recordId}`, async () => {
       await rejectMeshdNodeRequest(session, request);
+      suppressed.current.requests.add(request.recordId);
+      patchTopology((current) => ({
+        ...current,
+        pendingRequests: current.pendingRequests.filter((item) => item.recordId !== request.recordId)
+      }));
       toast.success("Request rejected");
-      await refreshTopology();
+      await refreshTopology({ silent: true });
     });
   }
 
@@ -378,8 +427,13 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
     if (!session) return;
     await runAction(`revoke-${key.recordId}`, async () => {
       await revokeMeshdInvite(session, key);
+      suppressed.current.invites.add(key.recordId);
+      patchTopology((current) => ({
+        ...current,
+        preAuthKeys: current.preAuthKeys.filter((item) => item.recordId !== key.recordId)
+      }));
       toast.success("Invite revoked");
-      await refreshTopology();
+      await refreshTopology({ silent: true });
     });
   }
 
@@ -398,9 +452,22 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
     if (!session || !selectedNetwork) return;
     await runAction(`remove-${node.recordId}`, async () => {
       await removeMeshdNode(session, selectedNetwork, node);
+      suppressed.current.nodes.add(node.recordId);
+      patchTopology((current) => ({
+        ...current,
+        members: current.members.map((member) => ({
+          ...member,
+          nodes: member.nodes.filter((item) => item.recordId !== node.recordId)
+        })),
+        legacyNodes: current.legacyNodes.filter((item) => item.recordId !== node.recordId)
+      }));
       toast.success("Node removed");
-      await refreshTopology();
+      await refreshTopology({ silent: true });
     });
+  }
+
+  function dismissInviteResult(tokenId: string) {
+    setInviteResults((prev) => prev.filter((result) => result.tokenId !== tokenId));
   }
 
   if (!ownerMatchesDashboardContext(context, did)) {
@@ -437,6 +504,7 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
     ...(topology?.members.flatMap((member) => member.nodes.map((node) => ({ node, member }))) ?? []),
     ...(topology?.legacyNodes.map((node) => ({ node, member: undefined })) ?? [])
   ];
+  const pendingRequests = topology?.pendingRequests ?? [];
 
   return (
     <div className="dashboard-grid">
@@ -463,11 +531,14 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
               </span>
             </button>
           ))}
+          {networks.length === 0 && loadState === "ready" ? (
+            <EmptyRow icon={<NetworkIcon size={16} />} text="No networks yet" />
+          ) : null}
         </div>
 
         <div className="create-box">
           <div className="section-heading">
-            <span>Create</span>
+            <span>New Network</span>
           </div>
           <label>
             Name
@@ -492,13 +563,13 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
       <section className="main-panel">
         {error ? <div className="error-banner">{error}</div> : null}
         {!selectedNetwork ? (
-          <StatePanel title="No networks" detail="Create a mesh network to start approving nodes." />
+          <StatePanel title="No networks" detail="Create a mesh network in the sidebar to start inviting devices." />
         ) : (
           <>
             <div className="network-header">
               <div>
                 <h1>{selectedNetwork.name}</h1>
-                <p>{selectedNetwork.meshCIDR}</p>
+                <p>{selectedNetwork.meshCIDR} · {allNodes.length} node{allNodes.length === 1 ? "" : "s"}</p>
               </div>
               <div className="header-buttons">
                 <button className="secondary-button" type="button" onClick={() => void handleCopyOwnerSetupCommand()}>
@@ -512,17 +583,37 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
               </div>
             </div>
 
+            {pendingRequests.length > 0 ? (
+              <section className="content-section pending-section">
+                <div className="section-heading">
+                  <span>Waiting for approval</span>
+                  <small className="count-badge">{pendingRequests.length}</small>
+                </div>
+                <div className="stack">
+                  {pendingRequests.map((request) => (
+                    <PendingRequestRow
+                      key={request.recordId}
+                      request={request}
+                      busyAction={busyAction}
+                      onApprove={handleApprove}
+                      onReject={handleReject}
+                    />
+                  ))}
+                </div>
+              </section>
+            ) : null}
+
             <section className="invite-composer">
               <div className="section-heading">
-                <span>New Invite</span>
+                <span>Invite a device</span>
               </div>
               <div className="invite-fields">
                 <label>
                   Label
-                  <input value={inviteLabel} onChange={(event) => setInviteLabel(event.target.value)} placeholder={selectedNetwork.name} />
+                  <input value={inviteLabel} onChange={(event) => setInviteLabel(event.target.value)} placeholder="e.g. laptop" />
                 </label>
                 <label>
-                  Expires
+                  Access expires
                   <select value={inviteExpiry} onChange={(event) => setInviteExpiry(event.target.value as ExpiryValue)}>
                     {EXPIRY_OPTIONS.map((option) => (
                       <option key={option.value} value={option.value}>{option.label}</option>
@@ -547,47 +638,18 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
                   Create Invite
                 </button>
               </div>
+              <p className="field-hint">
+                The device stays valid until the invite expires — you set the expiry once, here, and it carries to the node when you approve it.
+              </p>
             </section>
 
-            {inviteResults.map((result) => (
-              <div className="invite-result" key={result.tokenId}>
-                <div>
-                  <strong>{result.label || "Invite URL"}</strong>
-                  <code>{result.url}</code>
-                </div>
-                <button className="icon-button" type="button" aria-label="Copy invite URL" title="Copy" onClick={() => void copyToClipboard(result.url)}>
-                  <ClipboardIcon size={16} />
-                </button>
-              </div>
-            ))}
-
-            <section className="content-section">
-              <div className="section-heading">
-                <span>Pending</span>
-                <small>{topology?.pendingRequests.length ?? 0}</small>
-              </div>
-              <div className="inline-control">
-                <label>
-                  Approve for
-                  <select value={approvalExpiry} onChange={(event) => setApprovalExpiry(event.target.value as ExpiryValue)}>
-                    {EXPIRY_OPTIONS.map((option) => (
-                      <option key={option.value} value={option.value}>{option.label}</option>
-                    ))}
-                  </select>
-                </label>
-              </div>
+            {inviteResults.length > 0 ? (
               <div className="stack">
-                {topology?.pendingRequests.length ? topology.pendingRequests.map((request) => (
-                  <PendingRequestRow
-                    key={request.recordId}
-                    request={request}
-                    busyAction={busyAction}
-                    onApprove={handleApprove}
-                    onReject={handleReject}
-                  />
-                )) : <EmptyRow icon={<ShieldCheckIcon size={18} />} text="No pending approvals" />}
+                {inviteResults.map((result) => (
+                  <InviteResultCard key={result.tokenId} result={result} onDismiss={dismissInviteResult} />
+                ))}
               </div>
-            </section>
+            ) : null}
 
             <section className="content-section">
               <div className="section-heading">
@@ -605,13 +667,13 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
                     onUpdateExpiry={handleUpdateNodeExpiry}
                     onUpdateLabel={handleUpdateNodeLabel}
                   />
-                )) : <EmptyRow icon={<ServerIcon size={18} />} text="No nodes" />}
+                )) : <EmptyRow icon={<ServerIcon size={18} />} text="No nodes yet — invite a device to get started." />}
               </div>
             </section>
 
             <section className="content-section">
               <div className="section-heading">
-                <span>Invites</span>
+                <span>Active invites</span>
                 <small>{topology?.preAuthKeys.length ?? 0}</small>
               </div>
               <div className="stack">
@@ -646,19 +708,21 @@ function PendingRequestRow({
 }) {
   const approving = busyAction === `approve-${request.recordId}`;
   const rejecting = busyAction === `reject-${request.recordId}`;
+  const isOwnerRequest = request.requestKind === "owner-node" || request.protocolPath === "nodeRequest";
   return (
     <article className="data-row">
       <div className="row-main">
         <span className="row-icon"><ServerIcon size={17} /></span>
         <span>
           <strong>{request.label || truncateDid(request.nodeDID)}</strong>
-          <small>{request.requestKind === "owner-node" || request.protocolPath === "nodeRequest" ? "Owner request" : "Invite request"}</small>
+          <small>{isOwnerRequest ? "Owner request" : "Joined via invite"}</small>
         </span>
       </div>
       <code title={request.nodeDID}>{truncateDid(request.nodeDID)}</code>
       <div className="row-actions">
-        <button className="icon-button success" type="button" aria-label="Approve" title="Approve" disabled={approving || rejecting} onClick={() => void onApprove(request)}>
-          {approving ? <Loader2Icon className="spin" size={16} /> : <CheckIcon size={16} />}
+        <button className="primary-button small" type="button" disabled={approving || rejecting} onClick={() => void onApprove(request)}>
+          {approving ? <Loader2Icon className="spin" size={15} /> : <CheckIcon size={15} />}
+          Approve
         </button>
         <button className="icon-button danger" type="button" aria-label="Reject" title="Reject" disabled={approving || rejecting} onClick={() => void onReject(request)}>
           {rejecting ? <Loader2Icon className="spin" size={16} /> : <XIcon size={16} />}
@@ -686,66 +750,120 @@ function NodeCard({
   const removing = busyAction === `remove-${node.recordId}`;
   const updatingLabel = busyAction === `label-${node.recordId}`;
   const updatingExpiry = busyAction === `expiry-${node.recordId}`;
+  const [editing, setEditing] = useState(false);
   const [labelValue, setLabelValue] = useState(node.label ?? "");
-  const [expiryChoice, setExpiryChoice] = useState<ExpiryValue>("30d");
-  const state = expiryState(node.expiresAt);
-  const expiryLabel = node.expiresAt
-    ? state === "expired"
-      ? `Expired ${formatTime(node.expiresAt)}`
-      : `Expires ${formatTime(node.expiresAt)}`
-    : "No expiry";
+  const [expiryChoice, setExpiryChoice] = useState<ExpiryValue | "">("");
+  const expiry = describeExpiry(node.expiresAt);
+
   useEffect(() => {
     setLabelValue(node.label ?? "");
   }, [node.label]);
+
+  async function applyLabel() {
+    await onUpdateLabel(node, labelValue);
+  }
+
+  async function applyExpiry() {
+    if (!expiryChoice) return;
+    await onUpdateExpiry(node, expiryChoice);
+    setExpiryChoice("");
+  }
+
   return (
-    <article className={`node-card ${state === "expired" ? "expired" : state === "soon" ? "expiring" : ""}`}>
+    <article className={`node-card ${expiry.tone === "expired" ? "expired" : expiry.tone === "soon" ? "expiring" : ""}`}>
       <div className="node-card-header">
         <span className="row-icon"><ServerIcon size={17} /></span>
         <strong>{node.label || node.meshIP || truncateDid(node.did, 12, 6)}</strong>
-        <button className="icon-button danger small" type="button" aria-label="Remove node" title="Remove" disabled={removing} onClick={() => void onRemove(node)}>
-          {removing ? <Loader2Icon className="spin" size={15} /> : <Trash2Icon size={15} />}
-        </button>
+        <span className={`expiry-pill ${expiry.tone}`} title={node.expiresAt ? formatFullTime(node.expiresAt) : undefined}>
+          <ClockIcon size={13} />
+          {expiry.label}
+        </span>
       </div>
       <dl>
         <div><dt>Mesh IP</dt><dd>{node.meshIP || "unknown"}</dd></div>
         <div><dt>Node</dt><dd title={node.did}>{truncateDid(node.did)}</dd></div>
         {owner ? <div><dt>Owner</dt><dd title={owner}>{truncateDid(owner)}</dd></div> : null}
-        <div><dt>Expiry</dt><dd>{expiryLabel}</dd></div>
       </dl>
-      <div className="label-editor">
-        <label>
-          Label
-          <input value={labelValue} onChange={(event) => setLabelValue(event.target.value)} placeholder={node.meshIP || "Node label"} />
-        </label>
-        <button
-          className="icon-button"
-          type="button"
-          aria-label="Apply node label"
-          title="Apply label"
-          disabled={updatingLabel || removing}
-          onClick={() => void onUpdateLabel(node, labelValue)}
-        >
-          {updatingLabel ? <Loader2Icon className="spin" size={15} /> : <SaveIcon size={15} />}
+
+      {editing ? (
+        <div className="node-card-edit">
+          <div className="label-editor">
+            <label>
+              Label
+              <input value={labelValue} onChange={(event) => setLabelValue(event.target.value)} placeholder={node.meshIP || "Node label"} />
+            </label>
+            <button
+              className="icon-button success"
+              type="button"
+              aria-label="Save node label"
+              title="Save label"
+              disabled={updatingLabel || removing}
+              onClick={() => void applyLabel()}
+            >
+              {updatingLabel ? <Loader2Icon className="spin" size={15} /> : <CheckIcon size={15} />}
+            </button>
+          </div>
+          <div className="expiry-editor">
+            <select value={expiryChoice} onChange={(event) => setExpiryChoice(event.target.value as ExpiryValue)}>
+              <option value="" disabled>Change expiry…</option>
+              {EXPIRY_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>{option.label}</option>
+              ))}
+            </select>
+            <button
+              className="icon-button success"
+              type="button"
+              aria-label="Apply node expiry"
+              title="Apply expiry"
+              disabled={!expiryChoice || updatingExpiry || removing}
+              onClick={() => void applyExpiry()}
+            >
+              {updatingExpiry ? <Loader2Icon className="spin" size={15} /> : <CheckIcon size={15} />}
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="node-card-actions">
+        <button className="text-button" type="button" onClick={() => setEditing((value) => !value)}>
+          <PencilIcon size={14} />
+          {editing ? "Done" : "Edit"}
         </button>
-      </div>
-      <div className="expiry-editor">
-        <select value={expiryChoice} onChange={(event) => setExpiryChoice(event.target.value as ExpiryValue)}>
-          {EXPIRY_OPTIONS.map((option) => (
-            <option key={option.value} value={option.value}>{option.label}</option>
-          ))}
-        </select>
-        <button
-          className="icon-button success"
-          type="button"
-          aria-label="Apply node expiry"
-          title="Apply expiry"
-          disabled={updatingExpiry || removing}
-          onClick={() => void onUpdateExpiry(node, expiryChoice)}
-        >
-          {updatingExpiry ? <Loader2Icon className="spin" size={15} /> : <CheckIcon size={15} />}
+        <button className="text-button danger" type="button" disabled={removing} onClick={() => void onRemove(node)}>
+          {removing ? <Loader2Icon className="spin" size={14} /> : <Trash2Icon size={14} />}
+          Remove
         </button>
       </div>
     </article>
+  );
+}
+
+function InviteResultCard({
+  result,
+  onDismiss
+}: {
+  result: CreateMeshdInviteResult;
+  onDismiss: (tokenId: string) => void;
+}) {
+  const expiry = describeExpiry(result.expiresAt);
+  return (
+    <div className="invite-result">
+      <div className="invite-result-body">
+        <div className="invite-result-head">
+          <strong>{result.label || "New invite"}</strong>
+          <span className={`expiry-pill ${expiry.tone}`}><ClockIcon size={13} />{expiry.label}</span>
+        </div>
+        <code>{result.url}</code>
+      </div>
+      <div className="row-actions">
+        <button className="icon-button" type="button" aria-label="Copy invite URL" title="Copy" onClick={() => void copyToClipboard(result.url)}>
+          <ClipboardIcon size={16} />
+        </button>
+        <button className="icon-button" type="button" aria-label="Dismiss" title="Dismiss" onClick={() => onDismiss(result.tokenId)}>
+          <XIcon size={16} />
+        </button>
+      </div>
+    </div>
   );
 }
 
@@ -761,16 +879,20 @@ function InviteRow({
   onRevoke: (invite: MeshdPreAuthKeySummary) => Promise<void>;
 }) {
   const revoking = busyAction === `revoke-${invite.recordId}`;
+  const expiry = describeExpiry(invite.expiresAt);
   return (
     <article className="data-row">
       <div className="row-main">
         <span className="row-icon"><UserPlusIcon size={17} /></span>
         <span>
           <strong>{invite.label || truncateDid(invite.recordId, 12, 6)}</strong>
-          <small>{invite.expiresAt ? `Expires ${formatTime(invite.expiresAt)}` : "No expiry"}</small>
+          <small>
+            {expiry.label}
+            {invite.reusable ? " · reusable" : ""}
+            {invite.usedBy.length ? ` · ${invite.usedBy.length} used` : ""}
+          </small>
         </span>
       </div>
-      <code>{invite.usedBy.length} used</code>
       <div className="row-actions">
         <button className="icon-button" type="button" aria-label="Copy invite" title="Copy" onClick={() => void onCopy(invite)}>
           <ClipboardIcon size={16} />
@@ -800,4 +922,13 @@ function EmptyRow({ icon, text }: { icon: React.ReactNode; text: string }) {
       <span>{text}</span>
     </div>
   );
+}
+
+function formatFullTime(value: string) {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return value;
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short"
+  }).format(date);
 }

--- a/admin-dapp/src/meshd/admin.test.ts
+++ b/admin-dapp/src/meshd/admin.test.ts
@@ -929,4 +929,31 @@ describe("meshd invite lifecycle", () => {
     const payload = await blobJson(nodeWrite!.dataStream);
     expect(payload.label).toBe("laptop-01");
   });
+
+  // One expiry model: the invite defines the access window, and the node that
+  // joins with it inherits that expiry — the operator never re-picks it at
+  // approval time. This guards against the joined node showing "No expiry" even
+  // though the invite carried one.
+  it("carries the invite's expiry to the joined node", async () => {
+    // The invite must still be live at approval time (preAuthKeyAllows gates it),
+    // so use a far-future expiry and assert the node inherits that same instant.
+    const inviteExpiry = "2099-01-01T00:00:00Z";
+    const { session, requests } = createFakeSession({
+      recordIds: ["member-rec", "node-rec"],
+      queryEntries: [inviteEntry({ reusable: false, expiresAt: inviteExpiry })]
+    });
+    const request = await signedInviteNodeRequest({
+      networkId: network.recordId, secret, preAuthKeyId: "invite-rec", ownerDID: "did:example:owner", roleKeys
+    });
+    expect(request.expiresAt).toBeUndefined();
+
+    await approveMeshdNodeRequest(session, network, request);
+
+    const nodeWrite = requests.find(
+      (r) => r.messageType === DwnInterface.RecordsWrite && r.messageParams?.protocolPath === "network/member/node"
+    );
+    expect(nodeWrite).toBeDefined();
+    const payload = await blobJson(nodeWrite!.dataStream);
+    expect(payload.expiresAt).toBe(inviteExpiry);
+  });
 });

--- a/admin-dapp/src/meshd/admin.ts
+++ b/admin-dapp/src/meshd/admin.ts
@@ -1200,9 +1200,14 @@ export async function approveMeshdNodeRequest(
   }
   const member = await ensureMemberRecord(session, network, requestOwnerDID, memberRolePublicKey, effectiveLabel);
   const meshIP = await allocateMeshIp(network.meshCIDR, request.nodeDID);
+  // One expiry model: the invite defines the access window and the joined node
+  // inherits it, so an operator sets the expiry once (when creating the invite)
+  // and never re-picks it at approval time. An explicit options.expiresAt still
+  // overrides for tooling that wants to; the fallback covers owner-scoped joins
+  // that carry no invite (they may name their own expiry on the request).
   const expiresAt = Object.prototype.hasOwnProperty.call(options, "expiresAt")
     ? options.expiresAt?.trim()
-    : request.expiresAt;
+    : preAuthKey?.expiresAt ?? request.expiresAt;
 
   // Sealed-model key delivery: the node record below is a role record with a
   // recipient, so the agent mints the sealed `$encryption/audience` key during the

--- a/admin-dapp/src/styles.css
+++ b/admin-dapp/src/styles.css
@@ -29,7 +29,7 @@ button {
 
 button:disabled {
   cursor: not-allowed;
-  opacity: 0.62;
+  opacity: 0.55;
 }
 
 code {
@@ -83,7 +83,7 @@ code {
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;
-  border-radius: 8px;
+  border-radius: 9px;
   background: #17201d;
   color: #f7faf5;
 }
@@ -152,7 +152,7 @@ code {
   width: 100%;
   max-width: 1440px;
   margin: 0 auto;
-  padding: 1rem;
+  padding: 1.25rem;
 }
 
 .connect-panel,
@@ -162,9 +162,9 @@ code {
   width: min(100%, 520px);
   margin: clamp(2rem, 12vh, 7rem) auto;
   border: 1px solid #dfe5dd;
-  border-radius: 8px;
+  border-radius: 12px;
   background: #ffffff;
-  padding: 1.25rem;
+  padding: 1.5rem;
   box-shadow: 0 12px 40px rgba(23, 32, 29, 0.08);
 }
 
@@ -181,7 +181,7 @@ code {
   align-items: center;
   gap: 0.65rem;
   border: 1px solid #d8dfd5;
-  border-radius: 8px;
+  border-radius: 9px;
   background: #fbfcfa;
   padding: 0.65rem;
   min-width: 0;
@@ -200,7 +200,7 @@ p {
 .network-header h1 {
   font-size: 1.35rem;
   line-height: 1.2;
-  letter-spacing: 0;
+  letter-spacing: -0.01em;
 }
 
 .connect-title p,
@@ -214,14 +214,14 @@ p {
 .dashboard-grid {
   display: grid;
   grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
-  gap: 1rem;
+  gap: 1.25rem;
   align-items: start;
 }
 
 .sidebar,
 .main-panel {
   border: 1px solid #dfe5dd;
-  border-radius: 8px;
+  border-radius: 12px;
   background: #ffffff;
 }
 
@@ -230,30 +230,45 @@ p {
   top: 80px;
   display: grid;
   gap: 1rem;
-  padding: 0.9rem;
+  padding: 1rem;
 }
 
 .main-panel {
   display: grid;
-  gap: 1rem;
-  padding: 1rem;
+  gap: 1.35rem;
+  padding: 1.25rem;
   min-width: 0;
 }
 
 .section-heading {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
+  gap: 0.6rem;
   color: #303a35;
-  font-size: 0.82rem;
+  font-size: 0.78rem;
   font-weight: 720;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 
 .section-heading small {
   color: #6b746f;
   font-size: 0.78rem;
+  letter-spacing: 0;
+}
+
+.count-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 0.4rem;
+  border-radius: 999px;
+  background: #e2a53c;
+  color: #fffdf7;
+  font-size: 0.72rem;
+  font-weight: 720;
 }
 
 .network-list,
@@ -269,7 +284,7 @@ p {
   align-items: center;
   width: 100%;
   border: 1px solid transparent;
-  border-radius: 8px;
+  border-radius: 9px;
   background: transparent;
   padding: 0.65rem;
   color: #303a35;
@@ -310,7 +325,7 @@ p {
   display: grid;
   gap: 0.65rem;
   border-top: 1px solid #edf0ec;
-  padding-top: 0.9rem;
+  padding-top: 1rem;
 }
 
 label {
@@ -325,7 +340,7 @@ input,
 select {
   width: 100%;
   border: 1px solid #d5ddd2;
-  border-radius: 7px;
+  border-radius: 8px;
   background: #fbfcfa;
   color: #17201d;
   padding: 0.58rem 0.65rem;
@@ -343,7 +358,7 @@ select:focus {
   justify-content: space-between;
   gap: 1rem;
   border-bottom: 1px solid #edf0ec;
-  padding-bottom: 1rem;
+  padding-bottom: 1.1rem;
 }
 
 .header-buttons,
@@ -361,7 +376,7 @@ select:focus {
   align-items: center;
   justify-content: center;
   gap: 0.45rem;
-  border-radius: 8px;
+  border-radius: 9px;
   min-height: 38px;
   border: 1px solid transparent;
   font-weight: 680;
@@ -370,7 +385,13 @@ select:focus {
 .primary-button {
   background: #245a52;
   color: #ffffff;
-  padding: 0.58rem 0.85rem;
+  padding: 0.58rem 0.9rem;
+}
+
+.primary-button.small {
+  min-height: 32px;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.85rem;
 }
 
 .secondary-button {
@@ -392,7 +413,7 @@ select:focus {
   width: 31px;
   height: 31px;
   min-height: 31px;
-  border-radius: 7px;
+  border-radius: 8px;
 }
 
 .icon-button.success {
@@ -405,23 +426,56 @@ select:focus {
   color: #9b2f2f;
 }
 
-.primary-button:hover,
-.secondary-button:hover,
-.icon-button:hover {
-  filter: brightness(0.98);
+.primary-button:hover:not(:disabled),
+.secondary-button:hover:not(:disabled),
+.icon-button:hover:not(:disabled) {
+  filter: brightness(0.97);
+}
+
+.text-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: 0;
+  background: transparent;
+  padding: 0.2rem 0.1rem;
+  color: #4c5852;
+  font-size: 0.82rem;
+  font-weight: 640;
+}
+
+.text-button:hover:not(:disabled) {
+  color: #17201d;
+}
+
+.text-button.danger {
+  color: #9b2f2f;
+}
+
+.text-button.danger:hover:not(:disabled) {
+  color: #7c2323;
 }
 
 .content-section {
   display: grid;
-  gap: 0.65rem;
+  gap: 0.7rem;
   min-width: 0;
+}
+
+.pending-section {
+  border: 1px solid #ecd7a2;
+  border-radius: 11px;
+  background: #fffdf5;
+  padding: 0.9rem;
 }
 
 .invite-composer {
   display: grid;
   gap: 0.7rem;
-  border-bottom: 1px solid #edf0ec;
-  padding-bottom: 1rem;
+  border: 1px solid #cfe0d8;
+  border-radius: 11px;
+  background: #f4faf7;
+  padding: 1rem;
   min-width: 0;
 }
 
@@ -433,14 +487,10 @@ select:focus {
   min-width: 0;
 }
 
-.inline-control {
-  display: flex;
-  justify-content: flex-end;
-  min-width: 0;
-}
-
-.inline-control label {
-  width: min(220px, 100%);
+.field-hint {
+  color: #5f6b64;
+  font-size: 0.8rem;
+  line-height: 1.45;
 }
 
 .toggle-field {
@@ -458,13 +508,12 @@ select:focus {
 }
 
 .data-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1.4fr) minmax(120px, 0.8fr) auto;
+  display: flex;
   align-items: center;
   gap: 0.75rem;
   border: 1px solid #e3e9e1;
-  border-radius: 8px;
-  padding: 0.65rem;
+  border-radius: 10px;
+  padding: 0.7rem 0.8rem;
   min-width: 0;
 }
 
@@ -472,37 +521,44 @@ select:focus {
   display: flex;
   align-items: center;
   gap: 0.65rem;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.data-row > code {
+  flex: 0 1 auto;
   min-width: 0;
 }
 
 .node-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 0.65rem;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 0.75rem;
 }
 
 .node-card {
   display: grid;
   gap: 0.75rem;
   border: 1px solid #e3e9e1;
-  border-radius: 8px;
-  padding: 0.75rem;
+  border-radius: 11px;
+  padding: 0.85rem;
   min-width: 0;
+  background: #ffffff;
 }
 
 .node-card.expiring {
-  border-color: #d8b25d;
+  border-color: #e6cf9a;
   background: #fffdf6;
 }
 
 .node-card.expired {
-  border-color: #d36b61;
+  border-color: #e0aca6;
   background: #fff8f7;
 }
 
 .node-card-header {
   display: grid;
-  grid-template-columns: 32px minmax(0, 1fr) auto;
+  grid-template-columns: 32px minmax(0, 1fr);
   align-items: center;
   gap: 0.6rem;
 }
@@ -513,15 +569,49 @@ select:focus {
   white-space: nowrap;
 }
 
+.expiry-pill {
+  grid-column: 1 / -1;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  justify-self: start;
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.74rem;
+  font-weight: 650;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.expiry-pill.none {
+  background: #eef1ee;
+  color: #5f6b64;
+}
+
+.expiry-pill.active {
+  background: #e4f2ea;
+  color: #1f7a49;
+}
+
+.expiry-pill.soon {
+  background: #fdf3d8;
+  color: #8a6316;
+}
+
+.expiry-pill.expired {
+  background: #fbe4e2;
+  color: #9b2f2f;
+}
+
 dl {
   display: grid;
-  gap: 0.45rem;
+  gap: 0.4rem;
   margin: 0;
 }
 
 dl div {
   display: grid;
-  grid-template-columns: 72px minmax(0, 1fr);
+  grid-template-columns: 62px minmax(0, 1fr);
   gap: 0.5rem;
 }
 
@@ -541,14 +631,14 @@ dd {
   white-space: nowrap;
 }
 
-.expiry-editor {
+.node-card-edit {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 38px;
-  gap: 0.5rem;
-  align-items: center;
-  min-width: 0;
+  gap: 0.55rem;
+  border-top: 1px solid #edf0ec;
+  padding-top: 0.7rem;
 }
 
+.expiry-editor,
 .label-editor {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 38px;
@@ -557,21 +647,43 @@ dd {
   min-width: 0;
 }
 
+.node-card-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  border-top: 1px solid #edf0ec;
+  padding-top: 0.6rem;
+}
+
 .invite-result {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  display: flex;
   align-items: center;
   gap: 0.75rem;
   border: 1px solid #c8d8d1;
-  border-radius: 8px;
+  border-radius: 10px;
   background: #eef6f2;
-  padding: 0.75rem;
+  padding: 0.8rem;
   min-width: 0;
 }
 
-.invite-result strong {
-  display: block;
-  margin-bottom: 0.35rem;
+.invite-result-body {
+  display: grid;
+  gap: 0.4rem;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.invite-result-head {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.invite-result-head strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .invite-result code {
@@ -584,17 +696,18 @@ dd {
   align-items: center;
   gap: 0.5rem;
   border: 1px dashed #d9e1d6;
-  border-radius: 8px;
-  padding: 0.85rem;
+  border-radius: 10px;
+  padding: 0.9rem;
   color: #6b746f;
+  font-size: 0.88rem;
 }
 
 .error-banner {
   border: 1px solid #efcaca;
-  border-radius: 8px;
+  border-radius: 10px;
   background: #fff4f4;
   color: #8d2c2c;
-  padding: 0.75rem;
+  padding: 0.8rem;
   overflow-wrap: anywhere;
 }
 
@@ -618,7 +731,7 @@ dd {
 
 @media (max-width: 860px) {
   .workspace {
-    padding: 0.75rem;
+    padding: 0.85rem;
   }
 
   .dashboard-grid {
@@ -651,11 +764,12 @@ dd {
   }
 
   .data-row {
-    grid-template-columns: minmax(0, 1fr) auto;
+    flex-wrap: wrap;
   }
 
   .data-row > code {
-    grid-column: 1 / -1;
+    order: 3;
+    flex: 1 1 100%;
   }
 }
 
@@ -666,10 +780,6 @@ dd {
 
   .connect-title {
     align-items: flex-start;
-  }
-
-  .data-row {
-    grid-template-columns: minmax(0, 1fr);
   }
 
   .invite-fields {


### PR DESCRIPTION
## Summary

Tightens the meshd-admin dashboard and, most importantly, replaces the three
disconnected expiry controls with **one model: the invite defines the access
window, and the joined node inherits it.** This fixes the reported confusion
where setting "7 days" on an invite left the approved node showing **No expiry**
(the node was inheriting a separate "Approve for" dropdown that defaulted to
"never"), and where the node card's change-expiry dropdown showed a misleading
hardcoded "30 days" that looked like the current value.

Closes #204. Encryption follow-up tracked in #205.

## What changed (admin-dapp only)

- **Invite → node expiry.** `approveMeshdNodeRequest` now defaults the joined
  node's `expiresAt` to the invite's own expiry (falling back to the request's
  for owner-scoped joins); an explicit override still wins. The redundant
  "Approve for" dropdown is gone and approving is a single click.
- **Node cards show the real expiry** as a color-coded pill — *Expires in 6
  days* / *Expires in 3 hr* / *Expired 2 days ago* / *No expiry*. Label and
  change-expiry editing is behind an **Edit** toggle; the expiry `<select>` is a
  neutral "Change expiry…" action rather than a fake current value.
- **Optimistic removal + suppression.** Approve / reject / revoke / remove drop
  the item from the topology immediately and keep it suppressed, so a topology
  refetch that still reflects pre-delete DWN state can't resurrect it (approvals
  used to linger until a later refresh).
- **UI tightening:** amber "Waiting for approval" callout with a count badge, a
  single green invite card with a one-line explanation of the expiry model,
  dismissable freshly-created invite URLs, humanized relative expiry, and a
  responsive layout down to mobile.

## Screenshots

Verified by rendering the exact markup against the real `styles.css` at desktop
and mobile widths (active / expiring / expired node cards, pending accent,
invite composer, active invites).

## Verification

- `npm run build` (tsc + vite) — passes.
- `npm test` (vitest) — **42 passed**, including a new test asserting the joined
  node inherits the invite's `expiresAt`.
- `go build ./...` and `go vet ./...` — clean (no Go changes in this PR).

## Not in scope

Encrypting `nodeApproval` (#1) and documenting the deliberately-plaintext
bootstrapping records (#2) are tracked in **#205** — that is a protocol +
key-delivery change (the `nodeApproval` path has no `$keyAgreement` and is read
plaintext by Go `FindOwnerNodeApproval`), not a fold-in, and it only affects the
owner-adds-own-device flow — the invite → node join flow is already fully
encrypted.
