### PR TITLE
feat: one-command onboarding — install, join, wait for approval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Installer smoke fetch test
         run: ./scripts/e2e/install-smoke.test.sh
 
+      - name: Installer up-passthrough test
+        run: ./scripts/e2e/install-up.test.sh
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/README.md
+++ b/README.md
@@ -32,13 +32,19 @@ meshd up
 meshd invite create
 # prints: meshd://invite/eyJ...
 
-# On your second machine, join from the invite
-meshd up
-# paste the meshd://invite/... URL at the setup prompt
+# On each new machine, one command installs meshd, requests to join, waits
+# for approval, and starts the mesh:
+curl -fsSL https://meshd.sh/install | bash -s -- up 'meshd://invite/eyJ...'
 
-# That's it. After the anchor approves the invite, the machines can reach each other at 10.200.x.x
-# through encrypted WireGuard tunnels. NAT traversal is automatic.
+# That's it. Once the invite is approved (dashboard, or automatically while the
+# anchor is online), the machines reach each other at 10.200.x.x through
+# encrypted WireGuard tunnels. NAT traversal is automatic.
 ```
+
+The admin dashboard's invite composer copies that one-liner for you. If meshd
+is already installed, `meshd up 'meshd://invite/...'` does the same join —
+submit, wait for approval, connect. `--wait-timeout <dur>` bounds the wait
+(default 15m) and `--no-wait` restores the old submit-and-exit behavior.
 
 ### Wallet-delegate onboarding (enbox connect)
 
@@ -88,14 +94,15 @@ meshd up did:example:owner
 # Or run the wizard and paste the owner DID at the setup prompt.
 meshd up
 
-# Approve the pending device in the dashboard, then start it.
-meshd up
+# Approve the pending device in the dashboard; meshd keeps waiting and
+# starts on its own once the approval lands.
 ```
 
-`meshd up` stores the pending owner request locally and exits cleanly while it
-waits. After approval, the dashboard writes the node membership record, delivers
-the network context key, and writes a node approval response that the CLI
-consumes on the next `meshd up`.
+`meshd up` stores the pending owner request locally and polls for approval
+(default 15m, `--wait-timeout` to change, `--no-wait` to exit immediately).
+After approval, the dashboard writes the node membership record, delivers the
+network context key, and writes a node approval response that the waiting CLI
+picks up; if the wait timed out, a later `meshd up` resumes it.
 If the owner DID does not advertise a DWN endpoint, meshd uses the beta DWN
 endpoint by default. Use `--endpoint` or `DWN_ENDPOINT` to override it.
 The dashboard uses the same beta endpoint when creating a network for an owner

--- a/admin-dapp/src/App.tsx
+++ b/admin-dapp/src/App.tsx
@@ -25,7 +25,7 @@ import {
   ownerMatchesDashboardContext,
   type MeshdDashboardURLContext
 } from "./meshd/dashboard-url";
-import { ownerSetupCommand } from "./meshd/commands";
+import { installAndUpCommand } from "./meshd/commands";
 import {
   approveMeshdNodeRequest,
   buildMeshdInviteURL,
@@ -386,7 +386,7 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
           ? current.preAuthKeys.filter((key) => key.recordId !== consumedInvite.recordId)
           : current.preAuthKeys
       }));
-      toast.success(`Node approved at ${result.meshIP}`);
+      toast.success(`Node approved at ${result.meshIP} — a waiting device connects on its own; otherwise run 'meshd up' on it`);
       await refreshTopology({ silent: true });
     });
   }
@@ -443,9 +443,15 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
     await copyToClipboard(url);
   }
 
+  async function handleCopyExistingInviteCommand(key: MeshdPreAuthKeySummary) {
+    if (!session || !selectedNetwork) return;
+    const url = await buildMeshdInviteURL(session, selectedNetwork, key);
+    await copyToClipboard(installAndUpCommand(url));
+  }
+
   async function handleCopyOwnerSetupCommand() {
     if (!did) return;
-    await copyToClipboard(ownerSetupCommand(did));
+    await copyToClipboard(installAndUpCommand(did));
   }
 
   async function handleRemoveNode(node: MeshdNodeSummary) {
@@ -683,6 +689,7 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
                     invite={key}
                     busyAction={busyAction}
                     onCopy={handleCopyExistingInvite}
+                    onCopyCommand={handleCopyExistingInviteCommand}
                     onRevoke={handleRevokeInvite}
                   />
                 )) : <EmptyRow icon={<UserPlusIcon size={18} />} text="No active invites" />}
@@ -846,6 +853,7 @@ function InviteResultCard({
   onDismiss: (tokenId: string) => void;
 }) {
   const expiry = describeExpiry(result.expiresAt);
+  const command = installAndUpCommand(result.url);
   return (
     <div className="invite-result">
       <div className="invite-result-body">
@@ -853,10 +861,18 @@ function InviteResultCard({
           <strong>{result.label || "New invite"}</strong>
           <span className={`expiry-pill ${expiry.tone}`}><ClockIcon size={13} />{expiry.label}</span>
         </div>
-        <code>{result.url}</code>
+        <code>{command}</code>
+        <p className="field-hint">
+          Run this on the new device: it installs meshd, requests to join, and
+          connects on its own once you approve it here. If meshd is already
+          installed, copy just the invite URL and run `meshd up &lt;url&gt;` instead.
+        </p>
       </div>
       <div className="row-actions">
-        <button className="icon-button" type="button" aria-label="Copy invite URL" title="Copy" onClick={() => void copyToClipboard(result.url)}>
+        <button className="icon-button" type="button" aria-label="Copy install command" title="Copy install command" onClick={() => void copyToClipboard(command)}>
+          <TerminalIcon size={16} />
+        </button>
+        <button className="icon-button" type="button" aria-label="Copy invite URL" title="Copy invite URL" onClick={() => void copyToClipboard(result.url)}>
           <ClipboardIcon size={16} />
         </button>
         <button className="icon-button" type="button" aria-label="Dismiss" title="Dismiss" onClick={() => onDismiss(result.tokenId)}>
@@ -871,11 +887,13 @@ function InviteRow({
   invite,
   busyAction,
   onCopy,
+  onCopyCommand,
   onRevoke
 }: {
   invite: MeshdPreAuthKeySummary;
   busyAction?: string;
   onCopy: (invite: MeshdPreAuthKeySummary) => Promise<void>;
+  onCopyCommand: (invite: MeshdPreAuthKeySummary) => Promise<void>;
   onRevoke: (invite: MeshdPreAuthKeySummary) => Promise<void>;
 }) {
   const revoking = busyAction === `revoke-${invite.recordId}`;
@@ -894,7 +912,10 @@ function InviteRow({
         </span>
       </div>
       <div className="row-actions">
-        <button className="icon-button" type="button" aria-label="Copy invite" title="Copy" onClick={() => void onCopy(invite)}>
+        <button className="icon-button" type="button" aria-label="Copy install command" title="Copy install command" onClick={() => void onCopyCommand(invite)}>
+          <TerminalIcon size={16} />
+        </button>
+        <button className="icon-button" type="button" aria-label="Copy invite URL" title="Copy invite URL" onClick={() => void onCopy(invite)}>
           <ClipboardIcon size={16} />
         </button>
         <button className="icon-button danger" type="button" aria-label="Revoke invite" title="Revoke" disabled={revoking} onClick={() => void onRevoke(invite)}>

--- a/admin-dapp/src/meshd/commands.test.ts
+++ b/admin-dapp/src/meshd/commands.test.ts
@@ -1,21 +1,25 @@
 import { describe, expect, it } from "vitest";
 
-import { ownerSetupCommand, shellQuote } from "./commands";
+import { installAndUpCommand, shellQuote } from "./commands";
 
 describe("meshd admin command helpers", () => {
-  it("builds the owner setup command", () => {
-    expect(ownerSetupCommand("did:example:owner")).toBe("meshd up 'did:example:owner'");
-  });
-
-  it("trims the owner DID before building commands", () => {
-    expect(ownerSetupCommand("  did:example:owner  ")).toBe("meshd up 'did:example:owner'");
-  });
-
   it("shell-quotes single quotes defensively", () => {
     expect(shellQuote("did:example:o'wner")).toBe("'did:example:o'\\''wner'");
   });
 
-  it("rejects empty owner DIDs", () => {
-    expect(() => ownerSetupCommand("   ")).toThrow("Owner DID is required.");
+  it("builds the install+up one-liner for an invite URL", () => {
+    expect(installAndUpCommand("meshd://invite/abc123", "https://meshd.sh/install")).toBe(
+      "curl -fsSL https://meshd.sh/install | bash -s -- up 'meshd://invite/abc123'"
+    );
+  });
+
+  it("builds the install+up one-liner for an owner DID", () => {
+    expect(installAndUpCommand(" did:example:owner ", "https://meshd.sh/install")).toBe(
+      "curl -fsSL https://meshd.sh/install | bash -s -- up 'did:example:owner'"
+    );
+  });
+
+  it("rejects empty install+up targets", () => {
+    expect(() => installAndUpCommand("   ")).toThrow("An invite URL or owner DID is required.");
   });
 });

--- a/admin-dapp/src/meshd/commands.ts
+++ b/admin-dapp/src/meshd/commands.ts
@@ -1,11 +1,18 @@
+export const INSTALL_SCRIPT_URL: string =
+  import.meta.env?.VITE_MESHD_INSTALL_URL || "https://meshd.sh/install";
+
 export function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
-export function ownerSetupCommand(ownerDID: string): string {
-  const did = ownerDID.trim();
-  if (!did) {
-    throw new Error("Owner DID is required.");
+// installAndUpCommand builds the copy-paste onboarding one-liner: install the
+// latest meshd, submit the join request, wait for dashboard approval, and
+// start the mesh. `target` is either a meshd://invite URL or an owner DID —
+// both are positional arguments to `meshd up`.
+export function installAndUpCommand(target: string, installUrl: string = INSTALL_SCRIPT_URL): string {
+  const value = target.trim();
+  if (!value) {
+    throw new Error("An invite URL or owner DID is required.");
   }
-  return `meshd up ${shellQuote(did)}`;
+  return `curl -fsSL ${installUrl} | bash -s -- up ${shellQuote(value)}`;
 }

--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -85,6 +85,9 @@ Up flags:
   --no-tun          Use userspace mode without OS routes
   --port <n>        WireGuard UDP listen port (default: auto)
   --poll-interval   DWN poll interval (default: 30s)
+  --wait-timeout <dur>
+                    How long to wait for dashboard approval (default: 15m)
+  --no-wait         Exit immediately when the join request is still pending
   --foreground      Run in the current terminal instead of background
   -v, --verbose     Enable debug logging
 
@@ -1941,7 +1944,31 @@ func cmdJoin(ctx context.Context, args []string, flagProfile string) error {
 	if noStartHint {
 		joinArgs = append(joinArgs, "--no-start-hint")
 	}
-	return cmdNetworkJoin(ctx, joinArgs, flagProfile)
+	if err := cmdNetworkJoin(ctx, joinArgs, flagProfile); err != nil {
+		return err
+	}
+	if preauth {
+		rememberPendingJoinToken(stateDir, payload.TokenID)
+	}
+	return nil
+}
+
+// rememberPendingJoinToken records which invite token the pending join
+// request was submitted with, so a later `meshd up` with the same invite does
+// not submit a duplicate request. Best-effort: the token is an optimization,
+// not a correctness requirement.
+func rememberPendingJoinToken(stateDir, tokenID string) {
+	if tokenID == "" {
+		return
+	}
+	ns, err := state.LoadNetworkState(stateDir)
+	if err != nil || ns == nil || ns.NodeRecordID != "" || ns.PendingJoinTokenID == tokenID {
+		return
+	}
+	ns.PendingJoinTokenID = tokenID
+	if err := state.SaveNetworkState(stateDir, ns); err != nil {
+		fmt.Printf("  Warning: could not record the pending invite token: %v\n", err)
+	}
 }
 
 func parseJoinCommandArgs(args []string) (inviteURL string, ownerDID string, noStartHint bool, err error) {
@@ -3323,6 +3350,10 @@ type upFlags struct {
 	pollInterval time.Duration // --poll-interval <dur>
 	foreground   bool          // --foreground: keep meshd up attached
 	verbose      bool          // -v / --verbose
+
+	// Approval wait flags.
+	waitTimeout time.Duration // --wait-timeout <dur>: approval wait bound
+	noWait      bool          // --no-wait: exit instead of waiting for approval
 }
 
 func parseUpFlags(args []string) upFlags {
@@ -3380,6 +3411,15 @@ func parseUpFlags(args []string) upFlags {
 			f.noTun = true
 		case "--foreground":
 			f.foreground = true
+		case "--wait-timeout":
+			if i+1 < len(args) {
+				if d, err := time.ParseDuration(args[i+1]); err == nil {
+					f.waitTimeout = d
+				}
+				i++
+			}
+		case "--no-wait":
+			f.noWait = true
 		case "-v", "--verbose":
 			f.verbose = true
 		default:
@@ -3681,6 +3721,10 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 		socketPath := daemon.DefaultSocketPath()
 		if daemon.NewClient(socketPath).IsRunning() {
 			fmt.Println("meshd is already running.")
+			if f.inviteURL != "" || f.ownerDID != "" {
+				fmt.Println("  Note: the invite/owner argument was ignored — this machine is already in a mesh.")
+				fmt.Println("  To join a different network, run 'meshd down' and 'meshd network leave' first.")
+			}
 			fmt.Printf("  Socket: %s\n", socketPath)
 			fmt.Println("Run 'meshd status' to inspect it or 'meshd down' to stop it.")
 			return nil
@@ -3712,26 +3756,51 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 			return err
 		}
 	}
+	// Child processes never wait for approval: they are spawned only after
+	// membership is complete, and a wait loop inside them would block
+	// invisibly in the daemon log.
+	waitForApprovalEnabled := !f.noWait && !backgroundChild && os.Getenv(sudoChildEnv) != "1"
+
 	if ns != nil && ns.NetworkRecordID == "" && ns.NodeRecordID == "" && ns.AnchorDID != "" {
 		ns, err = refreshPendingOwnerApproval(ctx, stateDir, ns, identity)
 		if err != nil {
 			return err
 		}
 		if ns.NetworkRecordID == "" || ns.NodeRecordID == "" {
-			printPendingOwnerApproval(ns)
-			return nil
+			if !waitForApprovalEnabled {
+				printPendingOwnerApproval(ns)
+				return fmt.Errorf("node approval is still pending; approve it in the dashboard, then run 'meshd up'")
+			}
+			ns, err = awaitMembershipApproval(ctx, approvalWaitOwner, f, stateDir, ns, identity, flagProfile, shouldElevate)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	if ns.NodeRecordID == "" && ns.AnchorDID != identity.URI {
-		if createdFromInvite {
-			return fmt.Errorf("join request is waiting for approval; approve it in the wallet admin panel or keep the anchor online, then run 'meshd up'")
-		}
-		ns, err = refreshPendingJoin(ctx, stateDir, ns, flagProfile, true)
-		if err != nil {
-			return err
+		if !createdFromInvite {
+			ns, err = refreshPendingJoin(ctx, stateDir, ns, flagProfile, true)
+			if err != nil {
+				return err
+			}
+			if ns.NodeRecordID == "" && f.inviteURL != "" {
+				// Still pending and an invite was passed explicitly: the
+				// original invite may have expired or been revoked, so honor
+				// the new one instead of silently ignoring it.
+				ns, err = resubmitPendingInviteJoin(ctx, f.inviteURL, stateDir, ns, identity, flagProfile)
+				if err != nil {
+					return err
+				}
+			}
 		}
 		if ns.NodeRecordID == "" {
-			return fmt.Errorf("join request is waiting for approval; approve it in the wallet admin panel or keep the anchor online, then run 'meshd up'")
+			if !waitForApprovalEnabled {
+				return fmt.Errorf("join request is waiting for approval; approve it in the wallet admin panel or keep the anchor online, then run 'meshd up'")
+			}
+			ns, err = awaitMembershipApproval(ctx, approvalWaitJoin, f, stateDir, ns, identity, flagProfile, shouldElevate)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	selfNodeDID := networkNodeDID(ns, identity.URI)
@@ -4379,12 +4448,24 @@ func refreshPendingJoin(ctx context.Context, stateDir string, ns *state.NetworkS
 		_ = state.SaveNetworkState(stateDir, &previous)
 		return &previous, nil
 	}
+	// The rejoin rewrote the state file without the pending invite token;
+	// carry it over while the join is still pending so duplicate-request
+	// suppression keeps working across re-runs.
+	if refreshed.NodeRecordID == "" && previous.PendingJoinTokenID != "" && refreshed.PendingJoinTokenID == "" {
+		refreshed.PendingJoinTokenID = previous.PendingJoinTokenID
+		if err := state.SaveNetworkState(stateDir, refreshed); err != nil {
+			return nil, fmt.Errorf("saving refreshed network state: %w", err)
+		}
+	}
 	return refreshed, nil
 }
 
 // setupInteractive prompts the user to request owner approval, create, or join
 // a network.
 func setupInteractive(ctx context.Context, f upFlags, stateDir string, identity *did.DID, flagProfile string) (*state.NetworkState, error) {
+	if !stdinIsTerminal() {
+		return nil, fmt.Errorf("no network configured and no interactive terminal; run 'meshd up <meshd://invite/...>' or 'meshd up <owner-did>' (see 'meshd --help')")
+	}
 	fmt.Println("No network configured. What would you like to do?")
 	fmt.Println()
 	fmt.Println("  Paste an owner DID or invite URL, or choose:")

--- a/cmd/meshd/upwait.go
+++ b/cmd/meshd/upwait.go
@@ -1,0 +1,402 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/enboxorg/meshd/internal/did"
+	"github.com/enboxorg/meshd/internal/dwn"
+	"github.com/enboxorg/meshd/internal/invite"
+	"github.com/enboxorg/meshd/internal/mesh"
+	"github.com/enboxorg/meshd/internal/state"
+	"github.com/enboxorg/meshd/protocols"
+)
+
+// meshd up waits for dashboard approval by default so that a single command
+// (install + up <invite>) carries a fresh machine all the way into the mesh.
+const (
+	defaultApprovalWaitTimeout  = 15 * time.Minute
+	sudoRefreshInterval         = time.Minute
+	postApprovalRefreshAttempts = 4
+	postApprovalRefreshDelay    = 10 * time.Second
+)
+
+// approvalPollPolicy controls the poll cadence: pending answers back off to
+// max, transient check errors (DWN hiccups, rate limits) back off to errorMax.
+type approvalPollPolicy struct {
+	initial  time.Duration
+	max      time.Duration
+	errorMax time.Duration
+}
+
+var defaultApprovalPollPolicy = approvalPollPolicy{
+	initial:  3 * time.Second,
+	max:      15 * time.Second,
+	errorMax: time.Minute,
+}
+
+var errApprovalWaitTimeout = errors.New("timed out waiting for approval")
+
+// approvalWaitDeadline bounds the wait by the invite expiry when one is known:
+// polling past the invite's own lifetime can never succeed.
+func approvalWaitDeadline(now time.Time, timeout time.Duration, inviteExpiresAt string) time.Time {
+	deadline := now.Add(timeout)
+	if inviteExpiresAt == "" {
+		return deadline
+	}
+	expiry, err := time.Parse(time.RFC3339, inviteExpiresAt)
+	if err != nil {
+		return deadline
+	}
+	if expiry.Before(deadline) {
+		return expiry
+	}
+	return deadline
+}
+
+// waitForApproval polls check until it reports done, the deadline passes, or
+// ctx is cancelled. check errors are treated as transient (DWN hiccups, rate
+// limits) and retried with a longer backoff than the pending-state cadence.
+func waitForApproval(ctx context.Context, deadline time.Time, out io.Writer, policy approvalPollPolicy, check func(context.Context) (bool, error)) error {
+	delay := policy.initial
+	var lastErr error
+	for {
+		done, err := check(ctx)
+		if err == nil {
+			if done {
+				return nil
+			}
+			lastErr = nil
+			delay = nextApprovalPollDelay(delay, policy.max)
+		} else {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if lastErr == nil || lastErr.Error() != err.Error() {
+				fmt.Fprintf(out, "  Approval check failed (will retry): %v\n", err)
+			}
+			lastErr = err
+			delay = nextApprovalPollDelay(delay, policy.errorMax)
+		}
+
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			if lastErr != nil {
+				return fmt.Errorf("%w (last check error: %v)", errApprovalWaitTimeout, lastErr)
+			}
+			return errApprovalWaitTimeout
+		}
+		sleep := delay
+		if sleep > remaining {
+			sleep = remaining
+		}
+		timer := time.NewTimer(sleep)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func nextApprovalPollDelay(current, max time.Duration) time.Duration {
+	next := current + current/2
+	if next > max {
+		return max
+	}
+	return next
+}
+
+// pendingJoinApproved reports whether the anchor has provisioned a node record
+// for this identity. It is the read-only subset of the discovery performed by
+// cmdNetworkJoin, cheap enough to run in a poll loop.
+func pendingJoinApproved(ctx context.Context, ns *state.NetworkState, identity *did.DID) (bool, error) {
+	signer := &dwn.Signer{DID: identity.URI, PrivateKey: identity.SigningKey}
+	api := dwn.NewDwnAPI(dwn.NewSimpleAgent(ns.AnchorEndpoint, signer))
+	nodeDID := ns.EffectiveNodeDID(identity.URI)
+	ownerDID := ns.EffectiveOwnerDID(nodeDID)
+
+	nodeRecords, status, err := api.Query(ctx, ns.AnchorDID, dwn.QueryParams{
+		Filter: dwn.RecordsFilter{
+			Protocol:     protocols.MeshProtocolURI,
+			ProtocolPath: "network/node",
+			ContextID:    ns.NetworkRecordID,
+			Recipient:    nodeDID,
+		},
+		DateSort: "createdDescending",
+	}, "")
+	if err != nil {
+		return false, err
+	}
+	if status.Code == 200 && len(nodeRecords) > 0 {
+		return true, nil
+	}
+
+	memberRecords, memStatus, err := api.Query(ctx, ns.AnchorDID, dwn.QueryParams{
+		Filter: dwn.RecordsFilter{
+			Protocol:     protocols.MeshProtocolURI,
+			ProtocolPath: "network/member",
+			ContextID:    ns.NetworkRecordID,
+			Recipient:    ownerDID,
+		},
+		DateSort: "createdDescending",
+	}, "network/member")
+	if err != nil {
+		return false, err
+	}
+	if memStatus.Code != 200 {
+		return false, nil
+	}
+	for _, memberRecord := range memberRecords {
+		memberNodes, nodeStatus, err := api.Query(ctx, ns.AnchorDID, dwn.QueryParams{
+			Filter: dwn.RecordsFilter{
+				Protocol:     protocols.MeshProtocolURI,
+				ProtocolPath: "network/member/node",
+				ContextID:    ns.NetworkRecordID + "/" + memberRecord.ID,
+				Recipient:    nodeDID,
+			},
+			DateSort: "createdDescending",
+		}, "network/member")
+		if err != nil {
+			return false, err
+		}
+		if nodeStatus.Code == 200 && len(memberNodes) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// keepSudoFresh pre-validates sudo before the approval wait and keeps the
+// timestamp fresh while waiting, so the post-approval TUN elevation runs
+// without re-prompting after the user has walked away. The returned stop
+// function ends the refresh loop.
+func keepSudoFresh(ctx context.Context) (stop func(), err error) {
+	sudoPath, err := exec.LookPath("sudo")
+	if err != nil {
+		return nil, fmt.Errorf("system routing requires administrator privileges, but sudo was not found; run meshd as root or use --no-tun")
+	}
+	fmt.Fprintln(os.Stderr, "meshd: system routing needs administrator privileges; validating sudo now so the mesh can start unattended once approved.")
+	validate := exec.CommandContext(ctx, sudoPath, "-v")
+	validate.Stdin = os.Stdin
+	validate.Stdout = os.Stdout
+	validate.Stderr = os.Stderr
+	if err := validate.Run(); err != nil {
+		return nil, fmt.Errorf("sudo authentication failed: %w", err)
+	}
+	// Systems with timestamp_timeout=0 never cache sudo credentials, so the
+	// refresh loop cannot keep them fresh — warn instead of promising an
+	// unattended start.
+	if err := exec.Command(sudoPath, "-n", "-v").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "meshd: sudo does not cache credentials on this system; it will prompt again once the approval arrives.")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(sudoRefreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				_ = exec.Command(sudoPath, "-n", "-v").Run()
+			}
+		}
+	}()
+	return func() { close(done) }, nil
+}
+
+type approvalWaitKind int
+
+const (
+	approvalWaitJoin approvalWaitKind = iota
+	approvalWaitOwner
+)
+
+// awaitMembershipApproval blocks until the pending join (invite) or owner
+// request is approved, then returns the refreshed network state. It owns all
+// user-facing progress output for the wait.
+func awaitMembershipApproval(ctx context.Context, kind approvalWaitKind, f upFlags, stateDir string, ns *state.NetworkState, identity *did.DID, flagProfile string, shouldElevate bool) (*state.NetworkState, error) {
+	timeout := f.waitTimeout
+	if timeout <= 0 {
+		timeout = defaultApprovalWaitTimeout
+	}
+
+	inviteExpiresAt := ""
+	if f.inviteURL != "" {
+		if payload, err := invite.Decode(f.inviteURL); err == nil {
+			inviteExpiresAt = payload.ExpiresAt
+		}
+	}
+	deadline := approvalWaitDeadline(time.Now(), timeout, inviteExpiresAt)
+
+	waitCtx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	if shouldElevate {
+		stopSudo, err := keepSudoFresh(waitCtx)
+		if err != nil {
+			return nil, err
+		}
+		defer stopSudo()
+	}
+
+	ownerDID := ns.EffectiveOwnerDID(ns.AnchorDID)
+	// The dashboard operates in the network owner's wallet context. For invite
+	// joins that is the anchor DID — the local OwnerDID defaults to the
+	// joiner's own DID and would produce a URL the owner's wallet rejects.
+	adminCtx := adminContext{OwnerDID: ns.AnchorDID, NetworkRecordID: ns.NetworkRecordID}
+	fmt.Printf("\nWaiting for approval (timeout %s)...\n", timeout)
+	if kind == approvalWaitJoin {
+		fmt.Printf("  Approve this device in the dashboard, or keep the anchor node online\n")
+		fmt.Printf("  for automatic approval:\n")
+	} else {
+		fmt.Printf("  Approve this device in the dashboard:\n")
+	}
+	fmt.Printf("    %s\n", buildAdminURL(defaultAdminDashboardURL, adminCtx))
+	fmt.Printf("  meshd continues automatically once approved. Ctrl+C to stop waiting;\n")
+	fmt.Printf("  the request stays pending and 'meshd up' resumes it.\n\n")
+
+	var check func(context.Context) (bool, error)
+	switch kind {
+	case approvalWaitOwner:
+		nodeDID := ns.EffectiveNodeDID(identity.URI)
+		check = func(ctx context.Context) (bool, error) {
+			approval, _, err := mesh.FindOwnerNodeApproval(ctx, ns.AnchorEndpoint, ownerDID, nodeDID, dwnSigner(identity))
+			if err != nil {
+				return false, err
+			}
+			return approval != nil, nil
+		}
+	default:
+		check = func(ctx context.Context) (bool, error) {
+			return pendingJoinApproved(ctx, ns, identity)
+		}
+	}
+
+	if err := waitForApproval(waitCtx, deadline, os.Stdout, defaultApprovalPollPolicy, check); err != nil {
+		return nil, approvalWaitFailure(err, kind, inviteExpiresAt, deadline, adminCtx)
+	}
+
+	// Approval observed: run the existing refresh to persist the full
+	// membership state. The refresh re-queries the DWN, so a transient error
+	// or a propagation lag right after approval must not discard a successful
+	// unattended wait — retry briefly before giving up.
+	refresh := func() (*state.NetworkState, error) {
+		if kind == approvalWaitOwner {
+			refreshed, err := refreshPendingOwnerApproval(ctx, stateDir, ns, identity)
+			if err == nil && (refreshed.NetworkRecordID == "" || refreshed.NodeRecordID == "") {
+				return nil, fmt.Errorf("approval was detected but no node record was found")
+			}
+			return refreshed, err
+		}
+		refreshed, err := refreshPendingJoin(ctx, stateDir, ns, flagProfile, true)
+		if err == nil && refreshed.NodeRecordID == "" {
+			return nil, fmt.Errorf("approval was detected but no node record was found")
+		}
+		return refreshed, err
+	}
+	var refreshed *state.NetworkState
+	var refreshErr error
+	for attempt := 0; attempt < postApprovalRefreshAttempts; attempt++ {
+		if attempt > 0 {
+			timer := time.NewTimer(postApprovalRefreshDelay)
+			select {
+			case <-waitCtx.Done():
+				timer.Stop()
+				return nil, approvalWaitFailure(waitCtx.Err(), kind, inviteExpiresAt, deadline, adminCtx)
+			case <-timer.C:
+			}
+			fmt.Printf("  Membership refresh failed (%v); retrying...\n", refreshErr)
+		}
+		refreshed, refreshErr = refresh()
+		if refreshErr == nil {
+			return refreshed, nil
+		}
+	}
+	return nil, fmt.Errorf("%w; run 'meshd up' to retry", refreshErr)
+}
+
+// approvalWaitFailure turns a wait-loop error into an actionable message.
+func approvalWaitFailure(err error, kind approvalWaitKind, inviteExpiresAt string, deadline time.Time, adminCtx adminContext) error {
+	dashboardURL := buildAdminURL(defaultAdminDashboardURL, adminCtx)
+	approveHint := fmt.Sprintf("approve it in the dashboard (%s)", dashboardURL)
+	if kind == approvalWaitJoin {
+		approveHint += " or keep the anchor node online"
+	}
+	if errors.Is(err, errApprovalWaitTimeout) {
+		if inviteExpiresAt != "" {
+			if expiry, parseErr := time.Parse(time.RFC3339, inviteExpiresAt); parseErr == nil && !time.Now().Before(expiry) {
+				return fmt.Errorf("the invite expired at %s before it was approved; create a new invite in the dashboard (%s) and run 'meshd up <new-invite>'", inviteExpiresAt, dashboardURL)
+			}
+		}
+		return fmt.Errorf("%v; the request is still pending — %s and run 'meshd up' to continue, or re-run with --wait-timeout for a longer wait", err, approveHint)
+	}
+	if errors.Is(err, context.Canceled) {
+		return fmt.Errorf("interrupted while waiting for approval; the request stays pending — run 'meshd up' to resume")
+	}
+	return err
+}
+
+// resubmitPendingInviteJoin handles `meshd up <invite>` on a machine whose
+// earlier join request is still pending. The original invite may have expired
+// or been revoked, so an invite with a different token is submitted as a
+// fresh request; re-running with the same invite is a no-op. An invite for a
+// different network fails fast instead of being silently ignored.
+func resubmitPendingInviteJoin(ctx context.Context, inviteURL, stateDir string, ns *state.NetworkState, identity *did.DID, flagProfile string) (*state.NetworkState, error) {
+	payload, err := invite.Decode(inviteURL)
+	if err != nil {
+		return nil, err
+	}
+	if payload.NetworkID != ns.NetworkRecordID || payload.AnchorDID != ns.AnchorDID {
+		return nil, fmt.Errorf("this machine has a pending join request for network %q; run 'meshd network leave' before joining a different network", ns.NetworkName)
+	}
+	if payload.TokenID == "" && payload.Secret == "" {
+		return ns, nil
+	}
+	if payload.TokenID != "" && payload.TokenID == ns.PendingJoinTokenID {
+		return ns, nil
+	}
+	if err := payload.ValidatePreAuth(); err != nil {
+		return nil, err
+	}
+	if payload.ExpiresAt != "" {
+		if expiry, parseErr := time.Parse(time.RFC3339, payload.ExpiresAt); parseErr == nil && !time.Now().Before(expiry) {
+			return nil, fmt.Errorf("the invite expired at %s; create a new invite in the dashboard and run 'meshd up <new-invite>'", payload.ExpiresAt)
+		}
+	}
+
+	meta := resolveIdentityMetadata(flagProfile, identity.URI)
+	nodeDID := firstNonEmpty(meta.NodeDID, identity.URI)
+	label, _ := os.Hostname()
+	if err := mesh.WritePreAuthNodeRequest(ctx, mesh.WritePreAuthNodeRequestParams{
+		Invite:            payload,
+		NodeDID:           nodeDID,
+		MemberDID:         ns.EffectiveOwnerDID(nodeDID),
+		DelegateDID:       meta.DelegateDID,
+		RequestedBy:       identity.URI,
+		Signer:            &dwn.Signer{DID: identity.URI, PrivateKey: identity.SigningKey},
+		Label:             label,
+		NodeEncryptionKey: identity.EncryptionPrivateKey,
+	}); err != nil {
+		return nil, err
+	}
+	fmt.Printf("Join request resubmitted for %q.\n", firstNonEmpty(payload.NetworkName, ns.NetworkName))
+
+	ns.PendingJoinTokenID = payload.TokenID
+	if err := state.SaveNetworkState(stateDir, ns); err != nil {
+		return nil, fmt.Errorf("saving pending join token: %w", err)
+	}
+	return ns, nil
+}

--- a/cmd/meshd/upwait_dwn_test.go
+++ b/cmd/meshd/upwait_dwn_test.go
@@ -1,0 +1,290 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/enboxorg/meshd/internal/did"
+	"github.com/enboxorg/meshd/internal/dwn"
+	"github.com/enboxorg/meshd/internal/invite"
+	"github.com/enboxorg/meshd/internal/state"
+	"github.com/enboxorg/meshd/protocols"
+)
+
+// fakeDWNQueryServer answers Records Query messages from canned entries keyed
+// by protocolPath and accepts every Records Write, recording the paths seen.
+type fakeDWNQueryServer struct {
+	t *testing.T
+
+	mu         sync.Mutex
+	entries    map[string][]json.RawMessage // protocolPath -> query entries
+	queries    []map[string]any             // observed query filters
+	writePaths []string                     // observed write protocolPaths
+	failAll    bool
+}
+
+func (f *fakeDWNQueryServer) handler(w http.ResponseWriter, r *http.Request) {
+	if f.failAll {
+		http.Error(w, "boom", http.StatusInternalServerError)
+		return
+	}
+	var rpcReq dwn.JsonRpcRequest
+	if err := json.Unmarshal([]byte(r.Header.Get("dwn-request")), &rpcReq); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if rpcReq.Params == nil || rpcReq.Params.Message == nil {
+		http.Error(w, "missing DWN message", http.StatusBadRequest)
+		return
+	}
+	msg := rpcReq.Params.Message
+	method, _ := msg.Descriptor["method"].(string)
+	switch method {
+	case "Query":
+		filter, _ := msg.Descriptor["filter"].(map[string]any)
+		path, _ := filter["protocolPath"].(string)
+		f.mu.Lock()
+		f.queries = append(f.queries, filter)
+		entries := f.entries[path]
+		f.mu.Unlock()
+		f.reply(w, rpcReq.ID, dwn.Status{Code: 200, Detail: "OK"}, entries)
+	case "Write":
+		path, _ := msg.Descriptor["protocolPath"].(string)
+		f.mu.Lock()
+		f.writePaths = append(f.writePaths, path)
+		f.mu.Unlock()
+		f.reply(w, rpcReq.ID, dwn.Status{Code: 202, Detail: "Accepted"}, nil)
+	default:
+		f.reply(w, rpcReq.ID, dwn.Status{Code: 400, Detail: "unexpected method " + method}, nil)
+	}
+}
+
+func (f *fakeDWNQueryServer) reply(w http.ResponseWriter, id string, status dwn.Status, entries []json.RawMessage) {
+	f.t.Helper()
+	var entriesJSON json.RawMessage
+	if entries != nil {
+		var err error
+		entriesJSON, err = json.Marshal(entries)
+		if err != nil {
+			f.t.Fatalf("marshal entries: %v", err)
+		}
+	}
+	resp := &dwn.JsonRpcResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  &dwn.JsonRpcResult{Reply: &dwn.DwnReply{Status: status, Entries: entriesJSON}},
+	}
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		f.t.Fatalf("write DWN reply: %v", err)
+	}
+}
+
+func dwnQueryEntry(t *testing.T, recordID, contextID, protocolPath, recipient string, data any) json.RawMessage {
+	t.Helper()
+	dataBytes, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("marshal entry data: %v", err)
+	}
+	descriptor := map[string]any{
+		"interface":        "Records",
+		"method":           "Write",
+		"protocol":         protocols.MeshProtocolURI,
+		"protocolPath":     protocolPath,
+		"dataFormat":       "application/json",
+		"dateCreated":      dwn.Now(),
+		"messageTimestamp": dwn.Now(),
+	}
+	if recipient != "" {
+		descriptor["recipient"] = recipient
+	}
+	entry, err := json.Marshal(map[string]any{
+		"recordId":    recordID,
+		"contextId":   contextID,
+		"descriptor":  descriptor,
+		"encodedData": base64.RawURLEncoding.EncodeToString(dataBytes),
+	})
+	if err != nil {
+		t.Fatalf("marshal entry: %v", err)
+	}
+	return entry
+}
+
+func pendingJoinTestState(endpoint string, nodeDID string) *state.NetworkState {
+	return &state.NetworkState{
+		NetworkRecordID: "net-1",
+		AnchorDID:       "did:example:anchor",
+		AnchorEndpoint:  endpoint,
+		NetworkName:     "home",
+		NodeDID:         nodeDID,
+		OwnerDID:        "did:example:owner",
+		MemberDID:       "did:example:owner",
+	}
+}
+
+func TestPendingJoinApprovedDirectNodeRecord(t *testing.T) {
+	identity, err := did.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	fake := &fakeDWNQueryServer{t: t, entries: map[string][]json.RawMessage{
+		"network/node": {dwnQueryEntry(t, "node-1", "net-1", "network/node", identity.URI, map[string]string{"meshIP": "10.200.0.9"})},
+	}}
+	server := httptest.NewServer(http.HandlerFunc(fake.handler))
+	defer server.Close()
+
+	approved, err := pendingJoinApproved(context.Background(), pendingJoinTestState(server.URL, identity.URI), identity)
+	if err != nil {
+		t.Fatalf("pendingJoinApproved: %v", err)
+	}
+	if !approved {
+		t.Fatal("expected direct node record to count as approved")
+	}
+	if len(fake.queries) != 1 {
+		t.Fatalf("expected a single query, got %d", len(fake.queries))
+	}
+	if got, _ := fake.queries[0]["recipient"].(string); got != identity.URI {
+		t.Fatalf("node query recipient = %q, want node DID", got)
+	}
+	if got, _ := fake.queries[0]["contextId"].(string); got != "net-1" {
+		t.Fatalf("node query contextId = %q, want network record ID", got)
+	}
+}
+
+func TestPendingJoinApprovedMemberNodeRecord(t *testing.T) {
+	identity, err := did.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	fake := &fakeDWNQueryServer{t: t, entries: map[string][]json.RawMessage{
+		"network/member":      {dwnQueryEntry(t, "member-1", "net-1", "network/member", "did:example:owner", map[string]string{})},
+		"network/member/node": {dwnQueryEntry(t, "node-1", "net-1/member-1", "network/member/node", identity.URI, map[string]string{"meshIP": "10.200.0.9"})},
+	}}
+	server := httptest.NewServer(http.HandlerFunc(fake.handler))
+	defer server.Close()
+
+	approved, err := pendingJoinApproved(context.Background(), pendingJoinTestState(server.URL, identity.URI), identity)
+	if err != nil {
+		t.Fatalf("pendingJoinApproved: %v", err)
+	}
+	if !approved {
+		t.Fatal("expected member-associated node record to count as approved")
+	}
+	// The member/node query must scope to the member record's context.
+	last := fake.queries[len(fake.queries)-1]
+	if got, _ := last["contextId"].(string); got != "net-1/member-1" {
+		t.Fatalf("member node query contextId = %q, want net-1/member-1", got)
+	}
+}
+
+func TestPendingJoinApprovedStillPending(t *testing.T) {
+	identity, err := did.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	fake := &fakeDWNQueryServer{t: t, entries: map[string][]json.RawMessage{}}
+	server := httptest.NewServer(http.HandlerFunc(fake.handler))
+	defer server.Close()
+
+	approved, err := pendingJoinApproved(context.Background(), pendingJoinTestState(server.URL, identity.URI), identity)
+	if err != nil {
+		t.Fatalf("pendingJoinApproved: %v", err)
+	}
+	if approved {
+		t.Fatal("no records should mean still pending")
+	}
+}
+
+func TestPendingJoinApprovedQueryErrorSurfaces(t *testing.T) {
+	identity, err := did.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	fake := &fakeDWNQueryServer{t: t, failAll: true}
+	server := httptest.NewServer(http.HandlerFunc(fake.handler))
+	defer server.Close()
+
+	if _, err := pendingJoinApproved(context.Background(), pendingJoinTestState(server.URL, identity.URI), identity); err == nil {
+		t.Fatal("expected transport errors to surface for the wait loop's retry backoff")
+	}
+}
+
+func TestResubmitPendingInviteJoin(t *testing.T) {
+	identity, err := did.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	stateDir := t.TempDir()
+	t.Setenv("MESHD_STATE_DIR", stateDir)
+
+	fake := &fakeDWNQueryServer{t: t, entries: map[string][]json.RawMessage{}}
+	server := httptest.NewServer(http.HandlerFunc(fake.handler))
+	defer server.Close()
+
+	ns := pendingJoinTestState(server.URL, identity.URI)
+	ns.PendingJoinTokenID = "tok-1"
+	if err := state.SaveNetworkState(stateDir, ns); err != nil {
+		t.Fatalf("SaveNetworkState: %v", err)
+	}
+
+	encodeInvite := func(networkID, tokenID, expiresAt string) string {
+		u, err := invite.Encode(invite.New(server.URL, ns.AnchorDID, networkID, "home", tokenID, "secret-value", expiresAt))
+		if err != nil {
+			t.Fatalf("Encode: %v", err)
+		}
+		return u
+	}
+
+	// A different network fails fast instead of being silently ignored.
+	_, err = resubmitPendingInviteJoin(context.Background(), encodeInvite("other-net", "tok-2", ""), stateDir, ns, identity, "")
+	if err == nil || !strings.Contains(err.Error(), "network leave") {
+		t.Fatalf("expected different-network guidance, got %v", err)
+	}
+	if len(fake.writePaths) != 0 {
+		t.Fatalf("no request should be written for a different network, got %v", fake.writePaths)
+	}
+
+	// Re-running with the already-submitted token is a no-op.
+	got, err := resubmitPendingInviteJoin(context.Background(), encodeInvite("net-1", "tok-1", ""), stateDir, ns, identity, "")
+	if err != nil {
+		t.Fatalf("same-token resubmit: %v", err)
+	}
+	if got.PendingJoinTokenID != "tok-1" || len(fake.writePaths) != 0 {
+		t.Fatalf("same token must not resubmit (writes=%v)", fake.writePaths)
+	}
+
+	// An expired invite is rejected before any write.
+	expired := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	_, err = resubmitPendingInviteJoin(context.Background(), encodeInvite("net-1", "tok-2", expired), stateDir, ns, identity, "")
+	if err == nil || !strings.Contains(err.Error(), "expired") {
+		t.Fatalf("expected expired-invite error, got %v", err)
+	}
+	if len(fake.writePaths) != 0 {
+		t.Fatalf("no request should be written for an expired invite, got %v", fake.writePaths)
+	}
+
+	// A fresh token resubmits the join request and persists the new token.
+	got, err = resubmitPendingInviteJoin(context.Background(), encodeInvite("net-1", "tok-2", ""), stateDir, ns, identity, "")
+	if err != nil {
+		t.Fatalf("fresh-token resubmit: %v", err)
+	}
+	if got.PendingJoinTokenID != "tok-2" {
+		t.Fatalf("PendingJoinTokenID = %q, want tok-2", got.PendingJoinTokenID)
+	}
+	if len(fake.writePaths) != 1 || fake.writePaths[0] != "network/nodeRequest" {
+		t.Fatalf("expected one network/nodeRequest write, got %v", fake.writePaths)
+	}
+	reloaded, err := state.LoadNetworkState(stateDir)
+	if err != nil {
+		t.Fatalf("LoadNetworkState: %v", err)
+	}
+	if reloaded.PendingJoinTokenID != "tok-2" {
+		t.Fatalf("persisted PendingJoinTokenID = %q, want tok-2", reloaded.PendingJoinTokenID)
+	}
+}

--- a/cmd/meshd/upwait_test.go
+++ b/cmd/meshd/upwait_test.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+var testPollPolicy = approvalPollPolicy{
+	initial:  time.Millisecond,
+	max:      2 * time.Millisecond,
+	errorMax: 2 * time.Millisecond,
+}
+
+func TestParseUpFlagsWait(t *testing.T) {
+	f := parseUpFlags([]string{"--wait-timeout", "45m", "--no-wait"})
+	if f.waitTimeout != 45*time.Minute {
+		t.Fatalf("waitTimeout = %s, want 45m", f.waitTimeout)
+	}
+	if !f.noWait {
+		t.Fatal("expected --no-wait to be parsed")
+	}
+
+	f = parseUpFlags(nil)
+	if f.waitTimeout != 0 {
+		t.Fatalf("default waitTimeout = %s, want 0 (resolved later)", f.waitTimeout)
+	}
+	if f.noWait {
+		t.Fatal("noWait should default to false")
+	}
+}
+
+func TestApprovalWaitDeadline(t *testing.T) {
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	timeout := 15 * time.Minute
+
+	// No invite expiry: deadline is now+timeout.
+	if got := approvalWaitDeadline(now, timeout, ""); !got.Equal(now.Add(timeout)) {
+		t.Fatalf("deadline = %s, want %s", got, now.Add(timeout))
+	}
+
+	// Invalid expiry is ignored.
+	if got := approvalWaitDeadline(now, timeout, "not-a-time"); !got.Equal(now.Add(timeout)) {
+		t.Fatalf("deadline = %s, want %s", got, now.Add(timeout))
+	}
+
+	// Expiry after the timeout: timeout wins.
+	late := now.Add(time.Hour).Format(time.RFC3339)
+	if got := approvalWaitDeadline(now, timeout, late); !got.Equal(now.Add(timeout)) {
+		t.Fatalf("deadline = %s, want %s", got, now.Add(timeout))
+	}
+
+	// Expiry before the timeout: expiry caps the wait.
+	early := now.Add(5 * time.Minute).Format(time.RFC3339)
+	if got := approvalWaitDeadline(now, timeout, early); !got.Equal(now.Add(5*time.Minute)) {
+		t.Fatalf("deadline = %s, want %s", got, now.Add(5*time.Minute))
+	}
+}
+
+func TestNextApprovalPollDelay(t *testing.T) {
+	if got := nextApprovalPollDelay(4*time.Second, 15*time.Second); got != 6*time.Second {
+		t.Fatalf("delay = %s, want 6s", got)
+	}
+	if got := nextApprovalPollDelay(14*time.Second, 15*time.Second); got != 15*time.Second {
+		t.Fatalf("delay = %s, want capped 15s", got)
+	}
+	if got := nextApprovalPollDelay(15*time.Second, 15*time.Second); got != 15*time.Second {
+		t.Fatalf("delay = %s, want to stay at cap", got)
+	}
+}
+
+func TestWaitForApprovalSucceedsAfterRetries(t *testing.T) {
+	attempts := 0
+	check := func(context.Context) (bool, error) {
+		attempts++
+		return attempts >= 3, nil
+	}
+	err := waitForApproval(context.Background(), time.Now().Add(time.Second), &strings.Builder{}, testPollPolicy, check)
+	if err != nil {
+		t.Fatalf("waitForApproval: %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts = %d, want 3", attempts)
+	}
+}
+
+func TestWaitForApprovalTimesOut(t *testing.T) {
+	check := func(context.Context) (bool, error) { return false, nil }
+	err := waitForApproval(context.Background(), time.Now().Add(10*time.Millisecond), &strings.Builder{}, testPollPolicy, check)
+	if !errors.Is(err, errApprovalWaitTimeout) {
+		t.Fatalf("err = %v, want errApprovalWaitTimeout", err)
+	}
+}
+
+func TestWaitForApprovalTimeoutKeepsLastError(t *testing.T) {
+	check := func(context.Context) (bool, error) { return false, fmt.Errorf("dwn unreachable") }
+	var out strings.Builder
+	err := waitForApproval(context.Background(), time.Now().Add(10*time.Millisecond), &out, testPollPolicy, check)
+	if !errors.Is(err, errApprovalWaitTimeout) {
+		t.Fatalf("err = %v, want errApprovalWaitTimeout", err)
+	}
+	if !strings.Contains(err.Error(), "dwn unreachable") {
+		t.Fatalf("timeout error should carry the last check error, got %v", err)
+	}
+	if !strings.Contains(out.String(), "dwn unreachable") {
+		t.Fatalf("check failures should be reported to the user, got %q", out.String())
+	}
+}
+
+func TestWaitForApprovalRecoversFromTransientErrors(t *testing.T) {
+	attempts := 0
+	check := func(context.Context) (bool, error) {
+		attempts++
+		if attempts < 3 {
+			return false, fmt.Errorf("transient %d", attempts)
+		}
+		return true, nil
+	}
+	var out strings.Builder
+	err := waitForApproval(context.Background(), time.Now().Add(time.Second), &out, testPollPolicy, check)
+	if err != nil {
+		t.Fatalf("waitForApproval: %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts = %d, want 3", attempts)
+	}
+}
+
+func TestWaitForApprovalHonorsContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	check := func(context.Context) (bool, error) {
+		cancel()
+		return false, nil
+	}
+	err := waitForApproval(ctx, time.Now().Add(time.Minute), &strings.Builder{}, testPollPolicy, check)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}
+
+func TestApprovalWaitFailureMessages(t *testing.T) {
+	adminCtx := adminContext{OwnerDID: "did:example:owner", NetworkRecordID: "net-1"}
+	deadline := time.Now()
+
+	// Timeout with an already-expired invite points at creating a new invite.
+	expired := time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)
+	err := approvalWaitFailure(errApprovalWaitTimeout, approvalWaitJoin, expired, deadline, adminCtx)
+	if err == nil || !strings.Contains(err.Error(), "invite expired") {
+		t.Fatalf("expected invite-expired guidance, got %v", err)
+	}
+
+	// Plain timeout keeps the request pending and offers resume paths. The
+	// invite path also mentions anchor-side automatic approval (local-vault
+	// networks have no dashboard owner).
+	err = approvalWaitFailure(errApprovalWaitTimeout, approvalWaitJoin, "", deadline, adminCtx)
+	if err == nil || !strings.Contains(err.Error(), "still pending") || !strings.Contains(err.Error(), "--wait-timeout") {
+		t.Fatalf("expected pending/resume guidance, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "did%3Aexample%3Aowner") && !strings.Contains(err.Error(), "did:example:owner") {
+		t.Fatalf("expected dashboard URL with owner DID, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "keep the anchor node online") {
+		t.Fatalf("invite-path timeout should mention the anchor-online path, got %v", err)
+	}
+	err = approvalWaitFailure(errApprovalWaitTimeout, approvalWaitOwner, "", deadline, adminCtx)
+	if err == nil || strings.Contains(err.Error(), "keep the anchor node online") {
+		t.Fatalf("owner-path timeout should be dashboard-only, got %v", err)
+	}
+
+	// Interrupt explains that re-running resumes.
+	err = approvalWaitFailure(context.Canceled, approvalWaitOwner, "", deadline, adminCtx)
+	if err == nil || !strings.Contains(err.Error(), "resume") {
+		t.Fatalf("expected resume guidance on interrupt, got %v", err)
+	}
+
+	// Other errors pass through.
+	sentinel := fmt.Errorf("boom")
+	if err := approvalWaitFailure(sentinel, approvalWaitJoin, "", deadline, adminCtx); !errors.Is(err, sentinel) {
+		t.Fatalf("unexpected wrapping of non-wait errors: %v", err)
+	}
+}
+
+func TestSetupInteractiveRequiresTTY(t *testing.T) {
+	// Under `go test` stdin is not a terminal, so the interactive wizard must
+	// refuse cleanly instead of consuming piped input (curl | bash context).
+	if stdinIsTerminal() {
+		t.Skip("test requires a non-TTY stdin")
+	}
+	_, err := setupInteractive(context.Background(), upFlags{}, t.TempDir(), nil, "")
+	if err == nil || !strings.Contains(err.Error(), "no interactive terminal") {
+		t.Fatalf("expected non-TTY refusal, got %v", err)
+	}
+}

--- a/docs/smoke-test-mac-linux.md
+++ b/docs/smoke-test-mac-linux.md
@@ -66,7 +66,11 @@ meshd admin --owner '<OWNER_DID>' --print
 ```
 
 Connect the owner wallet and approve meshd Admin. Create a network if one does
-not already exist. Click `Copy Setup Command` in the network header.
+not already exist. Click `Copy Setup Command` in the network header; it copies
+a full install-and-join one-liner
+(`curl -fsSL https://meshd.sh/install | bash -s -- up '<OWNER_DID>'`). When
+testing a locally built binary, use the plain `meshd up '<OWNER_DID>'` form
+instead so the released installer does not overwrite your build.
 
 If the deployed dashboard is unavailable, run the local fallback from a repo
 checkout:
@@ -80,7 +84,8 @@ meshd admin --dashboard http://127.0.0.1:5173 --print
 
 ## 2. Submit the Linux node request
 
-On the Linux server, paste the setup command copied from the dashboard:
+On the Linux server, paste the setup command copied from the dashboard (or the
+plain form when testing a local build):
 
 ```bash
 meshd down || true
@@ -95,7 +100,9 @@ Expected result:
 - If the node has no local identity, meshd creates one and asks for a vault
   password.
 - meshd writes a signed owner-node request to the owner's DWN.
-- meshd exits cleanly or reports that it is waiting for dashboard approval.
+- meshd prints the dashboard URL and keeps waiting for approval (default 15m,
+  `--wait-timeout` to change, `--no-wait` for the old submit-and-exit
+  behavior). Leave it running and continue to the next step.
 
 ## 3. Approve from the dashboard
 
@@ -113,10 +120,11 @@ key to the node, and write a node approval response.
 
 ## 4. Start both mesh daemons
 
-On the Linux server:
+On the Linux server, the waiting `meshd up` from step 2 picks the approval up
+on its own and starts the daemon. Verify it (and run `meshd up` first if the
+wait had timed out — it resumes the pending request):
 
 ```bash
-meshd up
 meshd status
 meshd peer list
 ```
@@ -177,16 +185,20 @@ On a fresh profile or another node:
 ```bash
 meshd down || true
 meshd up '<meshd://invite/...>'
-meshd up
+# approve in the dashboard while it waits; it starts on its own
 meshd status
 meshd peer list
 ```
 
-You can also run `meshd up` without flags and paste the `meshd://invite/...`
-URL at the setup prompt.
+The invite composer also offers a copyable install-and-join one-liner
+(`curl -fsSL https://meshd.sh/install | bash -s -- up '<meshd://invite/...>'`)
+for machines that do not have meshd yet. You can also run `meshd up` without
+flags and paste the `meshd://invite/...` URL at the setup prompt.
 
-If the invite request appears pending in the dashboard, approve it and run
-`meshd up` again on the joining node.
+`meshd up '<invite>'` submits the request and waits for approval (approve it
+in the dashboard, or a running anchor daemon approves it automatically). If
+the wait times out, re-run `meshd up` to resume; re-running with a fresh
+invite for the same network resubmits the request with the new token.
 
 ## Troubleshooting
 

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,9 @@ APP='meshd'
 REPO='enboxorg/meshd'
 INSTALL_DIR="${HOME}/.${APP}/bin"
 REQUESTED_VERSION="${VERSION:-}"
+# Test/ops override for the release download base (offline CI tests use a
+# file:// mirror). Layout must match GitHub releases: <base>/<tag>/<archive>.
+DOWNLOAD_BASE="${MESHD_INSTALL_DOWNLOAD_BASE:-https://github.com/${REPO}/releases/download}"
 NO_MODIFY_PATH=false
 TMP_DIR=''
 
@@ -20,16 +23,21 @@ usage() {
   cat <<'EOF'
 meshd installer
 
-Usage: install.sh [options]
+Usage: install.sh [options] [up [meshd-up-arguments...]]
 
 Options:
   -h, --help              Show this help message
   -v, --version <version> Install a specific version (example: 0.1.0)
       --no-modify-path    Do not modify shell profile files
 
+Everything after 'up' is passed to 'meshd up', so one command can install
+meshd, request to join a network, wait for dashboard approval, and start
+the mesh.
+
 Examples:
   curl -fsSL https://meshd.sh/install | bash
   curl -fsSL https://meshd.sh/install | bash -s -- --version 0.1.0
+  curl -fsSL https://meshd.sh/install | bash -s -- up 'meshd://invite/<token>'
 EOF
 }
 
@@ -187,7 +195,38 @@ add_to_path() {
   printf '  %s\n' "$line"
 }
 
+# run_meshd_up hands off to the freshly installed binary by absolute path
+# (PATH updates only reach future shells). Under `curl | bash` stdin is the
+# script pipe, so reattach /dev/tty when one exists — that keeps the vault
+# password and sudo prompts working.
+run_meshd_up() {
+  local bin="$1"
+  shift
+
+  # ${1+"$@"} instead of bare "$@": bash <= 4.3 (macOS ships 3.2) treats an
+  # empty "$@" as unbound under set -u.
+  printf '\n==> Running meshd up\n'
+  local code=0
+  if (exec </dev/tty) 2>/dev/null; then
+    "$bin" up ${1+"$@"} </dev/tty || code=$?
+  else
+    "$bin" up ${1+"$@"} || code=$?
+  fi
+
+  if [ "$code" -ne 0 ]; then
+    local resume_args=''
+    if [ "$#" -gt 0 ]; then
+      resume_args=" $*"
+    fi
+    printf '\nmeshd up did not complete. Any join request stays pending; resume with:\n' >&2
+    printf '  %s up%s\n' "$bin" "$resume_args" >&2
+    exit "$code"
+  fi
+}
+
 main() {
+  RUN_UP=false
+  RUN_UP_ARGS=()
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -h|--help)
@@ -204,6 +243,12 @@ main() {
       --no-modify-path)
         NO_MODIFY_PATH=true
         shift
+        ;;
+      up)
+        RUN_UP=true
+        shift
+        RUN_UP_ARGS=("$@")
+        break
         ;;
       *)
         fail "unknown option: $1"
@@ -227,7 +272,7 @@ main() {
   fi
 
   local url
-  url="https://github.com/${REPO}/releases/download/${tag}/${archive}"
+  url="${DOWNLOAD_BASE}/${tag}/${archive}"
 
   TMP_DIR="$(mktemp -d)"
 
@@ -242,8 +287,12 @@ main() {
     suffix='.exe'
   fi
 
-  cp "${TMP_DIR}/meshd${suffix}" "${INSTALL_DIR}/meshd${suffix}"
-  chmod +x "${INSTALL_DIR}/meshd${suffix}"
+  # Install atomically: a plain cp onto a running binary fails with
+  # "Text file busy" (re-running the one-liner while meshd is up), while a
+  # rename over it succeeds.
+  cp "${TMP_DIR}/meshd${suffix}" "${INSTALL_DIR}/meshd${suffix}.new"
+  chmod +x "${INSTALL_DIR}/meshd${suffix}.new"
+  mv -f "${INSTALL_DIR}/meshd${suffix}.new" "${INSTALL_DIR}/meshd${suffix}"
 
   if [ "$NO_MODIFY_PATH" = false ] && [[ ":$PATH:" != *":${INSTALL_DIR}:"* ]]; then
     add_to_path
@@ -251,7 +300,17 @@ main() {
 
   printf '==> Installed to %s\n' "$INSTALL_DIR"
   "${INSTALL_DIR}/meshd${suffix}" --version || true
-  printf 'Run: meshd init\n'
+
+  if [ "$RUN_UP" = true ]; then
+    # meshd up can wait minutes for dashboard approval; drop the download
+    # scratch dir before handing off.
+    cleanup
+    TMP_DIR=''
+    run_meshd_up "${INSTALL_DIR}/meshd${suffix}" ${RUN_UP_ARGS[@]+"${RUN_UP_ARGS[@]}"}
+    return
+  fi
+
+  printf 'Run: meshd up\n'
 }
 
 main "$@"

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -113,6 +113,12 @@ type NetworkState struct {
 
 	// PendingOwnerRequestAt is when the owner-scoped node request was written.
 	PendingOwnerRequestAt string `json:"pendingOwnerRequestAt,omitempty"`
+
+	// PendingJoinTokenID is the invite token ID of the last submitted preauth
+	// join request, kept while the join is pending so re-running `meshd up`
+	// with the same invite does not submit a duplicate request (while a fresh
+	// invite for the same network is resubmitted).
+	PendingJoinTokenID string `json:"pendingJoinTokenId,omitempty"`
 }
 
 // NormalizeOwnerDID keeps the newer ownerDid field and the older memberDid

--- a/scripts/e2e/install-up.test.sh
+++ b/scripts/e2e/install-up.test.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Offline test for install.sh's `up` passthrough: everything after `up` must
+# reach the installed binary as `meshd up <args...>`, exit codes must
+# propagate, and the plain no-arg install must keep its contract. Runs against
+# a fake release archive served over file:// — no network, safe on every PR.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL="${HERE}/../../install.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+# install.sh's downloader prefers curl, and only curl handles the file://
+# mirror this test serves (wget does not support file:// URLs).
+command -v curl >/dev/null 2>&1 || { echo 'install-up test requires curl' >&2; exit 1; }
+
+VERSION_TAG="9.9.9"
+
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+case "$(uname -m)" in
+  x86_64|amd64) arch='x64' ;;
+  aarch64|arm64) arch='arm64' ;;
+  *) echo "unsupported test arch" >&2; exit 1 ;;
+esac
+
+# Fake release: a meshd stand-in that records its argv and exits with
+# MESHD_FAKE_EXIT (default 0).
+DIST="${WORK}/dist/v${VERSION_TAG}"
+mkdir -p "$DIST"
+cat > "${WORK}/meshd" <<'FAKE'
+#!/usr/bin/env bash
+if [ "${1:-}" = "--version" ]; then
+  echo "meshd 9.9.9"
+  exit 0
+fi
+printf '%s\n' "$@" > "${MESHD_FAKE_ARGV_OUT:?}"
+exit "${MESHD_FAKE_EXIT:-0}"
+FAKE
+chmod +x "${WORK}/meshd"
+tar -czf "${DIST}/meshd-${os}-${arch}.tar.gz" -C "$WORK" meshd
+
+fails=0
+check() { # check <name> <condition-rc>
+  if [ "$2" -eq 0 ]; then
+    printf 'ok   - %s\n' "$1"
+  else
+    printf 'FAIL - %s\n' "$1"
+    fails=$((fails + 1))
+  fi
+}
+
+run_install() { # run_install <home> [args...]
+  local home="$1"
+  shift
+  HOME="$home" \
+  VERSION="$VERSION_TAG" \
+  MESHD_INSTALL_DOWNLOAD_BASE="file://${WORK}/dist" \
+  MESHD_FAKE_ARGV_OUT="${home}/argv.txt" \
+    bash "$INSTALL" --no-modify-path "$@" </dev/null
+}
+
+# 1. Plain install: no run, final hint points at meshd up.
+home1="${WORK}/home1"; mkdir -p "$home1"
+out1="$(run_install "$home1")"
+rc=0
+[ -x "${home1}/.meshd/bin/meshd" ] || rc=1
+check "plain install drops the binary" "$rc"
+rc=0
+grep -q 'Run: meshd up' <<<"$out1" || rc=1
+check "plain install hints 'meshd up'" "$rc"
+rc=0
+[ ! -e "${home1}/argv.txt" ] || rc=1
+check "plain install does not run meshd up" "$rc"
+
+# 2. `up` passthrough: args after `up` reach the binary verbatim (including
+# ones that look like installer flags), via the absolute binary path.
+home2="${WORK}/home2"; mkdir -p "$home2"
+run_install "$home2" up 'meshd://invite/test-token' --no-tun --wait-timeout 1h >/dev/null
+rc=0
+expected="$(printf 'up\nmeshd://invite/test-token\n--no-tun\n--wait-timeout\n1h\n')"
+[ "$(cat "${home2}/argv.txt")" = "$expected" ] || rc=1
+check "up passthrough forwards args verbatim" "$rc"
+
+# 3. Exit codes from meshd up propagate, with a resume hint on stderr that
+# keeps the original arguments (a resume without the invite dead-ends when
+# the join request was never submitted).
+home3="${WORK}/home3"; mkdir -p "$home3"
+rc=0
+stderr3="${WORK}/stderr3.txt"
+MESHD_FAKE_EXIT=7 run_install "$home3" up 'meshd://invite/x' >/dev/null 2>"$stderr3" || rc=$?
+check "meshd up exit code propagates" "$([ "$rc" -eq 7 ]; echo $?)"
+rc=0
+grep -q "resume with" "$stderr3" && grep -q "up meshd://invite/x" "$stderr3" || rc=1
+check "failure prints a resume hint with the original args" "$rc"
+
+# 4. Unknown options still fail hard (guards against silently swallowing
+# typos like 'pu' or a bare invite URL).
+home4="${WORK}/home4"; mkdir -p "$home4"
+rc=0
+run_install "$home4" 'meshd://invite/oops' >/dev/null 2>&1 || rc=$?
+check "unknown option still fails" "$([ "$rc" -ne 0 ]; echo $?)"
+
+# 5. Bare `up` with no further arguments still runs (resume-style invocation;
+# also guards the set -u empty-"$@" expansion on old bash).
+home5="${WORK}/home5"; mkdir -p "$home5"
+run_install "$home5" up >/dev/null
+rc=0
+[ "$(cat "${home5}/argv.txt")" = "up" ] || rc=1
+check "bare up runs with no extra args" "$rc"
+
+if [ "$fails" -gt 0 ]; then
+  echo "${fails} install-up test(s) failed" >&2
+  exit 1
+fi
+echo "all install-up passthrough tests passed"


### PR DESCRIPTION
Closes #210

## What

One command on a fresh host — copyable straight from the admin dashboard — installs meshd, submits the join request, **waits for approval, and starts the mesh**:

```
curl -fsSL https://meshd.sh/install | bash -s -- up 'meshd://invite/<token>'
```

The second `meshd up` run is gone: approval detection was one-shot, so `cmdUp` used to exit with "run 'meshd up' again". It now polls until the dashboard (or the anchor's auto-approval loop) approves, then continues into TUN elevation and daemonization on its own.

## How

**CLI — `meshd up` waits (cmd/meshd/upwait.go):**
- Both pending paths (invite preauth + owner-DID request) enter a poll loop: lightweight node-record/nodeApproval query per tick (not the heavyweight rejoin), 3s→15s backoff (errors back off to 60s), deadline capped by the invite's own expiry. `--wait-timeout` (default 15m), `--no-wait` for the old behavior. Timeout/Ctrl+C leave the request pending with explicit resume instructions; `meshd up` resumes it.
- sudo is validated **before** the wait and refreshed every minute during it, so the post-approval elevation starts unattended even if the user walked away (with a warning when `timestamp_timeout=0` makes that impossible).
- The post-approval membership refresh retries (4×/10s) so one transient DWN error can't discard a successful unattended wait.
- Re-running `meshd up <invite>` over stale pending state now **resubmits** when the token differs (expired/revoked-invite recovery), no-ops for the same token (tracked as `PendingJoinTokenID` in network.json), and fails fast for a different network — previously the argument was silently ignored.
- Non-interactive hardening: the setup wizard refuses cleanly without a TTY instead of consuming piped input; an ignored invite/owner argument on an already-running daemon is called out.

**Installer — thin passthrough (install.sh):**
- `install.sh [opts] up [args...]` forwards everything after `up` to `~/.meshd/bin/meshd up ...` by absolute path (PATH edits only reach future shells), reattaching stdin to `/dev/tty` when one exists so the vault-password and sudo prompts work under `curl | bash`.
- Atomic install (`cp` + `mv`) so re-running the one-liner while meshd is running doesn't die on `Text file busy`; failure hints echo the original arguments; bash 3.2-safe (`${1+"$@"}` guard); stale `Run: meshd init` hint replaced.
- The no-arg/`--version`/`--no-modify-path` smoke-test contract is unchanged.

**Admin dapp:**
- The invite-composer result card and active-invite rows copy the full install+join one-liner (with a secondary copy for the bare invite URL); the header **Copy Setup Command** is install-wrapped for the owner-DID flow; the approval toast notes the device connects on its own.

**Docs:** README quick start + Mac/Linux smoke-test runbook updated for the blocking-wait flow.

## Testing

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./... -count=1 -race` — all 22 packages pass
- New unit tests: wait loop (retry/timeout/cancel/backoff), deadline capping, failure messages, flag parsing, TTY gate, `pendingJoinApproved` and `resubmitPendingInviteJoin` against a fake DWN
- New offline installer test `scripts/e2e/install-up.test.sh` (wired into CI): passthrough contract, exit-code propagation, resume hint, unknown-arg rejection, bare `up`
- `bunx vitest run` (admin-dapp) — 42 tests pass; `tsc --noEmit` clean; `bun run build` succeeds
- Manually exercised headless paths: fresh box without vault password → actionable error; bare `up` without TTY → clean refusal; invite arg with running daemon → explicit ignored-argument note
- Multi-agent adversarial review of the diff; all 14 confirmed findings fixed in this PR (invite-resubmit recovery, ETXTBSY, dashboard-URL owner context, refresh retry, sudo edge cases, doc contradictions, test gaps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)