### PR TITLE
fix: point the admin dashboard default at admin.meshd.sh

### DIFF
--- a/.github/workflows/admin-dapp.yml
+++ b/.github/workflows/admin-dapp.yml
@@ -53,7 +53,7 @@ jobs:
       deployments: write
     environment:
       name: meshd-admin
-      url: https://meshd-admin.pages.dev
+      url: https://admin.meshd.sh
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ endpoint by default. Use `--endpoint` or `DWN_ENDPOINT` to override it.
 The dashboard uses the same beta endpoint when creating a network for an owner
 without a published DWN endpoint.
 
-The default dashboard is deployed at `https://meshd-admin.pages.dev`.
+The default dashboard is deployed at `https://admin.meshd.sh`.
 
 For a full Mac/Linux validation pass, see
 [docs/smoke-test-mac-linux.md](docs/smoke-test-mac-linux.md).

--- a/admin-dapp/README.md
+++ b/admin-dapp/README.md
@@ -15,7 +15,7 @@ pending, expired locally, or had stale approval metadata.
 Production dashboard:
 
 ```text
-https://meshd-admin.pages.dev
+https://admin.meshd.sh
 ```
 
 ## Local development

--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -773,7 +773,7 @@ type adminOptions struct {
 	networkRecordID string
 }
 
-const defaultAdminDashboardURL = "https://meshd-admin.pages.dev"
+const defaultAdminDashboardURL = "https://admin.meshd.sh"
 
 func parseAdminArgs(args []string) (adminOptions, error) {
 	opts := adminOptions{dashboardURL: defaultAdminDashboardURL}

--- a/cmd/meshd/main_test.go
+++ b/cmd/meshd/main_test.go
@@ -257,7 +257,7 @@ func TestPrintDoctorCheck(t *testing.T) {
 }
 
 func TestBuildAdminURL(t *testing.T) {
-	rawURL := buildAdminURL("https://meshd-admin.pages.dev/", adminContext{
+	rawURL := buildAdminURL("https://admin.meshd.sh/", adminContext{
 		OwnerDID:        "did:dht:wallet",
 		NetworkRecordID: "network-1",
 	})
@@ -265,7 +265,7 @@ func TestBuildAdminURL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse: %v", err)
 	}
-	if got := parsed.Scheme + "://" + parsed.Host + parsed.Path; got != "https://meshd-admin.pages.dev" {
+	if got := parsed.Scheme + "://" + parsed.Host + parsed.Path; got != "https://admin.meshd.sh" {
 		t.Fatalf("admin URL base = %q", got)
 	}
 	if got := parsed.Query().Get("owner"); got != "did:dht:wallet" {
@@ -274,7 +274,7 @@ func TestBuildAdminURL(t *testing.T) {
 	if got := parsed.Query().Get("network"); got != "network-1" {
 		t.Fatalf("network query = %q", got)
 	}
-	if got := buildAdminURL("", adminContext{}); got != "https://meshd-admin.pages.dev" {
+	if got := buildAdminURL("", adminContext{}); got != "https://admin.meshd.sh" {
 		t.Fatalf("default admin URL = %q", got)
 	}
 	if got := adminDashboardCommand(adminContext{OwnerDID: "did:example:own'er", NetworkRecordID: "network-1"}, true); got != "meshd admin --owner 'did:example:own'\\''er' --network 'network-1' --print" {

--- a/docs/smoke-test-mac-linux.md
+++ b/docs/smoke-test-mac-linux.md
@@ -15,7 +15,7 @@ Assumptions:
   a network for that owner.
 - The released CLI is installed on both machines.
 - The standalone meshd Admin dapp is deployed at
-  `https://meshd-admin.pages.dev`.
+  `https://admin.meshd.sh`.
 
 ## 0. Install or update meshd
 
@@ -55,7 +55,7 @@ meshd admin --print
 The dashboard URL should use:
 
 ```text
-https://meshd-admin.pages.dev
+https://admin.meshd.sh
 ```
 
 If you are opening the dashboard from a machine without the owner profile,


### PR DESCRIPTION
Closes #213

## What

The admin dashboard is now served at **https://admin.meshd.sh** (custom domain added to the `meshd-admin` Cloudflare Pages project today). This switches every in-repo reference from `meshd-admin.pages.dev` to the branded domain:

- `defaultAdminDashboardURL` in `cmd/meshd/main.go` — the URL the CLI prints while waiting for approval, in `meshd admin`, doctor hints, and pending-request output
- `main_test.go` expectations
- README, admin-dapp README, and the Mac/Linux smoke-test runbook
- The `meshd-admin` deploy workflow's environment URL

`meshd-admin.pages.dev` keeps serving (Pages serves both domains), so dashboard URLs printed by older binaries continue to work.

Note for operators: wallet connections are per-origin in the browser, so anyone who previously connected the dashboard on the pages.dev origin will connect their wallet once more on admin.meshd.sh.

## Testing

- `go build ./...`, `go vet ./...` — clean
- `go test ./... -count=1 -race` — all packages pass
- `https://admin.meshd.sh` verified serving the deployed dapp (HTTP 200 via the new CNAME)

🤖 Generated with [Claude Code](https://claude.com/claude-code)