### PR TITLE
feat(admin): guided first-run onboarding and ID-referenced invites

### DIFF
--- a/admin-dapp/.gitignore
+++ b/admin-dapp/.gitignore
@@ -1,0 +1,1 @@
+dev-dist

--- a/admin-dapp/dev-dist/registerSW.js
+++ b/admin-dapp/dev-dist/registerSW.js
@@ -1,1 +1,0 @@
-if('serviceWorker' in navigator) navigator.serviceWorker.register('/dev-sw.js?dev-sw', { scope: '/', type: 'module' })

--- a/admin-dapp/dev-dist/registerSW.js
+++ b/admin-dapp/dev-dist/registerSW.js
@@ -1,0 +1,1 @@
+if('serviceWorker' in navigator) navigator.serviceWorker.register('/dev-sw.js?dev-sw', { scope: '/', type: 'module' })

--- a/admin-dapp/src/App.tsx
+++ b/admin-dapp/src/App.tsx
@@ -68,6 +68,10 @@ function truncateDid(did: string, head = 18, tail = 10) {
   return `${did.slice(0, head)}...${did.slice(-tail)}`;
 }
 
+function onboardedStorageKey(networkRecordId: string) {
+  return `enbox:meshd-admin:onboarded:${networkRecordId}`;
+}
+
 function formatDuration(ms: number): string {
   const minutes = Math.round(ms / 60_000);
   if (minutes < 60) return `${Math.max(1, minutes)} min`;
@@ -205,9 +209,14 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
   const [networkName, setNetworkName] = useState("");
   const [networkCIDR, setNetworkCIDR] = useState("10.200.0.0/16");
   // First-run guide: tracks the just-approved first device for the success
-  // step, and whether the operator finished or skipped the guide.
+  // step, and whether the operator finished or skipped the guide. Completion
+  // persists per network so an established network never re-enters the guide
+  // (page reloads, removing the last node).
   const [firstConnected, setFirstConnected] = useState<{ name?: string; meshIP: string }>();
   const [onboardingDone, setOnboardingDone] = useState(false);
+  // Rebuilt install command for an invite that is still active but was created
+  // in an earlier session (inviteResults is in-memory only).
+  const [rebuiltCommand, setRebuiltCommand] = useState<string>();
   const [busyAction, setBusyAction] = useState<string>();
   const [topologyRefreshing, setTopologyRefreshing] = useState(false);
   const topologyRefreshInFlight = useRef(false);
@@ -328,9 +337,53 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
   useEffect(() => {
     setInviteResults([]);
     setFirstConnected(undefined);
-    setOnboardingDone(false);
+    setRebuiltCommand(undefined);
+    setOnboardingDone(
+      selectedNetwork ? localStorage.getItem(onboardedStorageKey(selectedNetwork.recordId)) === "1" : false
+    );
     suppressed.current = { requests: new Set(), invites: new Set(), nodes: new Set() };
   }, [selectedNetwork?.recordId]);
+
+  const markOnboarded = useCallback(() => {
+    setOnboardingDone(true);
+    if (selectedNetwork) {
+      try {
+        localStorage.setItem(onboardedStorageKey(selectedNetwork.recordId), "1");
+      } catch {
+        // Storage full/unavailable: the in-memory flag still covers this session.
+      }
+    }
+  }, [selectedNetwork]);
+
+  // A network that already has nodes is established — never (re-)enter the
+  // guide for it, including after its last node is removed later.
+  useEffect(() => {
+    if (!topology || !selectedNetwork) return;
+    const hasNodes = topology.members.some((member) => member.nodes.length > 0) || topology.legacyNodes.length > 0;
+    if (hasNodes && localStorage.getItem(onboardedStorageKey(selectedNetwork.recordId)) !== "1") {
+      markOnboarded();
+    }
+  }, [markOnboarded, selectedNetwork, topology]);
+
+  // Mid-guide reload: inviteResults is session state, but an active invite may
+  // exist on the DWN — rebuild its install command so the operator sees the
+  // same command hero instead of being pushed to mint a second invite.
+  useEffect(() => {
+    if (!session || !selectedNetwork || !topology || onboardingDone) return;
+    if (inviteResults.length > 0 || rebuiltCommand) return;
+    const hasNodes = topology.members.some((member) => member.nodes.length > 0) || topology.legacyNodes.length > 0;
+    const newestInvite = topology.preAuthKeys[0];
+    if (hasNodes || !newestInvite) return;
+    let cancelled = false;
+    void buildMeshdInviteURL(session, selectedNetwork, newestInvite)
+      .then((url) => {
+        if (!cancelled) setRebuiltCommand(installAndUpCommand(url));
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [inviteResults.length, onboardingDone, rebuiltCommand, selectedNetwork, session, topology]);
 
   async function runAction(label: string, action: () => Promise<void>) {
     setBusyAction(label);
@@ -389,7 +442,9 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
     await runAction(`approve-${request.recordId}`, async () => {
       const result = await approveMeshdNodeRequest(session, selectedNetwork, request);
       if (isFirstDevice) {
-        setFirstConnected({ name: request.label, meshIP: result.meshIP });
+        // Set-once: with two pending requests approved back-to-back, the
+        // success step announces the first device, not the last writer.
+        setFirstConnected((current) => current ?? { name: request.label, meshIP: result.meshIP });
       }
       // Drop the approved request now, and drop the single-use invite it consumed,
       // so both disappear immediately instead of lingering until the delete
@@ -604,21 +659,26 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
           />
         ) : !selectedNetwork ? (
           <StatePanel title="Loading networks" detail="Fetching your mesh networks." loading />
+        ) : !topology ? (
+          // The onboarding-vs-dashboard decision needs a loaded topology: an
+          // established network must never flash the first-run guide while
+          // its node list is still in flight.
+          <StatePanel title={selectedNetwork.name} detail="Loading the network topology." loading />
         ) : firstConnected && !onboardingDone ? (
           <FirstNodeConnected
             name={firstConnected.name}
             meshIP={firstConnected.meshIP}
             onAddAnother={() => {
-              setOnboardingDone(true);
+              markOnboarded();
               void handleCreateInvite();
             }}
-            onDismiss={() => setOnboardingDone(true)}
+            onDismiss={markOnboarded}
           />
         ) : allNodes.length === 0 && !onboardingDone ? (
           <>
             <FirstDevicePanel
               networkName={selectedNetwork.name}
-              command={inviteResults[0] ? installAndUpCommand(inviteResults[0].url) : undefined}
+              command={inviteResults[0] ? installAndUpCommand(inviteResults[0].url) : rebuiltCommand}
               inviteHint={inviteHint}
               creating={busyAction === "create-invite"}
               pendingCount={pendingRequests.length}
@@ -637,7 +697,7 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
                 ))}
               </div>
             </FirstDevicePanel>
-            <button className="text-button skip-guide" type="button" onClick={() => setOnboardingDone(true)}>
+            <button className="text-button skip-guide" type="button" onClick={markOnboarded}>
               Skip the guided setup
             </button>
           </>
@@ -971,15 +1031,23 @@ function InviteRow({
   const saving = busyAction === `describe-${invite.recordId}`;
   const [editing, setEditing] = useState(false);
   const [descriptionValue, setDescriptionValue] = useState(invite.label ?? "");
+  const editButtonRef = useRef<HTMLButtonElement>(null);
   const expiry = describeExpiry(invite.expiresAt);
 
   useEffect(() => {
     setDescriptionValue(invite.label ?? "");
   }, [invite.label]);
 
+  // Closing the editor unmounts the focused input; put keyboard users back on
+  // the pencil button instead of dropping focus to <body>.
+  function closeEditor() {
+    setEditing(false);
+    editButtonRef.current?.focus();
+  }
+
   async function saveDescription() {
     await onSaveDescription(invite, descriptionValue);
-    setEditing(false);
+    closeEditor();
   }
 
   return (
@@ -998,9 +1066,11 @@ function InviteRow({
       </div>
       <div className="row-actions">
         <button
+          ref={editButtonRef}
           className="icon-button"
           type="button"
           aria-label={invite.label ? "Edit invite description" : "Add invite description"}
+          aria-expanded={editing}
           title={invite.label ? "Edit description" : "Add description"}
           onClick={() => setEditing((value) => !value)}
         >
@@ -1025,7 +1095,7 @@ function InviteRow({
             placeholder="What is this invite for? (optional)"
             onKeyDown={(event) => {
               if (event.key === "Enter") void saveDescription();
-              if (event.key === "Escape") setEditing(false);
+              if (event.key === "Escape") closeEditor();
             }}
           />
           <button

--- a/admin-dapp/src/App.tsx
+++ b/admin-dapp/src/App.tsx
@@ -26,6 +26,7 @@ import {
   type MeshdDashboardURLContext
 } from "./meshd/dashboard-url";
 import { installAndUpCommand } from "./meshd/commands";
+import { FirstDevicePanel, FirstNetworkPanel, FirstNodeConnected } from "./onboarding";
 import {
   approveMeshdNodeRequest,
   buildMeshdInviteURL,
@@ -36,6 +37,7 @@ import {
   rejectMeshdNodeRequest,
   removeMeshdNode,
   revokeMeshdInvite,
+  updateMeshdInviteDescription,
   updateMeshdNodeExpiry,
   updateMeshdNodeLabel,
   type CreateMeshdInviteResult,
@@ -198,11 +200,14 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
   const [loadState, setLoadState] = useState<LoadState>("idle");
   const [error, setError] = useState<string>();
   const [inviteResults, setInviteResults] = useState<CreateMeshdInviteResult[]>([]);
-  const [inviteLabel, setInviteLabel] = useState("");
   const [inviteExpiry, setInviteExpiry] = useState<ExpiryValue>("7d");
   const [inviteReusable, setInviteReusable] = useState(false);
   const [networkName, setNetworkName] = useState("");
   const [networkCIDR, setNetworkCIDR] = useState("10.200.0.0/16");
+  // First-run guide: tracks the just-approved first device for the success
+  // step, and whether the operator finished or skipped the guide.
+  const [firstConnected, setFirstConnected] = useState<{ name?: string; meshIP: string }>();
+  const [onboardingDone, setOnboardingDone] = useState(false);
   const [busyAction, setBusyAction] = useState<string>();
   const [topologyRefreshing, setTopologyRefreshing] = useState(false);
   const topologyRefreshInFlight = useRef(false);
@@ -322,6 +327,8 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
   // carries across.
   useEffect(() => {
     setInviteResults([]);
+    setFirstConnected(undefined);
+    setOnboardingDone(false);
     suppressed.current = { requests: new Set(), invites: new Set(), nodes: new Set() };
   }, [selectedNetwork?.recordId]);
 
@@ -337,10 +344,10 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
     }
   }
 
-  async function handleCreateNetwork() {
+  async function handleCreateNetwork(name: string, cidr: string) {
     if (!session) return;
     await runAction("create-network", async () => {
-      const network = await createMeshdNetwork(session, { name: networkName, meshCIDR: networkCIDR });
+      const network = await createMeshdNetwork(session, { name, meshCIDR: cidr });
       setNetworkName("");
       setNetworks((current) => [network, ...current]);
       setSelectedNetworkId(network.recordId);
@@ -352,11 +359,9 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
     if (!session || !selectedNetwork) return;
     await runAction("create-invite", async () => {
       const result = await createMeshdInvite(session, selectedNetwork, {
-        label: inviteLabel.trim() || undefined,
         expiresAt: expiryTimestamp(inviteExpiry),
         reusable: inviteReusable
       });
-      setInviteLabel("");
       // Keep every invite created this session pinned and copyable, newest first,
       // so several machines can be invited and copied without losing earlier URLs.
       setInviteResults((prev) => [result, ...prev]);
@@ -365,10 +370,27 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
     });
   }
 
+  async function handleUpdateInviteDescription(key: MeshdPreAuthKeySummary, description: string) {
+    if (!session || !selectedNetwork) return;
+    await runAction(`describe-${key.recordId}`, async () => {
+      const updated = await updateMeshdInviteDescription(session, selectedNetwork, key, description);
+      patchTopology((current) => ({
+        ...current,
+        preAuthKeys: current.preAuthKeys.map((item) => (item.recordId === updated.recordId ? updated : item))
+      }));
+      toast.success(description.trim() ? "Invite description saved" : "Invite description cleared");
+    });
+  }
+
   async function handleApprove(request: MeshdNodeRequestSummary) {
     if (!session || !selectedNetwork) return;
+    const isFirstDevice = !topology?.members.some((member) => member.nodes.length > 0)
+      && (topology?.legacyNodes.length ?? 0) === 0;
     await runAction(`approve-${request.recordId}`, async () => {
       const result = await approveMeshdNodeRequest(session, selectedNetwork, request);
+      if (isFirstDevice) {
+        setFirstConnected({ name: request.label, meshIP: result.meshIP });
+      }
       // Drop the approved request now, and drop the single-use invite it consumed,
       // so both disappear immediately instead of lingering until the delete
       // propagates back through a refetch.
@@ -511,6 +533,10 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
     ...(topology?.legacyNodes.map((node) => ({ node, member: undefined })) ?? [])
   ];
   const pendingRequests = topology?.pendingRequests ?? [];
+  const expiryLabel = (EXPIRY_OPTIONS.find((option) => option.value === inviteExpiry)?.label ?? inviteExpiry).toLowerCase();
+  const inviteHint = inviteExpiry === "never"
+    ? `The invite never expires and admits ${inviteReusable ? "any number of devices" : "one device"}.`
+    : `The invite is valid for ${expiryLabel} and admits ${inviteReusable ? "any number of devices" : "one device"}.`;
 
   return (
     <div className="dashboard-grid">
@@ -542,34 +568,79 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
           ) : null}
         </div>
 
-        <div className="create-box">
-          <div className="section-heading">
-            <span>New Network</span>
+        {networks.length > 0 ? (
+          <div className="create-box">
+            <div className="section-heading">
+              <span>New Network</span>
+            </div>
+            <label>
+              Name
+              <input value={networkName} onChange={(event) => setNetworkName(event.target.value)} placeholder="home" />
+            </label>
+            <label>
+              CIDR
+              <input value={networkCIDR} onChange={(event) => setNetworkCIDR(event.target.value)} />
+            </label>
+            <button
+              className="secondary-button"
+              type="button"
+              disabled={busyAction === "create-network" || networkName.trim() === ""}
+              onClick={() => void handleCreateNetwork(networkName, networkCIDR)}
+            >
+              {busyAction === "create-network" ? <Loader2Icon className="spin" size={16} /> : <PlusIcon size={16} />}
+              Create Network
+            </button>
           </div>
-          <label>
-            Name
-            <input value={networkName} onChange={(event) => setNetworkName(event.target.value)} placeholder="home" />
-          </label>
-          <label>
-            CIDR
-            <input value={networkCIDR} onChange={(event) => setNetworkCIDR(event.target.value)} />
-          </label>
-          <button
-            className="secondary-button"
-            type="button"
-            disabled={busyAction === "create-network" || networkName.trim() === ""}
-            onClick={() => void handleCreateNetwork()}
-          >
-            {busyAction === "create-network" ? <Loader2Icon className="spin" size={16} /> : <PlusIcon size={16} />}
-            Create Network
-          </button>
-        </div>
+        ) : null}
       </aside>
 
       <section className="main-panel">
         {error ? <div className="error-banner">{error}</div> : null}
-        {!selectedNetwork ? (
-          <StatePanel title="No networks" detail="Create a mesh network in the sidebar to start inviting devices." />
+        {networks.length === 0 && loadState === "ready" ? (
+          <FirstNetworkPanel
+            busy={busyAction === "create-network"}
+            defaultCIDR="10.200.0.0/16"
+            onCreate={(name, cidr) => void handleCreateNetwork(name, cidr)}
+          />
+        ) : !selectedNetwork ? (
+          <StatePanel title="Loading networks" detail="Fetching your mesh networks." loading />
+        ) : firstConnected && !onboardingDone ? (
+          <FirstNodeConnected
+            name={firstConnected.name}
+            meshIP={firstConnected.meshIP}
+            onAddAnother={() => {
+              setOnboardingDone(true);
+              void handleCreateInvite();
+            }}
+            onDismiss={() => setOnboardingDone(true)}
+          />
+        ) : allNodes.length === 0 && !onboardingDone ? (
+          <>
+            <FirstDevicePanel
+              networkName={selectedNetwork.name}
+              command={inviteResults[0] ? installAndUpCommand(inviteResults[0].url) : undefined}
+              inviteHint={inviteHint}
+              creating={busyAction === "create-invite"}
+              pendingCount={pendingRequests.length}
+              onCreateInvite={() => void handleCreateInvite()}
+              onCopyCommand={copyToClipboard}
+            >
+              <div className="stack">
+                {pendingRequests.map((request) => (
+                  <PendingRequestRow
+                    key={request.recordId}
+                    request={request}
+                    busyAction={busyAction}
+                    onApprove={handleApprove}
+                    onReject={handleReject}
+                  />
+                ))}
+              </div>
+            </FirstDevicePanel>
+            <button className="text-button skip-guide" type="button" onClick={() => setOnboardingDone(true)}>
+              Skip the guided setup
+            </button>
+          </>
         ) : (
           <>
             <div className="network-header">
@@ -615,10 +686,6 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
               </div>
               <div className="invite-fields">
                 <label>
-                  Label
-                  <input value={inviteLabel} onChange={(event) => setInviteLabel(event.target.value)} placeholder="e.g. laptop" />
-                </label>
-                <label>
                   Access expires
                   <select value={inviteExpiry} onChange={(event) => setInviteExpiry(event.target.value as ExpiryValue)}>
                     {EXPIRY_OPTIONS.map((option) => (
@@ -645,7 +712,8 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
                 </button>
               </div>
               <p className="field-hint">
-                The device stays valid until the invite expires — you set the expiry once, here, and it carries to the node when you approve it.
+                The joined device stays valid until the invite expires — set once here, inherited on approval.
+                Devices are named by their own hostname; rename them on the node card after they connect.
               </p>
             </section>
 
@@ -690,6 +758,7 @@ function Dashboard({ context }: { context: MeshdDashboardURLContext }) {
                     busyAction={busyAction}
                     onCopy={handleCopyExistingInvite}
                     onCopyCommand={handleCopyExistingInviteCommand}
+                    onSaveDescription={handleUpdateInviteDescription}
                     onRevoke={handleRevokeInvite}
                   />
                 )) : <EmptyRow icon={<UserPlusIcon size={18} />} text="No active invites" />}
@@ -796,14 +865,14 @@ function NodeCard({
         <div className="node-card-edit">
           <div className="label-editor">
             <label>
-              Label
-              <input value={labelValue} onChange={(event) => setLabelValue(event.target.value)} placeholder={node.meshIP || "Node label"} />
+              Device name
+              <input value={labelValue} onChange={(event) => setLabelValue(event.target.value)} placeholder={node.meshIP || "hostname"} />
             </label>
             <button
               className="icon-button success"
               type="button"
-              aria-label="Save node label"
-              title="Save label"
+              aria-label="Save device name"
+              title="Save name"
               disabled={updatingLabel || removing}
               onClick={() => void applyLabel()}
             >
@@ -858,7 +927,7 @@ function InviteResultCard({
     <div className="invite-result">
       <div className="invite-result-body">
         <div className="invite-result-head">
-          <strong>{result.label || "New invite"}</strong>
+          <strong className="invite-id" title={result.tokenId}>Invite {truncateDid(result.tokenId, 10, 4)}</strong>
           <span className={`expiry-pill ${expiry.tone}`}><ClockIcon size={13} />{expiry.label}</span>
         </div>
         <code>{command}</code>
@@ -888,23 +957,39 @@ function InviteRow({
   busyAction,
   onCopy,
   onCopyCommand,
+  onSaveDescription,
   onRevoke
 }: {
   invite: MeshdPreAuthKeySummary;
   busyAction?: string;
   onCopy: (invite: MeshdPreAuthKeySummary) => Promise<void>;
   onCopyCommand: (invite: MeshdPreAuthKeySummary) => Promise<void>;
+  onSaveDescription: (invite: MeshdPreAuthKeySummary, description: string) => Promise<void>;
   onRevoke: (invite: MeshdPreAuthKeySummary) => Promise<void>;
 }) {
   const revoking = busyAction === `revoke-${invite.recordId}`;
+  const saving = busyAction === `describe-${invite.recordId}`;
+  const [editing, setEditing] = useState(false);
+  const [descriptionValue, setDescriptionValue] = useState(invite.label ?? "");
   const expiry = describeExpiry(invite.expiresAt);
+
+  useEffect(() => {
+    setDescriptionValue(invite.label ?? "");
+  }, [invite.label]);
+
+  async function saveDescription() {
+    await onSaveDescription(invite, descriptionValue);
+    setEditing(false);
+  }
+
   return (
-    <article className="data-row">
+    <article className="data-row invite-row">
       <div className="row-main">
         <span className="row-icon"><UserPlusIcon size={17} /></span>
         <span>
-          <strong>{invite.label || truncateDid(invite.recordId, 12, 6)}</strong>
+          <strong className="invite-id" title={invite.recordId}>Invite {truncateDid(invite.recordId, 10, 4)}</strong>
           <small>
+            {invite.label ? `${invite.label} · ` : ""}
             {expiry.label}
             {invite.reusable ? " · reusable" : ""}
             {invite.usedBy.length ? ` · ${invite.usedBy.length} used` : ""}
@@ -912,6 +997,15 @@ function InviteRow({
         </span>
       </div>
       <div className="row-actions">
+        <button
+          className="icon-button"
+          type="button"
+          aria-label={invite.label ? "Edit invite description" : "Add invite description"}
+          title={invite.label ? "Edit description" : "Add description"}
+          onClick={() => setEditing((value) => !value)}
+        >
+          <PencilIcon size={16} />
+        </button>
         <button className="icon-button" type="button" aria-label="Copy install command" title="Copy install command" onClick={() => void onCopyCommand(invite)}>
           <TerminalIcon size={16} />
         </button>
@@ -922,6 +1016,30 @@ function InviteRow({
           {revoking ? <Loader2Icon className="spin" size={16} /> : <Trash2Icon size={16} />}
         </button>
       </div>
+      {editing ? (
+        <div className="invite-description-editor">
+          <input
+            autoFocus
+            value={descriptionValue}
+            onChange={(event) => setDescriptionValue(event.target.value)}
+            placeholder="What is this invite for? (optional)"
+            onKeyDown={(event) => {
+              if (event.key === "Enter") void saveDescription();
+              if (event.key === "Escape") setEditing(false);
+            }}
+          />
+          <button
+            className="icon-button success"
+            type="button"
+            aria-label="Save invite description"
+            title="Save description"
+            disabled={saving}
+            onClick={() => void saveDescription()}
+          >
+            {saving ? <Loader2Icon className="spin" size={15} /> : <CheckIcon size={15} />}
+          </button>
+        </div>
+      ) : null}
     </article>
   );
 }

--- a/admin-dapp/src/dev/preview.tsx
+++ b/admin-dapp/src/dev/preview.tsx
@@ -1,0 +1,84 @@
+import { CheckIcon, ServerIcon, XIcon } from "lucide-react";
+
+import { FirstDevicePanel, FirstNetworkPanel, FirstNodeConnected } from "../onboarding";
+
+// Dev-only visual harness: `bun run dev` then open /?preview to render every
+// guided-onboarding state with fixture data, no wallet session required.
+// Guarded behind import.meta.env.DEV in main.tsx, so it never ships.
+
+const FIXTURE_COMMAND =
+  "curl -fsSL https://meshd.sh/install | bash -s -- up 'meshd://invite/eyJ2ZXJzaW9uIjoxLCJlbmRwb2ludCI6Imh0dHBzOi8vZGV2LmF3cy5kd24uZW5ib3guaWQiLCJhbmNob3JEaWQiOiJkaWQ6ZXhhbXBsZTpvd25lciJ9'";
+
+function FakePendingRow() {
+  return (
+    <article className="data-row">
+      <div className="row-main">
+        <span className="row-icon"><ServerIcon size={17} /></span>
+        <span>
+          <strong>homelab-01</strong>
+          <small>Joined via invite</small>
+        </span>
+      </div>
+      <code>did:jwk:eyJrdHkiOiJPS1AiLCJjcnYi...</code>
+      <div className="row-actions">
+        <button className="primary-button small" type="button"><CheckIcon size={15} />Approve</button>
+        <button className="icon-button danger" type="button" aria-label="Reject"><XIcon size={16} /></button>
+      </div>
+    </article>
+  );
+}
+
+export function Preview() {
+  const noop = () => undefined;
+  const noopAsync = async () => undefined;
+  return (
+    <div className="workspace" style={{ display: "grid", gap: "3rem" }}>
+      <PreviewCase title="1 · First network">
+        <FirstNetworkPanel defaultCIDR="10.200.0.0/16" onCreate={noop} />
+      </PreviewCase>
+      <PreviewCase title="2 · Add first device — before invite">
+        <FirstDevicePanel
+          networkName="home"
+          inviteHint="The invite is valid for 7 days and admits one device."
+          pendingCount={0}
+          onCreateInvite={noop}
+          onCopyCommand={noopAsync}
+        />
+      </PreviewCase>
+      <PreviewCase title="3 · Add first device — waiting">
+        <FirstDevicePanel
+          networkName="home"
+          command={FIXTURE_COMMAND}
+          inviteHint=""
+          pendingCount={0}
+          onCreateInvite={noop}
+          onCopyCommand={noopAsync}
+        />
+      </PreviewCase>
+      <PreviewCase title="4 · Add first device — request arrived">
+        <FirstDevicePanel
+          networkName="home"
+          command={FIXTURE_COMMAND}
+          inviteHint=""
+          pendingCount={1}
+          onCreateInvite={noop}
+          onCopyCommand={noopAsync}
+        >
+          <div className="stack"><FakePendingRow /></div>
+        </FirstDevicePanel>
+      </PreviewCase>
+      <PreviewCase title="5 · First device connected">
+        <FirstNodeConnected name="homelab-01" meshIP="10.200.31.7" onAddAnother={noop} onDismiss={noop} />
+      </PreviewCase>
+    </div>
+  );
+}
+
+function PreviewCase({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section style={{ display: "grid", gap: "0.75rem" }}>
+      <div className="section-heading"><span>{title}</span></div>
+      <div className="main-panel">{children}</div>
+    </section>
+  );
+}

--- a/admin-dapp/src/main.tsx
+++ b/admin-dapp/src/main.tsx
@@ -6,11 +6,25 @@ import { App } from "./App";
 import { EnboxProvider } from "./enbox/EnboxProvider";
 import "./styles.css";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <EnboxProvider>
-      <App />
-      <Toaster position="bottom-right" richColors />
-    </EnboxProvider>
-  </React.StrictMode>
-);
+const root = ReactDOM.createRoot(document.getElementById("root")!);
+
+// Dev-only visual harness for the guided onboarding states (no wallet needed):
+// `bun run dev` and open /?preview. Excluded from production builds.
+if (import.meta.env.DEV && new URLSearchParams(window.location.search).has("preview")) {
+  void import("./dev/preview").then(({ Preview }) => {
+    root.render(
+      <React.StrictMode>
+        <Preview />
+      </React.StrictMode>
+    );
+  });
+} else {
+  root.render(
+    <React.StrictMode>
+      <EnboxProvider>
+        <App />
+        <Toaster position="bottom-right" richColors />
+      </EnboxProvider>
+    </React.StrictMode>
+  );
+}

--- a/admin-dapp/src/meshd/admin.test.ts
+++ b/admin-dapp/src/meshd/admin.test.ts
@@ -14,6 +14,7 @@ import {
   parseMeshdNodeRequestRecord,
   parseMeshdPreAuthKeyRecord,
   rejectMeshdNodeRequest,
+  updateMeshdInviteDescription,
   updateMeshdNodeExpiry,
   updateMeshdNodeLabel,
   type MeshdAdminAgent,
@@ -634,6 +635,70 @@ describe("meshd admin DWN operations", () => {
     await expect(blobJson(requests[0].dataStream)).resolves.not.toHaveProperty("label");
   });
 
+  it("updates the invite description while preserving the invite payload", async () => {
+    const { session, requests } = createFakeSession({ recordIds: ["invite-record"] });
+    const network: MeshdNetworkSummary = {
+      recordId: "network-record",
+      name: "Home mesh",
+      meshCIDR: "10.200.0.0/16",
+      anchorEndpoint: "https://owner.dwn.example"
+    };
+
+    const invite = await updateMeshdInviteDescription(session, network, {
+      recordId: "invite-record",
+      key: "secret-value",
+      createdAt: "2026-06-24T00:00:00Z",
+      expiresAt: "2026-06-25T00:00:00Z",
+      reusable: true,
+      usedBy: ["did:example:used"],
+      recordCreatedAt: "2026-06-24T00:00:00Z"
+    }, "office rack invite");
+
+    expect(invite.label).toBe("office rack invite");
+    expect(requests[0]).toMatchObject({
+      encryption: true,
+      messageType: DwnInterface.RecordsWrite,
+      messageParams: {
+        protocol: MESHD_PROTOCOL_URI,
+        protocolPath: "network/preAuthKey",
+        schema: "https://enbox.id/schemas/wireguard-mesh/pre-auth-key",
+        parentContextId: "network-record",
+        recordId: "invite-record",
+        dateCreated: "2026-06-24T00:00:00Z"
+      }
+    });
+    await expect(blobJson(requests[0].dataStream)).resolves.toEqual({
+      key: "secret-value",
+      createdAt: "2026-06-24T00:00:00Z",
+      expiresAt: "2026-06-25T00:00:00Z",
+      reusable: true,
+      label: "office rack invite",
+      usedBy: ["did:example:used"]
+    });
+  });
+
+  it("clears the invite description while keeping the secret and usage list", async () => {
+    const { session, requests } = createFakeSession({ recordIds: ["invite-record"] });
+    const network: MeshdNetworkSummary = {
+      recordId: "network-record",
+      name: "Home mesh",
+      meshCIDR: "10.200.0.0/16"
+    };
+
+    const invite = await updateMeshdInviteDescription(session, network, {
+      recordId: "invite-record",
+      key: "secret-value",
+      label: "old note",
+      usedBy: []
+    }, "   ");
+
+    expect(invite.label).toBeUndefined();
+    await expect(blobJson(requests[0].dataStream)).resolves.toEqual({
+      key: "secret-value",
+      usedBy: []
+    });
+  });
+
   it("fails closed when the session has no delegate identity (never authors as owner)", async () => {
     const { session, agent, requests, pushes } = createFakeSession({ delegate: false });
 
@@ -910,7 +975,10 @@ describe("meshd invite lifecycle", () => {
     expect(payload.usedBy).toEqual([request.nodeDID]);
   });
 
-  it("carries the invite label to the joined node when the request has none", async () => {
+  // Invites are operator annotations referenced by ID — their description never
+  // names a machine. The node's name is its self-reported hostname (the request
+  // label), editable on the node card after it connects.
+  it("does not carry the invite description to the joined node", async () => {
     const { session, requests } = createFakeSession({
       recordIds: ["member-rec", "node-rec"],
       queryEntries: [inviteEntry({ reusable: false, label: "laptop-01" })]
@@ -927,7 +995,7 @@ describe("meshd invite lifecycle", () => {
     );
     expect(nodeWrite).toBeDefined();
     const payload = await blobJson(nodeWrite!.dataStream);
-    expect(payload.label).toBe("laptop-01");
+    expect(payload).not.toHaveProperty("label");
   });
 
   // One expiry model: the invite defines the access window, and the node that

--- a/admin-dapp/src/meshd/admin.test.ts
+++ b/admin-dapp/src/meshd/admin.test.ts
@@ -635,8 +635,23 @@ describe("meshd admin DWN operations", () => {
     await expect(blobJson(requests[0].dataStream)).resolves.not.toHaveProperty("label");
   });
 
-  it("updates the invite description while preserving the invite payload", async () => {
-    const { session, requests } = createFakeSession({ recordIds: ["invite-record"] });
+  // The description edit re-reads the record before rewriting: the anchor
+  // daemon consumes invites concurrently, and writing a stale usedBy back
+  // would re-arm a spent single-use invite. The caller's (possibly stale)
+  // summary must contribute nothing but the record ID.
+  it("updates the invite description from the fresh record, never the stale summary", async () => {
+    const { session, requests } = createFakeSession({
+      recordIds: ["invite-record"],
+      queryEntries: [
+        recordEntry("invite-record", "network/preAuthKey", {
+          key: "secret-value",
+          createdAt: "2026-06-24T00:00:00Z",
+          expiresAt: "2026-06-25T00:00:00Z",
+          reusable: false,
+          usedBy: ["did:example:already-joined"]
+        })
+      ]
+    });
     const network: MeshdNetworkSummary = {
       recordId: "network-record",
       name: "Home mesh",
@@ -644,20 +659,19 @@ describe("meshd admin DWN operations", () => {
       anchorEndpoint: "https://owner.dwn.example"
     };
 
+    // Stale summary: fetched before the anchor daemon consumed the invite.
     const invite = await updateMeshdInviteDescription(session, network, {
       recordId: "invite-record",
       key: "secret-value",
-      createdAt: "2026-06-24T00:00:00Z",
-      expiresAt: "2026-06-25T00:00:00Z",
-      reusable: true,
-      usedBy: ["did:example:used"],
-      recordCreatedAt: "2026-06-24T00:00:00Z"
-    }, "office rack invite");
+      usedBy: [],
+      recordCreatedAt: "2026-01-01T00:00:00Z"
+    } as never, "office rack invite");
 
     expect(invite.label).toBe("office rack invite");
-    expect(requests[0]).toMatchObject({
+    expect(invite.usedBy).toEqual(["did:example:already-joined"]);
+    const write = requests.find((request) => request.messageType === DwnInterface.RecordsWrite);
+    expect(write).toMatchObject({
       encryption: true,
-      messageType: DwnInterface.RecordsWrite,
       messageParams: {
         protocol: MESHD_PROTOCOL_URI,
         protocolPath: "network/preAuthKey",
@@ -667,36 +681,54 @@ describe("meshd admin DWN operations", () => {
         dateCreated: "2026-06-24T00:00:00Z"
       }
     });
-    await expect(blobJson(requests[0].dataStream)).resolves.toEqual({
+    await expect(blobJson(write!.dataStream)).resolves.toEqual({
       key: "secret-value",
       createdAt: "2026-06-24T00:00:00Z",
       expiresAt: "2026-06-25T00:00:00Z",
-      reusable: true,
+      reusable: false,
       label: "office rack invite",
-      usedBy: ["did:example:used"]
+      usedBy: ["did:example:already-joined"]
     });
   });
 
-  it("clears the invite description while keeping the secret and usage list", async () => {
-    const { session, requests } = createFakeSession({ recordIds: ["invite-record"] });
+  it("clears the invite description while keeping the fresh secret and usage list", async () => {
+    const { session, requests } = createFakeSession({
+      recordIds: ["invite-record"],
+      queryEntries: [
+        recordEntry("invite-record", "network/preAuthKey", {
+          key: "secret-value",
+          label: "old note",
+          usedBy: []
+        })
+      ]
+    });
     const network: MeshdNetworkSummary = {
       recordId: "network-record",
       name: "Home mesh",
       meshCIDR: "10.200.0.0/16"
     };
 
-    const invite = await updateMeshdInviteDescription(session, network, {
-      recordId: "invite-record",
-      key: "secret-value",
-      label: "old note",
-      usedBy: []
-    }, "   ");
+    const invite = await updateMeshdInviteDescription(session, network, { recordId: "invite-record" }, "   ");
 
     expect(invite.label).toBeUndefined();
-    await expect(blobJson(requests[0].dataStream)).resolves.toEqual({
+    const write = requests.find((request) => request.messageType === DwnInterface.RecordsWrite);
+    await expect(blobJson(write!.dataStream)).resolves.toEqual({
       key: "secret-value",
       usedBy: []
     });
+  });
+
+  it("refuses to update the description of a revoked or consumed invite", async () => {
+    const { session } = createFakeSession({ recordIds: ["invite-record"], queryEntries: [] });
+    const network: MeshdNetworkSummary = {
+      recordId: "network-record",
+      name: "Home mesh",
+      meshCIDR: "10.200.0.0/16"
+    };
+
+    await expect(
+      updateMeshdInviteDescription(session, network, { recordId: "invite-record" }, "note")
+    ).rejects.toThrow("no longer exists");
   });
 
   it("fails closed when the session has no delegate identity (never authors as owner)", async () => {

--- a/admin-dapp/src/meshd/admin.ts
+++ b/admin-dapp/src/meshd/admin.ts
@@ -830,6 +830,50 @@ export async function revokeMeshdInvite(
   await deleteRecord(session, MESHD_PROTOCOL_URI, key.recordId, false);
 }
 
+// Rewrites an invite's preAuthKey record with an updated description (stored in
+// the record's `label` field), preserving the secret, expiry, reusability, and
+// usage list. Invites are referenced by ID; the description is an optional
+// operator note added after creation.
+export async function updateMeshdInviteDescription(
+  session: MeshdAdminSession,
+  network: MeshdNetworkSummary,
+  invite: MeshdPreAuthKeySummary,
+  description?: string
+): Promise<MeshdPreAuthKeySummary> {
+  const nextDescription = description?.trim();
+  await writeRecord(
+    session,
+    MESHD_PROTOCOL_URI,
+    {
+      protocol: MESHD_PROTOCOL_URI,
+      protocolPath: "network/preAuthKey",
+      schema: "https://enbox.id/schemas/wireguard-mesh/pre-auth-key",
+      dataFormat: "application/json",
+      parentContextId: network.recordId,
+      recordId: invite.recordId,
+      ...(invite.recordCreatedAt ? { dateCreated: invite.recordCreatedAt } : {})
+    },
+    {
+      key: invite.key,
+      ...(invite.createdAt ? { createdAt: invite.createdAt } : {}),
+      ...(invite.expiresAt ? { expiresAt: invite.expiresAt } : {}),
+      ...(invite.reusable !== undefined ? { reusable: invite.reusable } : {}),
+      ...(invite.ephemeral !== undefined ? { ephemeral: invite.ephemeral } : {}),
+      ...(nextDescription ? { label: nextDescription } : {}),
+      usedBy: invite.usedBy ?? []
+    },
+    true
+  );
+
+  const next = { ...invite };
+  if (nextDescription) {
+    next.label = nextDescription;
+  } else {
+    delete next.label;
+  }
+  return next;
+}
+
 function nodeJoinProofMessage(
   networkId: string,
   nodeDID: string,
@@ -1178,10 +1222,11 @@ export async function approveMeshdNodeRequest(
   const preAuthKey = ownerScopedRequest ? undefined : await readPreAuthKey(session, network, request);
   const requestOwnerDID = nodeOwnerDID(request);
 
-  // An invite can pre-name the machine that joins with it: when the node request
-  // carries no label of its own, fall back to the invite's label, so an invite
-  // labeled "laptop-01" makes the joined node show as "laptop-01".
-  const effectiveLabel = request.label?.trim() || preAuthKey?.label;
+  // The node is named by what it reports about itself — its hostname, sent as
+  // the request label. An invite's description never names a machine: invites
+  // are operator annotations referenced by ID, and the joined device's name is
+  // editable on the node card after it connects.
+  const effectiveLabel = request.label?.trim() || undefined;
 
   // The node authorizes as network/member and its peer records are encrypted to the
   // network/member audience, so that reading-role audience must be delivered to it. A

--- a/admin-dapp/src/meshd/admin.ts
+++ b/admin-dapp/src/meshd/admin.ts
@@ -831,16 +831,35 @@ export async function revokeMeshdInvite(
 }
 
 // Rewrites an invite's preAuthKey record with an updated description (stored in
-// the record's `label` field), preserving the secret, expiry, reusability, and
-// usage list. Invites are referenced by ID; the description is an optional
-// operator note added after creation.
+// the record's `label` field). Invites are referenced by ID; the description is
+// an optional operator note added after creation.
+//
+// The record is re-read immediately before the rewrite: the anchor daemon
+// consumes invites concurrently (appending to usedBy), and rewriting from a
+// stale topology snapshot would reset usedBy — re-arming a spent single-use
+// invite for anyone still holding its URL. Only the description may come from
+// the caller; everything else is preserved from the fresh record.
 export async function updateMeshdInviteDescription(
   session: MeshdAdminSession,
   network: MeshdNetworkSummary,
-  invite: MeshdPreAuthKeySummary,
+  invite: Pick<MeshdPreAuthKeySummary, "recordId">,
   description?: string
 ): Promise<MeshdPreAuthKeySummary> {
   const nextDescription = description?.trim();
+  const entries = await queryRecords(
+    session,
+    MESHD_PROTOCOL_URI,
+    "network/preAuthKey",
+    network.recordId,
+    { recordId: invite.recordId }
+  );
+  const fresh = entries
+    .map(parseMeshdPreAuthKeyRecord)
+    .find((entry) => entry?.recordId === invite.recordId);
+  if (!fresh) {
+    throw new Error("This invite no longer exists — it may have been revoked or already consumed.");
+  }
+
   await writeRecord(
     session,
     MESHD_PROTOCOL_URI,
@@ -850,22 +869,22 @@ export async function updateMeshdInviteDescription(
       schema: "https://enbox.id/schemas/wireguard-mesh/pre-auth-key",
       dataFormat: "application/json",
       parentContextId: network.recordId,
-      recordId: invite.recordId,
-      ...(invite.recordCreatedAt ? { dateCreated: invite.recordCreatedAt } : {})
+      recordId: fresh.recordId,
+      ...(fresh.recordCreatedAt ? { dateCreated: fresh.recordCreatedAt } : {})
     },
     {
-      key: invite.key,
-      ...(invite.createdAt ? { createdAt: invite.createdAt } : {}),
-      ...(invite.expiresAt ? { expiresAt: invite.expiresAt } : {}),
-      ...(invite.reusable !== undefined ? { reusable: invite.reusable } : {}),
-      ...(invite.ephemeral !== undefined ? { ephemeral: invite.ephemeral } : {}),
+      key: fresh.key,
+      ...(fresh.createdAt ? { createdAt: fresh.createdAt } : {}),
+      ...(fresh.expiresAt ? { expiresAt: fresh.expiresAt } : {}),
+      ...(fresh.reusable !== undefined ? { reusable: fresh.reusable } : {}),
+      ...(fresh.ephemeral !== undefined ? { ephemeral: fresh.ephemeral } : {}),
       ...(nextDescription ? { label: nextDescription } : {}),
-      usedBy: invite.usedBy ?? []
+      usedBy: fresh.usedBy
     },
     true
   );
 
-  const next = { ...invite };
+  const next = { ...fresh };
   if (nextDescription) {
     next.label = nextDescription;
   } else {

--- a/admin-dapp/src/onboarding.tsx
+++ b/admin-dapp/src/onboarding.tsx
@@ -119,7 +119,7 @@ export function FirstDevicePanel({
           <div>
             <h1>Add your first device</h1>
             <p>
-              An invite lets one device request to join <strong>{networkName}</strong>.
+              An invite lets a device request to join <strong>{networkName}</strong>.
               You approve every request here before it can connect.
             </p>
           </div>
@@ -139,19 +139,23 @@ export function FirstDevicePanel({
             </p>
           </div>
           <CommandHero command={command} onCopy={onCopyCommand} />
-          {pendingCount > 0 ? (
-            <div className="onboarding-approve rise">
-              <div className="section-heading"><span>A device is asking to join</span></div>
-              {children}
-            </div>
-          ) : (
-            <div className="waiting-row" role="status">
-              <span className="waiting-dot" aria-hidden="true" />
-              Waiting for a device to run the command — this page updates on its own.
-            </div>
-          )}
         </>
       )}
+      {/* One persistent live region across all states: swapping its text is
+          announced to screen readers, unmounting it would not be. A pending
+          request always surfaces here, even when the command was lost (page
+          reload) — the device is waiting either way. */}
+      <div className="waiting-row" role="status">
+        {pendingCount === 0 && command ? <span className="waiting-dot" aria-hidden="true" /> : null}
+        {pendingCount > 0
+          ? "A device is asking to join — approve it below."
+          : command
+            ? "Waiting for a device to run the command — this page updates on its own."
+            : "Devices appear here as soon as they request to join."}
+      </div>
+      {pendingCount > 0 ? (
+        <div className="onboarding-approve rise">{children}</div>
+      ) : null}
     </section>
   );
 }

--- a/admin-dapp/src/onboarding.tsx
+++ b/admin-dapp/src/onboarding.tsx
@@ -1,0 +1,216 @@
+import { useState, type FormEvent, type ReactNode } from "react";
+import {
+  CheckIcon,
+  ClipboardIcon,
+  Loader2Icon,
+  NetworkIcon,
+  PartyPopperIcon,
+  ServerIcon,
+  UserPlusIcon
+} from "lucide-react";
+
+// Guided first-run flow: create the first network, add the first device with
+// the install one-liner, approve it live. Purely presentational — state and
+// DWN actions stay in App. Rendered instead of the regular dashboard panels
+// until the first node is connected.
+
+const STEPS = ["Network", "Device", "Approve"] as const;
+
+export function OnboardingSteps({ current }: { current: 1 | 2 | 3 }) {
+  return (
+    <ol className="onboarding-steps" aria-label={`Setup step ${current} of ${STEPS.length}`}>
+      {STEPS.map((step, index) => {
+        const number = index + 1;
+        const state = number < current ? "done" : number === current ? "active" : "todo";
+        return (
+          <li key={step} className={`onboarding-step ${state}`} aria-current={state === "active" ? "step" : undefined}>
+            <span className="onboarding-step-dot">{state === "done" ? <CheckIcon size={12} /> : number}</span>
+            {step}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+export function FirstNetworkPanel({
+  busy,
+  defaultCIDR,
+  onCreate
+}: {
+  busy?: boolean;
+  defaultCIDR: string;
+  onCreate: (name: string, cidr: string) => void;
+}) {
+  const [name, setName] = useState("");
+  const [cidr, setCidr] = useState(defaultCIDR);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    if (!name.trim() || busy) return;
+    onCreate(name.trim(), cidr.trim() || defaultCIDR);
+  }
+
+  return (
+    <section className="onboarding-panel rise">
+      <OnboardingSteps current={1} />
+      <span className="panel-icon"><NetworkIcon size={22} /></span>
+      <div>
+        <h1>Create your first network</h1>
+        <p>
+          A network is a private mesh your devices join — they reach each other
+          directly over encrypted WireGuard tunnels, from anywhere.
+        </p>
+      </div>
+      <form className="onboarding-form" onSubmit={submit}>
+        <label>
+          Network name
+          <input
+            autoFocus
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="home"
+          />
+        </label>
+        {showAdvanced ? (
+          <label>
+            Mesh CIDR
+            <input value={cidr} onChange={(event) => setCidr(event.target.value)} />
+          </label>
+        ) : null}
+        <button className="primary-button" type="submit" disabled={busy || name.trim() === ""}>
+          {busy ? <Loader2Icon className="spin" size={16} /> : <NetworkIcon size={16} />}
+          Create network
+        </button>
+      </form>
+      <button className="text-button" type="button" onClick={() => setShowAdvanced((value) => !value)}>
+        {showAdvanced ? "Hide advanced options" : "Advanced options"}
+      </button>
+    </section>
+  );
+}
+
+export function FirstDevicePanel({
+  networkName,
+  command,
+  inviteHint,
+  creating,
+  pendingCount,
+  onCreateInvite,
+  onCopyCommand,
+  children
+}: {
+  networkName: string;
+  command?: string;
+  inviteHint: string;
+  creating?: boolean;
+  pendingCount: number;
+  onCreateInvite: () => void;
+  onCopyCommand: (command: string) => Promise<void>;
+  children?: ReactNode;
+}) {
+  return (
+    <section className="onboarding-panel wide rise">
+      <OnboardingSteps current={pendingCount > 0 ? 3 : 2} />
+      <span className="panel-icon"><ServerIcon size={22} /></span>
+      {!command ? (
+        <>
+          <div>
+            <h1>Add your first device</h1>
+            <p>
+              An invite lets one device request to join <strong>{networkName}</strong>.
+              You approve every request here before it can connect.
+            </p>
+          </div>
+          <button className="primary-button" type="button" disabled={creating} onClick={onCreateInvite}>
+            {creating ? <Loader2Icon className="spin" size={16} /> : <UserPlusIcon size={16} />}
+            Create an invite
+          </button>
+          <p className="field-hint">{inviteHint}</p>
+        </>
+      ) : (
+        <>
+          <div>
+            <h1>Run this on the device</h1>
+            <p>
+              It installs meshd, asks to join <strong>{networkName}</strong>, and
+              connects on its own once you approve the request here.
+            </p>
+          </div>
+          <CommandHero command={command} onCopy={onCopyCommand} />
+          {pendingCount > 0 ? (
+            <div className="onboarding-approve rise">
+              <div className="section-heading"><span>A device is asking to join</span></div>
+              {children}
+            </div>
+          ) : (
+            <div className="waiting-row" role="status">
+              <span className="waiting-dot" aria-hidden="true" />
+              Waiting for a device to run the command — this page updates on its own.
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+export function CommandHero({ command, onCopy }: { command: string; onCopy: (command: string) => Promise<void> }) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    await onCopy(command);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1800);
+  }
+
+  return (
+    <div className="command-hero">
+      <code>{command}</code>
+      <button
+        className={`secondary-button ${copied ? "copied" : ""}`}
+        type="button"
+        onClick={() => void copy()}
+      >
+        {copied ? <CheckIcon size={16} /> : <ClipboardIcon size={16} />}
+        {copied ? "Copied" : "Copy command"}
+      </button>
+    </div>
+  );
+}
+
+export function FirstNodeConnected({
+  name,
+  meshIP,
+  onAddAnother,
+  onDismiss
+}: {
+  name?: string;
+  meshIP: string;
+  onAddAnother: () => void;
+  onDismiss: () => void;
+}) {
+  return (
+    <section className="onboarding-panel rise success">
+      <span className="panel-icon success"><PartyPopperIcon size={22} /></span>
+      <div>
+        <h1>{name || "Your device"} is on the mesh</h1>
+        <p>
+          It answers at <code className="mesh-ip">{meshIP}</code> from any of your
+          other devices. Add the rest of your machines the same way — one command
+          each, approved here.
+        </p>
+      </div>
+      <div className="onboarding-actions">
+        <button className="primary-button" type="button" onClick={onAddAnother}>
+          <UserPlusIcon size={16} />
+          Add another device
+        </button>
+        <button className="secondary-button" type="button" onClick={onDismiss}>
+          Go to the dashboard
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/admin-dapp/src/styles.css
+++ b/admin-dapp/src/styles.css
@@ -821,7 +821,8 @@ dd {
 
 .onboarding-steps {
   display: flex;
-  gap: 1.1rem;
+  flex-wrap: wrap;
+  gap: 0.55rem 1.1rem;
   margin: 0;
   padding: 0;
   list-style: none;

--- a/admin-dapp/src/styles.css
+++ b/admin-dapp/src/styles.css
@@ -790,3 +790,225 @@ dd {
     justify-content: flex-end;
   }
 }
+
+/* ── Guided first-run onboarding ───────────────────────────────────────── */
+
+.onboarding-panel {
+  display: grid;
+  justify-items: start;
+  gap: 1.1rem;
+  width: min(100%, 560px);
+  margin: clamp(1rem, 6vh, 4rem) auto;
+  padding: 0.5rem 0;
+}
+
+.onboarding-panel.wide {
+  width: min(100%, 680px);
+}
+
+.onboarding-panel h1 {
+  font-size: 1.55rem;
+  line-height: 1.15;
+  letter-spacing: -0.015em;
+}
+
+.onboarding-panel > div > p {
+  margin-top: 0.45rem;
+  max-width: 48ch;
+  color: #5f6b64;
+  line-height: 1.5;
+}
+
+.onboarding-steps {
+  display: flex;
+  gap: 1.1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: #6b746f;
+  font-size: 0.78rem;
+  font-weight: 680;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.onboarding-step {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.onboarding-step-dot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: 1px solid #d5ddd2;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #6b746f;
+  font-size: 0.7rem;
+}
+
+.onboarding-step.active {
+  color: #17201d;
+}
+
+.onboarding-step.active .onboarding-step-dot {
+  border-color: #245a52;
+  background: #245a52;
+  color: #ffffff;
+}
+
+.onboarding-step.done {
+  color: #1f7a49;
+}
+
+.onboarding-step.done .onboarding-step-dot {
+  border-color: #bfdccb;
+  background: #e4f2ea;
+  color: #1f7a49;
+}
+
+.onboarding-form {
+  display: grid;
+  gap: 0.75rem;
+  width: min(100%, 380px);
+}
+
+.onboarding-form input {
+  padding: 0.7rem 0.8rem;
+  font-size: 1.05rem;
+}
+
+.command-hero {
+  display: grid;
+  gap: 0.7rem;
+  width: 100%;
+  border: 1px solid #c8d8d1;
+  border-radius: 12px;
+  background: #17201d;
+  padding: 1rem;
+}
+
+.command-hero code {
+  overflow: visible;
+  background: transparent;
+  padding: 0;
+  color: #d9e5de;
+  font-size: 0.86rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  text-overflow: clip;
+}
+
+.command-hero .secondary-button {
+  justify-self: start;
+}
+
+.command-hero .secondary-button.copied {
+  border-color: #bfdccb;
+  color: #1f7a49;
+}
+
+.waiting-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  border: 1px dashed #c8d8d1;
+  border-radius: 10px;
+  padding: 0.85rem;
+  color: #49534e;
+  font-size: 0.88rem;
+}
+
+.waiting-dot {
+  flex: 0 0 auto;
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: #2f8f6b;
+  animation: pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(47, 143, 107, 0.35);
+  }
+  50% {
+    box-shadow: 0 0 0 6px rgba(47, 143, 107, 0);
+  }
+}
+
+.onboarding-approve {
+  display: grid;
+  gap: 0.7rem;
+  width: 100%;
+  border: 1px solid #ecd7a2;
+  border-radius: 11px;
+  background: #fffdf5;
+  padding: 0.9rem;
+}
+
+.onboarding-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.panel-icon.success {
+  background: #1f7a49;
+}
+
+.mesh-ip {
+  font-size: 0.95rem;
+}
+
+.rise {
+  animation: rise 0.35s ease-out both;
+}
+
+@keyframes rise {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rise,
+  .waiting-dot {
+    animation: none;
+  }
+}
+
+.skip-guide {
+  justify-self: center;
+  color: #6b746f;
+}
+
+.invite-row {
+  flex-wrap: wrap;
+}
+
+.invite-description-editor {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 38px;
+  gap: 0.5rem;
+  flex: 1 1 100%;
+  margin-top: 0.25rem;
+  border-top: 1px solid #edf0ec;
+  padding-top: 0.55rem;
+}
+
+.invite-id {
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
Closes #217

## What

The dashboard now walks a new owner from zero to a connected device instead of presenting empty utility panels:

1. **Create your first network** — centered hero with just a name field (CIDR behind "Advanced options"), replacing the sidebar-buried form + "No networks" empty state.
2. **Add your first device** — one click creates an invite and puts the full `curl … | bash -s -- up '<invite>'` command front and center in a dark command hero with a copy button, above a live "waiting for a device…" status (driven by the existing 10s topology refresh).
3. **Approve** — the join request surfaces inline in the guide the moment it arrives, with the approve button right there.
4. **Success** — "\<hostname\> is on the mesh at 10.200.x.x", with "Add another device" / "Go to the dashboard".

A "Skip the guided setup" link is always available; completion persists per network, and networks that ever had nodes never re-enter the guide.

**Invite model rework** (per #217): invites are referenced by short record ID and created without a label. An optional *description* can be added afterward from the invite row (pencil → inline editor; stored in the record's existing `label` field, so CLI-created invites and the schema are untouched). The invite description no longer pre-names joined machines — a node is named by its self-reported hostname and renamed on the node card ("Device name") after it connects.

## Review hardening

A multi-agent adversarial review of the diff confirmed 8 findings, all fixed in the second commit — most notably: **the description editor now re-reads the invite record before rewriting it**, because writing `usedBy` from a stale topology snapshot could have reset a consumed single-use invite to unused (re-arming it for anyone holding the URL, with the anchor daemon auto-approving). A regression test pins the fresh-read behavior. Also fixed: established networks flashing/sticking on the guide while topology loads, pending requests hidden after a mid-wait reload (command is rebuilt from the newest active invite), double-approve races, screen-reader announcement of request arrival, editor focus restoration, and a 320px overflow.

## Preview

Click through the real build (production untouched): **https://preview-onboarding.meshd-admin.pages.dev**

Dev-only fixture harness for the onboarding states: `bun run dev` → `/?preview` (excluded from production bundles).

## Testing

- `bunx vitest run` — 45 tests pass (including new: fresh-read description update, revoked-invite refusal, inverted invite-label-carry)
- `bunx tsc --noEmit` — clean; `bun run build` — clean
- Visual verification of all five onboarding states via the preview harness (screenshots reviewed at desktop width; steps wrap at 320px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)