### PR TITLE
feat(admin): unify brand with meshd.sh

### DIFF
--- a/admin-dapp/index.html
+++ b/admin-dapp/index.html
@@ -3,8 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#101820" />
+    <meta name="theme-color" content="#12101a" />
     <title>meshd Admin</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,600;12..96,800&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/admin-dapp/public/favicon.svg
+++ b/admin-dapp/public/favicon.svg
@@ -1,7 +1,15 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="meshd">
-  <rect width="64" height="64" rx="14" fill="#17201d"/>
-  <circle cx="20" cy="22" r="7" fill="#8fd7c5"/>
-  <circle cx="44" cy="22" r="7" fill="#f1c46b"/>
-  <circle cx="32" cy="44" r="7" fill="#d46a6a"/>
-  <path d="M26 23h12M23 28l6 10M41 28l-6 10" fill="none" stroke="#f7faf5" stroke-width="4" stroke-linecap="round"/>
+  <rect width="64" height="64" rx="14" fill="#12101a"/>
+  <g fill="none" stroke="#4ddac8" stroke-width="2.4" stroke-linecap="round" stroke-opacity="0.45">
+    <path d="M32 33 32 16M32 33 48.2 27.7M32 33 42 46.8M32 33 22 46.8M32 33 15.8 27.7"/>
+    <path d="M32 16 48.2 27.7 42 46.8 22 46.8 15.8 27.7Z"/>
+  </g>
+  <g fill="#4ddac8">
+    <circle cx="32" cy="16" r="4.4"/>
+    <circle cx="48.2" cy="27.7" r="4.4"/>
+    <circle cx="42" cy="46.8" r="4.4"/>
+    <circle cx="22" cy="46.8" r="4.4"/>
+    <circle cx="15.8" cy="27.7" r="4.4"/>
+  </g>
+  <circle cx="32" cy="33" r="5.2" fill="#ff9f6b"/>
 </svg>

--- a/admin-dapp/src/App.tsx
+++ b/admin-dapp/src/App.tsx
@@ -113,7 +113,7 @@ export function App() {
     <div className="app-shell">
       <header className="topbar">
         <button className="brand" type="button" aria-label="meshd Admin">
-          <span className="brand-mark"><NetworkIcon size={20} /></span>
+          <span className="brand-mark"><img src="/favicon.svg" alt="" width={38} height={38} /></span>
           <span className="brand-copy">
             <span>meshd</span>
             <small>Admin</small>

--- a/admin-dapp/src/onboarding.tsx
+++ b/admin-dapp/src/onboarding.tsx
@@ -171,7 +171,10 @@ export function CommandHero({ command, onCopy }: { command: string; onCopy: (com
 
   return (
     <div className="command-hero">
-      <code>{command}</code>
+      <div className="command-hero-line">
+        <span className="command-hero-prompt" aria-hidden="true">$</span>
+        <code>{command}</code>
+      </div>
       <button
         className={`secondary-button ${copied ? "copied" : ""}`}
         type="button"

--- a/admin-dapp/src/styles.css
+++ b/admin-dapp/src/styles.css
@@ -96,14 +96,14 @@ code {
 .panel-icon {
   width: 44px;
   height: 44px;
-  background: #245a52;
+  background: #0e7569;
 }
 
 .row-icon {
   width: 32px;
   height: 32px;
-  background: #e1efe9;
-  color: #245a52;
+  background: #def0ec;
+  color: #0e7569;
 }
 
 .brand-copy {
@@ -265,7 +265,7 @@ p {
   height: 20px;
   padding: 0 0.4rem;
   border-radius: 999px;
-  background: #e2a53c;
+  background: #ee8a4e;
   color: #fffdf7;
   font-size: 0.72rem;
   font-weight: 720;
@@ -293,8 +293,8 @@ p {
 
 .network-row:hover,
 .network-row.active {
-  border-color: #c8d8d1;
-  background: #eef6f2;
+  border-color: #c2ded8;
+  background: #ecf7f5;
 }
 
 .network-row span,
@@ -348,8 +348,8 @@ select {
 
 input:focus,
 select:focus {
-  border-color: #4c8f7e;
-  outline: 3px solid rgba(76, 143, 126, 0.16);
+  border-color: #2aa392;
+  outline: 3px solid rgba(42, 163, 146, 0.18);
 }
 
 .network-header {
@@ -383,7 +383,7 @@ select:focus {
 }
 
 .primary-button {
-  background: #245a52;
+  background: #0e7569;
   color: #ffffff;
   padding: 0.58rem 0.9rem;
 }
@@ -472,9 +472,9 @@ select:focus {
 .invite-composer {
   display: grid;
   gap: 0.7rem;
-  border: 1px solid #cfe0d8;
+  border: 1px solid #cbe3dd;
   border-radius: 11px;
-  background: #f4faf7;
+  background: #f2faf8;
   padding: 1rem;
   min-width: 0;
 }
@@ -504,7 +504,7 @@ select:focus {
 .toggle-field input {
   width: 17px;
   height: 17px;
-  accent-color: #245a52;
+  accent-color: #0e7569;
 }
 
 .data-row {
@@ -660,9 +660,9 @@ dd {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  border: 1px solid #c8d8d1;
+  border: 1px solid #c2ded8;
   border-radius: 10px;
-  background: #eef6f2;
+  background: #ecf7f5;
   padding: 0.8rem;
   min-width: 0;
 }
@@ -857,8 +857,8 @@ dd {
 }
 
 .onboarding-step.active .onboarding-step-dot {
-  border-color: #245a52;
-  background: #245a52;
+  border-color: #0e7569;
+  background: #0e7569;
   color: #ffffff;
 }
 
@@ -887,9 +887,9 @@ dd {
   display: grid;
   gap: 0.7rem;
   width: 100%;
-  border: 1px solid #c8d8d1;
+  border: 1px solid #c2ded8;
   border-radius: 12px;
-  background: #17201d;
+  background: #12101a;
   padding: 1rem;
 }
 
@@ -897,7 +897,7 @@ dd {
   overflow: visible;
   background: transparent;
   padding: 0;
-  color: #d9e5de;
+  color: #e9e7f2;
   font-size: 0.86rem;
   line-height: 1.55;
   white-space: pre-wrap;
@@ -919,7 +919,7 @@ dd {
   align-items: center;
   gap: 0.6rem;
   width: 100%;
-  border: 1px dashed #c8d8d1;
+  border: 1px dashed #c2ded8;
   border-radius: 10px;
   padding: 0.85rem;
   color: #49534e;
@@ -931,17 +931,17 @@ dd {
   width: 9px;
   height: 9px;
   border-radius: 999px;
-  background: #2f8f6b;
+  background: #17a08d;
   animation: pulse 1.6s ease-in-out infinite;
 }
 
 @keyframes pulse {
   0%,
   100% {
-    box-shadow: 0 0 0 0 rgba(47, 143, 107, 0.35);
+    box-shadow: 0 0 0 0 rgba(23, 160, 141, 0.35);
   }
   50% {
-    box-shadow: 0 0 0 6px rgba(47, 143, 107, 0);
+    box-shadow: 0 0 0 6px rgba(23, 160, 141, 0);
   }
 }
 
@@ -1012,4 +1012,34 @@ dd {
 
 .invite-id {
   font-variant-numeric: tabular-nums;
+}
+
+/* ── Shared brand (meshd.sh cohesion) ──────────────────────────────────── */
+
+h1,
+.brand-copy span {
+  font-family: "Bricolage Grotesque", Inter, ui-sans-serif, system-ui, sans-serif;
+}
+
+.brand-mark {
+  background: transparent;
+}
+
+.brand-mark img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+}
+
+.command-hero-line {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+}
+
+.command-hero-prompt {
+  color: #ff9f6b;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-weight: 600;
 }

--- a/admin-dapp/vite.config.ts
+++ b/admin-dapp/vite.config.ts
@@ -31,8 +31,8 @@ export default defineConfig({
         name: "meshd Admin",
         short_name: "meshd",
         description: "Dashboard for managing meshd WireGuard networks over DWN",
-        theme_color: "#101820",
-        background_color: "#101820"
+        theme_color: "#12101a",
+        background_color: "#12101a"
       },
 
       injectManifest: {


### PR DESCRIPTION
Closes #220

## What

The dashboard and meshd.sh now carry one identity:

- **Shared mark** — night tile, teal mesh pentagon, coral hub — is the dashboard's favicon + PWA icon source (`public/favicon.svg`, icons regenerate at build) and the topbar brand chip. meshd.sh ships the identical SVG (deployed earlier today).
- **Accent family** — the dashboard's moss greens (`#245a52` et al.) shift to the matching deep teal (`#0e7569`/`#2aa392` + tints); the pending-count badge goes from amber to brand coral; success/danger semantics unchanged. The light paper workspace stays — light tool, dark marketing, one brand.
- **Type bridge** — Bricolage Grotesque (the site's display face) on `h1`s and the wordmark.
- **Terminal echo** — the onboarding command hero sits on the same night surface as the site's terminal block, coral `$` prompt included. PWA `theme_color` matches.

## Preview

https://preview-onboarding.meshd-admin.pages.dev (updated to this branch)

## Testing

- `bunx tsc --noEmit` clean, `bunx vitest run` 45 tests pass, `bun run build` clean
- Visual pass over the connect panel and all onboarding states via the dev preview harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)