### PR TITLE
fix: enable macOS tray during curl onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,13 @@ curl -fsSL https://meshd.sh/install | bash -s -- up 'meshd://invite/eyJ...'
 # encrypted WireGuard tunnels. NAT traversal is automatic.
 ```
 
-The admin dashboard's invite composer copies that one-liner for you. If meshd
-is already installed, `meshd up 'meshd://invite/...'` does the same join —
-submit, wait for approval, connect. `--wait-timeout <dur>` bounds the wait
-(default 15m) and `--no-wait` restores the old submit-and-exit behavior.
+The admin dashboard's invite composer copies that one-liner for you. On a
+first macOS install it also enables the menu-bar app at login after the invite
+flow completes; the invite is never passed to or stored by the tray or its
+LaunchAgent. If meshd is already installed,
+`meshd up 'meshd://invite/...'` does the same join — submit, wait for approval,
+connect. `--wait-timeout <dur>` bounds the wait (default 15m) and `--no-wait`
+restores the old submit-and-exit behavior.
 
 ### Menu-bar companion
 
@@ -53,12 +56,14 @@ daemon's connected state in the tray icon and provides Connect, Disconnect,
 Open Dashboard, Copy Mesh IP, and a live peer list; selecting a peer copies its
 mesh IP. Linux tray packaging is deferred for the first release.
 
-For password-encrypted profiles, opt in to OS credential storage once from a
-terminal, then enable the tray at login:
+The curl installer enables the tray at login automatically on the first macOS
+install. Windows users, and macOS users who need to restore a removed login
+item, can enable it explicitly. For password-encrypted profiles, opt in to OS
+credential storage once from a terminal:
 
 ```bash
 meshd vault remember       # macOS Keychain / Windows Credential Manager
-meshd-tray install         # LaunchAgent / per-user Startup shortcut
+meshd-tray install         # Explicit LaunchAgent / Startup shortcut setup
 ```
 
 Use `meshd vault forget` to remove the saved credential. On macOS, Connect

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,7 @@ TRAY_APP_DIR="${HOME}/.${APP}/meshd-tray.app"
 TRAY_APP_BACKUP="${TRAY_APP_DIR}.previous"
 TRAY_SWAP_ACTIVE=false
 TRAY_LAUNCH_AGENT_LABEL='org.enbox.meshd-tray'
+TRAY_AUTOSTART_MARKER="${HOME}/.${APP}/.tray-autostart-initialized"
 LAUNCHCTL="${MESHD_INSTALL_LAUNCHCTL:-/bin/launchctl}"
 MESHD_WINDOWS_RESTART=false
 REQUESTED_VERSION="${VERSION:-}"
@@ -41,7 +42,8 @@ Options:
 
 Everything after 'up' is passed to 'meshd up', so one command can install
 meshd, request to join a network, wait for dashboard approval, and start
-the mesh.
+the mesh. On the first macOS install, the menu-bar app is also enabled at
+login after setup completes.
 
 Examples:
   curl -fsSL https://meshd.sh/install | bash
@@ -53,6 +55,26 @@ EOF
 fail() {
   printf 'error: %s\n' "$*" >&2
   exit 1
+}
+
+print_shell_command() {
+  local arg
+  printf '  '
+  for arg in "$@"; do
+    printf '%q ' "$arg"
+  done
+  printf '\n'
+}
+
+profile_arg_from() {
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = '--profile' ] && [ "$#" -gt 1 ]; then
+      printf '%s' "$2"
+      return 0
+    fi
+    shift
+  done
+  return 0
 }
 
 has_command() {
@@ -262,6 +284,39 @@ install_macos_tray() {
   restart_macos_tray_if_loaded
 }
 
+enable_macos_tray_at_login() {
+  local tray="${INSTALL_DIR}/meshd-tray"
+  local profile="${1:-}"
+  local tray_args=(install)
+  if [ -n "$profile" ]; then
+    tray_args+=(--profile "$profile")
+  fi
+
+  printf '\n==> Enabling meshd-tray at login\n'
+  if "$tray" "${tray_args[@]}"; then
+    if ! (
+      umask 077
+      printf 'initialized\n' > "${TRAY_AUTOSTART_MARKER}.new" &&
+        mv -f "${TRAY_AUTOSTART_MARKER}.new" "$TRAY_AUTOSTART_MARKER"
+    ); then
+      printf 'warning: could not record meshd-tray login setup; a later installer run may retry it\n' >&2
+      rm -f "${TRAY_AUTOSTART_MARKER}.new" || true
+    fi
+    return
+  fi
+
+  # launchctl requires an interactive Aqua session. A headless/SSH install
+  # must still be allowed to finish the invite flow; leave an actionable retry
+  # without retaining the invite in a LaunchAgent argument or environment.
+  printf 'warning: meshd-tray could not be enabled at login; retry with:\n' >&2
+  if [ -n "$profile" ]; then
+    print_shell_command "$tray" install --profile "$profile" >&2
+  else
+    print_shell_command "$tray" install >&2
+  fi
+  return 0
+}
+
 windows_native_path() {
   if has_command cygpath; then
     cygpath -w "$1"
@@ -384,7 +439,8 @@ restart_windows_meshd_after_upgrade() {
 # password and sudo prompts working.
 run_meshd_up() {
   local bin="$1"
-  shift
+  local profile="$2"
+  shift 2
 
   # ${1+"$@"} instead of bare "$@": bash <= 4.3 (macOS ships 3.2) treats an
   # empty "$@" as unbound under set -u.
@@ -397,13 +453,14 @@ run_meshd_up() {
   fi
 
   if [ "$code" -ne 0 ]; then
-    local resume_args=''
-    if [ "$#" -gt 0 ]; then
-      resume_args=" $*"
+    printf '\nmeshd up did not complete. Re-run the original command to retry.\n' >&2
+    printf 'If its join request is already pending, resume without repeating the invite:\n' >&2
+    if [ -n "$profile" ]; then
+      print_shell_command "$bin" up --profile "$profile" >&2
+    else
+      print_shell_command "$bin" up >&2
     fi
-    printf '\nmeshd up did not complete. Any join request stays pending; resume with:\n' >&2
-    printf '  %s up%s\n' "$bin" "$resume_args" >&2
-    exit "$code"
+    return "$code"
   fi
 }
 
@@ -482,7 +539,16 @@ main() {
   mv -f "${INSTALL_DIR}/meshd${suffix}.new" "${INSTALL_DIR}/meshd${suffix}"
 
   local tray_installed=false
+  local macos_tray_needs_autostart=false
+  local up_profile
+  up_profile="$(profile_arg_from ${RUN_UP_ARGS[@]+"${RUN_UP_ARGS[@]}"})"
   if [ "$os" = 'darwin' ] && [ -d "${TMP_DIR}/meshd-tray.app" ]; then
+    # Installer-owned one-time state lets existing tray users receive this
+    # behavior once, while a later explicit tray uninstall remains respected
+    # across upgrades.
+    if [ ! -e "$TRAY_AUTOSTART_MARKER" ]; then
+      macos_tray_needs_autostart=true
+    fi
     install_macos_tray "${TMP_DIR}/meshd-tray.app"
     tray_installed=true
   elif [ "$os" = 'windows' ] && [ -f "${TMP_DIR}/meshd-tray.exe" ]; then
@@ -501,7 +567,7 @@ main() {
   printf '==> Installed to %s\n' "$INSTALL_DIR"
   "${INSTALL_DIR}/meshd${suffix}" --version || true
 
-  if [ "$tray_installed" = true ]; then
+  if [ "$tray_installed" = true ] && [ "$os" != 'darwin' ]; then
     printf 'Enable the menu-bar app at login with: meshd-tray install\n'
   fi
 
@@ -510,8 +576,19 @@ main() {
     # scratch dir before handing off.
     cleanup
     TMP_DIR=''
-    run_meshd_up "${INSTALL_DIR}/meshd${suffix}" ${RUN_UP_ARGS[@]+"${RUN_UP_ARGS[@]}"}
+    local up_code=0
+    run_meshd_up "${INSTALL_DIR}/meshd${suffix}" "$up_profile" ${RUN_UP_ARGS[@]+"${RUN_UP_ARGS[@]}"} || up_code=$?
+    if [ "$macos_tray_needs_autostart" = true ]; then
+      enable_macos_tray_at_login "$up_profile"
+    fi
+    if [ "$up_code" -ne 0 ]; then
+      exit "$up_code"
+    fi
     return
+  fi
+
+  if [ "$macos_tray_needs_autostart" = true ]; then
+    enable_macos_tray_at_login "$up_profile"
   fi
 
   printf 'Run: meshd up\n'

--- a/scripts/e2e/install-tray.test.sh
+++ b/scripts/e2e/install-tray.test.sh
@@ -41,12 +41,18 @@ cat > "${PAYLOAD}/meshd" <<'FAKE'
 #!/usr/bin/env bash
 if [ "${1:-}" = '--version' ]; then
   echo 'meshd 9.9.9'
+  exit 0
 fi
+printf 'meshd-up\n' >> "${MESHD_TEST_EVENT_LOG:?}"
+printf '%s\n' "$@" > "${MESHD_TEST_MESHD_ARGV_LOG:?}"
+exit "${MESHD_TEST_MESHD_EXIT:-0}"
 FAKE
 cat > "${PAYLOAD}/meshd-tray.app/Contents/MacOS/meshd-tray" <<'FAKE'
 #!/usr/bin/env bash
 # tray fixture: first
-exit 0
+printf 'tray-install\n' >> "${MESHD_TEST_EVENT_LOG:?}"
+printf '%s\n' "$@" >> "${MESHD_TEST_TRAY_ARGV_LOG:?}"
+exit "${MESHD_TEST_TRAY_EXIT:-0}"
 FAKE
 printf '<plist><dict><key>LSUIElement</key><true/></dict></plist>\n' > "${PAYLOAD}/meshd-tray.app/Contents/Info.plist"
 chmod +x "${PAYLOAD}/meshd" "${PAYLOAD}/meshd-tray.app/Contents/MacOS/meshd-tray"
@@ -54,6 +60,9 @@ tar -czf "${DIST}/meshd-darwin-arm64.tar.gz" -C "$PAYLOAD" meshd meshd-tray.app
 
 HOME_DIR="${WORK}/home"
 LAUNCHCTL_LOG="${WORK}/launchctl.log"
+EVENT_LOG="${WORK}/events.log"
+MESHD_ARGV_LOG="${WORK}/meshd-argv.log"
+TRAY_ARGV_LOG="${WORK}/tray-argv.log"
 mkdir -p "$HOME_DIR"
 output="$(
   HOME="$HOME_DIR" \
@@ -62,7 +71,10 @@ output="$(
   MESHD_INSTALL_DOWNLOAD_BASE="file://${WORK}/dist" \
   MESHD_INSTALL_LAUNCHCTL="${FAKE_BIN}/launchctl" \
   MESHD_TEST_LAUNCHCTL_LOG="$LAUNCHCTL_LOG" \
-    bash "$INSTALL" --no-modify-path
+  MESHD_TEST_EVENT_LOG="$EVENT_LOG" \
+  MESHD_TEST_MESHD_ARGV_LOG="$MESHD_ARGV_LOG" \
+  MESHD_TEST_TRAY_ARGV_LOG="$TRAY_ARGV_LOG" \
+    bash "$INSTALL" --no-modify-path up 'meshd://invite/test-token' --profile work
 )"
 
 test -x "${HOME_DIR}/.meshd/bin/meshd"
@@ -72,7 +84,11 @@ test -L "${HOME_DIR}/.meshd/bin/meshd-tray"
 test "$(readlink "${HOME_DIR}/.meshd/bin/meshd-tray")" = "${HOME_DIR}/.meshd/meshd-tray.app/Contents/MacOS/meshd-tray"
 grep -q 'tray fixture: first' "${HOME_DIR}/.meshd/meshd-tray.app/Contents/MacOS/meshd-tray"
 grep -q '^kickstart -k gui/[0-9][0-9]*/org.enbox.meshd-tray$' "$LAUNCHCTL_LOG"
-grep -q 'meshd-tray install' <<<"$output"
+test "$(cat "$MESHD_ARGV_LOG")" = "$(printf 'up\nmeshd://invite/test-token\n--profile\nwork')"
+test "$(cat "$TRAY_ARGV_LOG")" = "$(printf 'install\n--profile\nwork')"
+test "$(cat "$EVENT_LOG")" = "$(printf 'meshd-up\ntray-install')"
+test -f "${HOME_DIR}/.meshd/.tray-autostart-initialized"
+grep -q 'Enabling meshd-tray at login' <<<"$output"
 
 # Reinstall over an existing app and verify the two-rename swap leaves the new
 # bundle live, removes its rollback copy, and restarts the loaded LaunchAgent.
@@ -84,10 +100,103 @@ VERSION="$VERSION_TAG" \
 MESHD_INSTALL_DOWNLOAD_BASE="file://${WORK}/dist" \
 MESHD_INSTALL_LAUNCHCTL="${FAKE_BIN}/launchctl" \
 MESHD_TEST_LAUNCHCTL_LOG="$LAUNCHCTL_LOG" \
+MESHD_TEST_EVENT_LOG="$EVENT_LOG" \
+MESHD_TEST_MESHD_ARGV_LOG="$MESHD_ARGV_LOG" \
+MESHD_TEST_TRAY_ARGV_LOG="$TRAY_ARGV_LOG" \
   bash "$INSTALL" --no-modify-path >/dev/null
 
 grep -q 'tray fixture: second' "${HOME_DIR}/.meshd/meshd-tray.app/Contents/MacOS/meshd-tray"
 test ! -e "${HOME_DIR}/.meshd/meshd-tray.app.previous"
 test "$(grep -c '^kickstart -k gui/[0-9][0-9]*/org.enbox.meshd-tray$' "$LAUNCHCTL_LOG")" -eq 2
+test "$(cat "$TRAY_ARGV_LOG")" = "$(printf 'install\n--profile\nwork')"
+
+# A plain first install also enables the tray without running meshd up.
+PLAIN_HOME="${WORK}/plain-home"
+PLAIN_EVENT_LOG="${WORK}/plain-events.log"
+PLAIN_MESHD_ARGV_LOG="${WORK}/plain-meshd-argv.log"
+PLAIN_TRAY_ARGV_LOG="${WORK}/plain-tray-argv.log"
+mkdir -p "$PLAIN_HOME"
+plain_output="$(
+  HOME="$PLAIN_HOME" \
+  PATH="${FAKE_BIN}:$PATH" \
+  VERSION="$VERSION_TAG" \
+  MESHD_INSTALL_DOWNLOAD_BASE="file://${WORK}/dist" \
+  MESHD_INSTALL_LAUNCHCTL="${FAKE_BIN}/launchctl" \
+  MESHD_TEST_LAUNCHCTL_LOG="$LAUNCHCTL_LOG" \
+  MESHD_TEST_EVENT_LOG="$PLAIN_EVENT_LOG" \
+  MESHD_TEST_MESHD_ARGV_LOG="$PLAIN_MESHD_ARGV_LOG" \
+  MESHD_TEST_TRAY_ARGV_LOG="$PLAIN_TRAY_ARGV_LOG" \
+    bash "$INSTALL" --no-modify-path
+)"
+test ! -e "$PLAIN_MESHD_ARGV_LOG"
+test "$(cat "$PLAIN_TRAY_ARGV_LOG")" = 'install'
+test "$(cat "$PLAIN_EVENT_LOG")" = 'tray-install'
+test -f "${PLAIN_HOME}/.meshd/.tray-autostart-initialized"
+grep -q 'Run: meshd up' <<<"$plain_output"
+
+# Headless tray registration is optional: a successful invite remains
+# successful, emits an absolute retry command, and can be retried later.
+WARN_HOME="${WORK}/warn home"
+WARN_EVENT_LOG="${WORK}/warn-events.log"
+WARN_MESHD_ARGV_LOG="${WORK}/warn-meshd-argv.log"
+WARN_TRAY_ARGV_LOG="${WORK}/warn-tray-argv.log"
+WARN_STDERR="${WORK}/warn-stderr.log"
+mkdir -p "$WARN_HOME"
+HOME="$WARN_HOME" \
+PATH="${FAKE_BIN}:$PATH" \
+VERSION="$VERSION_TAG" \
+MESHD_INSTALL_DOWNLOAD_BASE="file://${WORK}/dist" \
+MESHD_INSTALL_LAUNCHCTL="${FAKE_BIN}/launchctl" \
+MESHD_TEST_LAUNCHCTL_LOG="$LAUNCHCTL_LOG" \
+MESHD_TEST_EVENT_LOG="$WARN_EVENT_LOG" \
+MESHD_TEST_MESHD_ARGV_LOG="$WARN_MESHD_ARGV_LOG" \
+MESHD_TEST_TRAY_ARGV_LOG="$WARN_TRAY_ARGV_LOG" \
+MESHD_TEST_TRAY_EXIT=9 \
+  bash "$INSTALL" --no-modify-path up 'meshd://invite/warn-token' --profile work \
+    >/dev/null 2>"$WARN_STDERR"
+
+test "$(cat "$WARN_MESHD_ARGV_LOG")" = "$(printf 'up\nmeshd://invite/warn-token\n--profile\nwork')"
+test "$(cat "$WARN_TRAY_ARGV_LOG")" = "$(printf 'install\n--profile\nwork')"
+test "$(cat "$WARN_EVENT_LOG")" = "$(printf 'meshd-up\ntray-install')"
+test ! -e "${WARN_HOME}/.meshd/.tray-autostart-initialized"
+warn_retry="$(printf '%q ' "${WARN_HOME}/.meshd/bin/meshd-tray" install --profile work)"
+grep -Fq "  $warn_retry" "$WARN_STDERR"
+! grep -q 'warn-token' "$WARN_STDERR"
+
+# A failed invite and a failed headless LaunchAgent registration preserve the
+# meshd up exit code, still attempt tray setup afterward, and leave the marker
+# absent so a later interactive install can retry.
+FAIL_HOME="${WORK}/fail home"
+FAIL_EVENT_LOG="${WORK}/fail-events.log"
+FAIL_MESHD_ARGV_LOG="${WORK}/fail-meshd-argv.log"
+FAIL_TRAY_ARGV_LOG="${WORK}/fail-tray-argv.log"
+FAIL_STDERR="${WORK}/fail-stderr.log"
+mkdir -p "$FAIL_HOME"
+rc=0
+HOME="$FAIL_HOME" \
+PATH="${FAKE_BIN}:$PATH" \
+VERSION="$VERSION_TAG" \
+MESHD_INSTALL_DOWNLOAD_BASE="file://${WORK}/dist" \
+MESHD_INSTALL_LAUNCHCTL="${FAKE_BIN}/launchctl" \
+MESHD_TEST_LAUNCHCTL_LOG="$LAUNCHCTL_LOG" \
+MESHD_TEST_EVENT_LOG="$FAIL_EVENT_LOG" \
+MESHD_TEST_MESHD_ARGV_LOG="$FAIL_MESHD_ARGV_LOG" \
+MESHD_TEST_TRAY_ARGV_LOG="$FAIL_TRAY_ARGV_LOG" \
+MESHD_TEST_MESHD_EXIT=7 \
+MESHD_TEST_TRAY_EXIT=9 \
+  bash "$INSTALL" --no-modify-path up 'meshd://invite/failure-token' --profile work \
+    >/dev/null 2>"$FAIL_STDERR" || rc=$?
+
+test "$rc" -eq 7
+test "$(cat "$FAIL_MESHD_ARGV_LOG")" = "$(printf 'up\nmeshd://invite/failure-token\n--profile\nwork')"
+test "$(cat "$FAIL_TRAY_ARGV_LOG")" = "$(printf 'install\n--profile\nwork')"
+test "$(cat "$FAIL_EVENT_LOG")" = "$(printf 'meshd-up\ntray-install')"
+test ! -e "${FAIL_HOME}/.meshd/.tray-autostart-initialized"
+grep -q 'meshd-tray could not be enabled at login' "$FAIL_STDERR"
+fail_up_retry="$(printf '%q ' "${FAIL_HOME}/.meshd/bin/meshd" up --profile work)"
+fail_tray_retry="$(printf '%q ' "${FAIL_HOME}/.meshd/bin/meshd-tray" install --profile work)"
+grep -Fq "  $fail_up_retry" "$FAIL_STDERR"
+grep -Fq "  $fail_tray_retry" "$FAIL_STDERR"
+! grep -q 'failure-token' "$FAIL_STDERR"
 
 echo 'tray artifact install test passed'

--- a/scripts/e2e/install-up.test.sh
+++ b/scripts/e2e/install-up.test.sh
@@ -83,17 +83,18 @@ expected="$(printf 'up\nmeshd://invite/test-token\n--no-tun\n--wait-timeout\n1h\
 [ "$(cat "${home2}/argv.txt")" = "$expected" ] || rc=1
 check "up passthrough forwards args verbatim" "$rc"
 
-# 3. Exit codes from meshd up propagate, with a resume hint on stderr that
-# keeps the original arguments (a resume without the invite dead-ends when
-# the join request was never submitted).
+# 3. Exit codes from meshd up propagate, with a resume hint that never repeats
+# the bearer invite into terminal or CI logs.
 home3="${WORK}/home3"; mkdir -p "$home3"
 rc=0
 stderr3="${WORK}/stderr3.txt"
-MESHD_FAKE_EXIT=7 run_install "$home3" up 'meshd://invite/x' >/dev/null 2>"$stderr3" || rc=$?
+MESHD_FAKE_EXIT=7 run_install "$home3" up 'meshd://invite/x' --profile work >/dev/null 2>"$stderr3" || rc=$?
 check "meshd up exit code propagates" "$([ "$rc" -eq 7 ]; echo $?)"
 rc=0
-grep -q "resume with" "$stderr3" && grep -q "up meshd://invite/x" "$stderr3" || rc=1
-check "failure prints a resume hint with the original args" "$rc"
+grep -q "resume without repeating the invite" "$stderr3" || rc=1
+grep -q -- "--profile work" "$stderr3" || rc=1
+! grep -q "meshd://invite/x" "$stderr3" || rc=1
+check "failure prints a redacted resume hint" "$rc"
 
 # 4. Unknown options still fail hard (guards against silently swallowing
 # typos like 'pu' or a bare invite URL).


### PR DESCRIPTION
Summary

- Automatically register the packaged macOS tray after the initial curl setup or admin-provided install-and-join command completes.
- Keep invite validation in meshd up; the tray receives only its profile and never the bearer invite.
- Use one-time installer state so upgrades do not re-enable an explicitly removed login item.
- Keep headless LaunchAgent failures nonfatal, preserve meshd up exit codes, and emit shell-safe redacted recovery commands.
- Document and test plain installs, invite onboarding, named profiles, upgrades, and failure paths.

Validation

- go build ./...
- go vet ./...
- go test ./... -count=1 -race
- bash syntax validation
- installer smoke, invite passthrough, macOS tray, Windows tray, and macOS version mapping tests

Closes #225