### PR TITLE
fix: stabilize tray peer refresh

### DIFF
--- a/cmd/meshd-tray/peer_menu.go
+++ b/cmd/meshd-tray/peer_menu.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/enboxorg/meshd/internal/trayapp"
+)
+
+const maxPeerMenuSlots = 64
+
+// peerMenuEntry is the presentation and click binding for one preallocated
+// native menu item. Key identifies a peer across refreshes so input reordering
+// does not move an existing peer to a different native item.
+type peerMenuEntry struct {
+	Key     string
+	Title   string
+	Tooltip string
+	MeshIP  string
+	Visible bool
+}
+
+type peerMenuPlan struct {
+	Title           string
+	EmptyTitle      string
+	EmptyVisible    bool
+	Slots           []peerMenuEntry
+	OverflowTitle   string
+	OverflowVisible bool
+}
+
+// planPeerMenu maps the current peers onto an already-created set of slots.
+// It never grows that set. Existing keys keep their slot, while new keys take
+// the lowest free slot. peers is already deterministically sorted by Model.View.
+func planPeerMenu(connected bool, peers []trayapp.PeerView, previousKeys []string) peerMenuPlan {
+	plan := peerMenuPlan{
+		Title:        "Peers",
+		EmptyTitle:   "Connect to view peers",
+		EmptyVisible: true,
+		Slots:        make([]peerMenuEntry, len(previousKeys)),
+	}
+	if connected {
+		plan.EmptyTitle = "No peers"
+	}
+	if !connected || len(peers) == 0 || len(previousKeys) == 0 {
+		return plan
+	}
+
+	plan.Title = fmt.Sprintf("Peers (%d)", len(peers))
+	plan.EmptyVisible = false
+
+	visibleCount := min(len(peers), len(previousKeys))
+	visiblePeers := peers[:visibleCount]
+	peerByKey := make(map[string]trayapp.PeerView, visibleCount)
+	peerOrder := make([]string, 0, visibleCount)
+	for _, peer := range visiblePeers {
+		// PeerView.Key is name+IP today. Duplicate status rows are unusual but
+		// still deserve separate menu rows, so disambiguate them deterministically.
+		key := uniquePeerMenuKey(peer.Key, peerByKey)
+		peerByKey[key] = peer
+		peerOrder = append(peerOrder, key)
+	}
+
+	assigned := make(map[string]struct{}, visibleCount)
+	for index, key := range previousKeys {
+		peer, ok := peerByKey[key]
+		if !ok {
+			continue
+		}
+		plan.Slots[index] = peerMenuEntryFor(key, peer)
+		assigned[key] = struct{}{}
+	}
+
+	freeIndex := 0
+	for _, key := range peerOrder {
+		if _, ok := assigned[key]; ok {
+			continue
+		}
+		for freeIndex < len(plan.Slots) && plan.Slots[freeIndex].Visible {
+			freeIndex++
+		}
+		if freeIndex == len(plan.Slots) {
+			break
+		}
+		plan.Slots[freeIndex] = peerMenuEntryFor(key, peerByKey[key])
+		assigned[key] = struct{}{}
+	}
+
+	if overflow := len(peers) - visibleCount; overflow > 0 {
+		plan.OverflowVisible = true
+		plan.OverflowTitle = fmt.Sprintf("%d more peers — open the dashboard to view all", overflow)
+	}
+	return plan
+}
+
+func uniquePeerMenuKey(base string, existing map[string]trayapp.PeerView) string {
+	if _, ok := existing[base]; !ok {
+		return base
+	}
+	for duplicate := 2; ; duplicate++ {
+		key := fmt.Sprintf("%s\x00%d", base, duplicate)
+		if _, ok := existing[key]; !ok {
+			return key
+		}
+	}
+}
+
+func peerMenuEntryFor(key string, peer trayapp.PeerView) peerMenuEntry {
+	return peerMenuEntry{
+		Key:     key,
+		Title:   peer.Title,
+		Tooltip: "Copy " + peer.MeshIP,
+		MeshIP:  peer.MeshIP,
+		Visible: true,
+	}
+}

--- a/cmd/meshd-tray/peer_menu_test.go
+++ b/cmd/meshd-tray/peer_menu_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/enboxorg/meshd/internal/trayapp"
+)
+
+func TestPlanPeerMenuRefreshLifecycle(t *testing.T) {
+	keys := make([]string, 4)
+	a := testPeerView("a", "alpha", "10.200.0.2", true)
+	b := testPeerView("b", "beta", "10.200.0.3", false)
+
+	plan := planPeerMenu(true, []trayapp.PeerView{a, b}, keys)
+	assertPeerMenuSlot(t, plan.Slots[0], a)
+	assertPeerMenuSlot(t, plan.Slots[1], b)
+	keys = peerMenuPlanKeys(plan)
+
+	// Reordering the input preserves each peer's native slot.
+	plan = planPeerMenu(true, []trayapp.PeerView{b, a}, keys)
+	assertPeerMenuSlot(t, plan.Slots[0], a)
+	assertPeerMenuSlot(t, plan.Slots[1], b)
+
+	// An online-state title update changes presentation without changing its key.
+	aOnline := a
+	aOnline.Online = false
+	aOnline.Title = "○ alpha · 10.200.0.2"
+	plan = planPeerMenu(true, []trayapp.PeerView{aOnline, b}, peerMenuPlanKeys(plan))
+	assertPeerMenuSlot(t, plan.Slots[0], aOnline)
+
+	// Rename and IP changes receive new keys but reuse freed fixed slots.
+	aRenamed := testPeerView("a-renamed", "atlas", "10.200.0.2", false)
+	bMoved := testPeerView("b-moved", "beta", "10.200.0.30", false)
+	plan = planPeerMenu(true, []trayapp.PeerView{aRenamed, bMoved}, peerMenuPlanKeys(plan))
+	assertPeerMenuSlot(t, plan.Slots[0], aRenamed)
+	assertPeerMenuSlot(t, plan.Slots[1], bMoved)
+
+	// Dropping a peer clears its slot; a later addition uses that free slot
+	// without growing the native menu or moving the surviving peer.
+	plan = planPeerMenu(true, []trayapp.PeerView{bMoved}, peerMenuPlanKeys(plan))
+	if plan.Slots[0].Visible {
+		t.Fatalf("removed peer slot = %+v, want hidden", plan.Slots[0])
+	}
+	assertPeerMenuSlot(t, plan.Slots[1], bMoved)
+	c := testPeerView("c", "charlie", "10.200.0.4", true)
+	plan = planPeerMenu(true, []trayapp.PeerView{bMoved, c}, peerMenuPlanKeys(plan))
+	assertPeerMenuSlot(t, plan.Slots[0], c)
+	assertPeerMenuSlot(t, plan.Slots[1], bMoved)
+	if got := len(plan.Slots); got != len(keys) {
+		t.Fatalf("slot count grew to %d, want fixed %d", got, len(keys))
+	}
+}
+
+func TestPlanPeerMenuCapAndOverflow(t *testing.T) {
+	peers := make([]trayapp.PeerView, maxPeerMenuSlots+3)
+	for index := range peers {
+		ip := fmt.Sprintf("10.200.1.%d", index+1)
+		peers[index] = testPeerView(fmt.Sprintf("peer-%02d", index), fmt.Sprintf("peer-%02d", index), ip, index%2 == 0)
+	}
+
+	plan := planPeerMenu(true, peers, make([]string, maxPeerMenuSlots))
+	if got, want := plan.Title, fmt.Sprintf("Peers (%d)", len(peers)); got != want {
+		t.Fatalf("title = %q, want %q", got, want)
+	}
+	if got := len(plan.Slots); got != maxPeerMenuSlots {
+		t.Fatalf("slot count = %d, want %d", got, maxPeerMenuSlots)
+	}
+	for index, slot := range plan.Slots {
+		if !slot.Visible {
+			t.Fatalf("slot %d hidden below cap", index)
+		}
+	}
+	if !plan.OverflowVisible || !strings.Contains(plan.OverflowTitle, "3 more peers") || !strings.Contains(plan.OverflowTitle, "dashboard") {
+		t.Fatalf("overflow = visible %t title %q", plan.OverflowVisible, plan.OverflowTitle)
+	}
+
+	// A refresh with a much larger list must keep exactly the initialized pool.
+	morePeers := append(append([]trayapp.PeerView{}, peers...), peers...)
+	plan = planPeerMenu(true, morePeers, peerMenuPlanKeys(plan))
+	if got := len(plan.Slots); got != maxPeerMenuSlots {
+		t.Fatalf("slot count after growth = %d, want %d", got, maxPeerMenuSlots)
+	}
+}
+
+func TestPlanPeerMenuEmptyStates(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		connected  bool
+		emptyTitle string
+	}{
+		{name: "disconnected", emptyTitle: "Connect to view peers"},
+		{name: "connected", connected: true, emptyTitle: "No peers"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := planPeerMenu(tc.connected, nil, make([]string, maxPeerMenuSlots))
+			if plan.Title != "Peers" || !plan.EmptyVisible || plan.EmptyTitle != tc.emptyTitle || plan.OverflowVisible {
+				t.Fatalf("empty plan = %+v", plan)
+			}
+		})
+	}
+}
+
+func TestPlanPeerMenuCurrentIPFollowsKeyedPeer(t *testing.T) {
+	a := testPeerView("a", "alpha", "10.200.0.2", true)
+	b := testPeerView("b", "beta", "10.200.0.3", true)
+	plan := planPeerMenu(true, []trayapp.PeerView{a, b}, make([]string, 2))
+
+	// Input order can change independently of the sorted model; the click IP
+	// remains attached to the peer key already occupying each native slot.
+	plan = planPeerMenu(true, []trayapp.PeerView{b, a}, peerMenuPlanKeys(plan))
+	if got := plan.Slots[0].MeshIP; got != a.MeshIP {
+		t.Fatalf("alpha slot IP = %q, want %q", got, a.MeshIP)
+	}
+	if got := plan.Slots[1].MeshIP; got != b.MeshIP {
+		t.Fatalf("beta slot IP = %q, want %q", got, b.MeshIP)
+	}
+}
+
+func testPeerView(key, name, ip string, online bool) trayapp.PeerView {
+	indicator := "○"
+	if online {
+		indicator = "●"
+	}
+	return trayapp.PeerView{
+		Key:    key,
+		Name:   name,
+		MeshIP: ip,
+		Online: online,
+		Title:  fmt.Sprintf("%s %s · %s", indicator, name, ip),
+	}
+}
+
+func peerMenuPlanKeys(plan peerMenuPlan) []string {
+	keys := make([]string, len(plan.Slots))
+	for index, slot := range plan.Slots {
+		keys[index] = slot.Key
+	}
+	return keys
+}
+
+func assertPeerMenuSlot(t *testing.T, got peerMenuEntry, want trayapp.PeerView) {
+	t.Helper()
+	if !got.Visible || got.Key != want.Key || got.Title != want.Title || got.MeshIP != want.MeshIP || got.Tooltip != "Copy "+want.MeshIP {
+		t.Fatalf("slot = %+v, want peer %+v", got, want)
+	}
+}

--- a/cmd/meshd-tray/tray_supported.go
+++ b/cmd/meshd-tray/tray_supported.go
@@ -36,34 +36,48 @@ type trayUI struct {
 	dashboard  *systray.MenuItem
 	copyIP     *systray.MenuItem
 	peers      *systray.MenuItem
+	peersTitle string
 	connect    *systray.MenuItem
 	disconnect *systray.MenuItem
 	quit       *systray.MenuItem
 
-	peerEmpty       *systray.MenuItem
-	peerItems       []*peerMenuSlot
-	peerSignature   string
-	iconInitialized bool
-	iconConnected   bool
+	peerEmpty         *systray.MenuItem
+	peerEmptyTitle    string
+	peerEmptyShown    bool
+	peerOverflow      *systray.MenuItem
+	peerOverflowTitle string
+	peerOverflowShown bool
+	peerItems         []*peerMenuSlot
+	peerSignature     string
+	iconInitialized   bool
+	iconConnected     bool
 }
 
 type peerMenuSlot struct {
 	item *systray.MenuItem
 
-	mu     sync.RWMutex
-	meshIP string
+	mu    sync.RWMutex
+	entry peerMenuEntry
 }
 
-func (slot *peerMenuSlot) setMeshIP(meshIP string) {
+func (slot *peerMenuSlot) setEntry(entry peerMenuEntry) {
 	slot.mu.Lock()
-	slot.meshIP = meshIP
+	slot.entry = entry
 	slot.mu.Unlock()
 }
 
-func (slot *peerMenuSlot) MeshIP() string {
+func (slot *peerMenuSlot) clear() {
+	slot.setEntry(peerMenuEntry{})
+}
+
+func (slot *peerMenuSlot) Entry() peerMenuEntry {
 	slot.mu.RLock()
 	defer slot.mu.RUnlock()
-	return slot.meshIP
+	return slot.entry
+}
+
+func (slot *peerMenuSlot) MeshIP() string {
+	return slot.Entry().MeshIP
 }
 
 func runTray(profile string) error {
@@ -84,8 +98,12 @@ func (ui *trayUI) onReady() {
 	ui.dashboard = systray.AddMenuItem("Open Dashboard…", "Open the active network in your browser")
 	ui.copyIP = systray.AddMenuItem("Copy Mesh IP", "Copy this device's mesh IP")
 	ui.peers = systray.AddMenuItem("Peers", "Click a peer to copy its mesh IP")
+	ui.peersTitle = "Peers"
 	ui.peerEmpty = ui.peers.AddSubMenuItem("Connect to view peers", "")
 	ui.peerEmpty.Disable()
+	ui.peerEmptyTitle = "Connect to view peers"
+	ui.peerEmptyShown = true
+	ui.initializePeerSlots()
 	systray.AddSeparator()
 	ui.connect = systray.AddMenuItem("Connect", "Start meshd")
 	ui.disconnect = systray.AddMenuItem("Disconnect", "Stop meshd")
@@ -260,47 +278,84 @@ func (ui *trayUI) renderPeers(connected bool, peers []trayapp.PeerView) {
 	}
 	ui.peerSignature = signature
 
-	if len(peers) == 0 {
-		ui.peers.SetTitle("Peers")
-		title := "Connect to view peers"
-		if connected {
-			title = "No peers"
-		}
-		ui.peerEmpty.SetTitle(title)
-		ui.peerEmpty.Show()
-		for _, slot := range ui.peerItems {
-			slot.setMeshIP("")
-			slot.item.Disable()
-			slot.item.Hide()
-		}
-		return
+	previousKeys := make([]string, len(ui.peerItems))
+	for index, slot := range ui.peerItems {
+		previousKeys[index] = slot.Entry().Key
 	}
-	ui.peerEmpty.Hide()
-	ui.peers.SetTitle(fmt.Sprintf("Peers (%d)", len(peers)))
-	ui.ensurePeerSlots(len(peers))
-	for index, peer := range peers {
-		slot := ui.peerItems[index]
-		slot.setMeshIP(peer.MeshIP)
-		slot.item.SetTitle(peer.Title)
-		slot.item.SetTooltip("Copy " + peer.MeshIP)
-		slot.item.Enable()
-		slot.item.Show()
+	plan := planPeerMenu(connected, peers, previousKeys)
+
+	if ui.peersTitle != plan.Title {
+		ui.peers.SetTitle(plan.Title)
+		ui.peersTitle = plan.Title
 	}
-	for _, slot := range ui.peerItems[len(peers):] {
-		slot.setMeshIP("")
-		slot.item.Disable()
-		slot.item.Hide()
+	if ui.peerEmptyTitle != plan.EmptyTitle {
+		ui.peerEmpty.SetTitle(plan.EmptyTitle)
+		ui.peerEmptyTitle = plan.EmptyTitle
+	}
+	if ui.peerEmptyShown != plan.EmptyVisible {
+		setVisible(ui.peerEmpty, plan.EmptyVisible)
+		ui.peerEmptyShown = plan.EmptyVisible
+	}
+	for index, entry := range plan.Slots {
+		ui.renderPeerSlot(ui.peerItems[index], entry)
+	}
+	if ui.peerOverflowTitle != plan.OverflowTitle {
+		ui.peerOverflow.SetTitle(plan.OverflowTitle)
+		ui.peerOverflowTitle = plan.OverflowTitle
+	}
+	if ui.peerOverflowShown != plan.OverflowVisible {
+		setVisible(ui.peerOverflow, plan.OverflowVisible)
+		ui.peerOverflowShown = plan.OverflowVisible
 	}
 }
 
-func (ui *trayUI) ensurePeerSlots(count int) {
-	for len(ui.peerItems) < count {
+func (ui *trayUI) initializePeerSlots() {
+	ui.peerItems = make([]*peerMenuSlot, 0, maxPeerMenuSlots)
+	for range maxPeerMenuSlots {
 		item := ui.peers.AddSubMenuItem("", "")
+		item.Disable()
 		item.Hide()
 		slot := &peerMenuSlot{item: item}
 		ui.peerItems = append(ui.peerItems, slot)
 		ui.startWorker(func() { ui.peerClicks(slot) })
 	}
+	ui.peerOverflow = ui.peers.AddSubMenuItem("", "")
+	ui.peerOverflow.Disable()
+	ui.peerOverflow.Hide()
+}
+
+func (ui *trayUI) renderPeerSlot(slot *peerMenuSlot, next peerMenuEntry) {
+	current := slot.Entry()
+	if !next.Visible {
+		// Clear the click binding before disabling the native item so an event
+		// already in flight can never copy a peer that has just disappeared.
+		slot.clear()
+		setEnabled(slot.item, false)
+		if current.Visible {
+			setVisible(slot.item, false)
+		}
+		return
+	}
+
+	remapped := current.Key != next.Key || current.MeshIP != next.MeshIP
+	if remapped {
+		// Keep an existing native menu item inert for the whole remap. This
+		// makes the title and the IP observed by its click worker change as one
+		// logical operation without adding or removing an NSMenuItem.
+		slot.clear()
+		setEnabled(slot.item, false)
+	}
+	if current.Title != next.Title || remapped {
+		slot.item.SetTitle(next.Title)
+	}
+	if current.Tooltip != next.Tooltip || remapped {
+		slot.item.SetTooltip(next.Tooltip)
+	}
+	slot.setEntry(next)
+	if !current.Visible {
+		setVisible(slot.item, true)
+	}
+	setEnabled(slot.item, true)
 }
 
 func (ui *trayUI) peerClicks(slot *peerMenuSlot) {
@@ -351,6 +406,14 @@ func setEnabled(item *systray.MenuItem, enabled bool) {
 		item.Enable()
 	} else if !enabled && !item.Disabled() {
 		item.Disable()
+	}
+}
+
+func setVisible(item *systray.MenuItem, visible bool) {
+	if visible {
+		item.Show()
+	} else {
+		item.Hide()
 	}
 }
 

--- a/cmd/meshd-tray/tray_supported_test.go
+++ b/cmd/meshd-tray/tray_supported_test.go
@@ -40,8 +40,8 @@ func TestPeerMenuSlotConcurrentUpdate(t *testing.T) {
 	go func() {
 		defer close(done)
 		for i := 0; i < 1000; i++ {
-			slot.setMeshIP("10.200.0.8")
-			slot.setMeshIP("")
+			slot.setEntry(peerMenuEntry{Key: "peer", MeshIP: "10.200.0.8", Visible: true})
+			slot.clear()
 		}
 	}()
 	for i := 0; i < 1000; i++ {


### PR DESCRIPTION
Summary

- Preallocate a fixed pool of native peer menu rows before polling starts.
- Eliminate refresh-time AddSubMenuItem, Remove, and click-channel lifecycle churn that can crash AppKit while a menu is tracking.
- Preserve peer-to-row bindings by stable peer key and clear click targets before remapping.
- Bound the menu at 64 visible peers with a disabled dashboard overflow row.
- Gate unchanged titles and visibility to minimize synchronous native mutations.
- Add platform-neutral tests for add/drop/reorder, rename/IP/online changes, overflow, fixed pool size, and current click IP mapping.

Validation

- go build ./...
- go vet ./...
- go test ./... -count=1 -race
- git diff --check
- independent lifecycle review

Closes #230