### PR TITLE
fix: preserve peer identity across membership changes

### DIFF
--- a/internal/control/dwnclient.go
+++ b/internal/control/dwnclient.go
@@ -2,7 +2,10 @@ package control
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -743,9 +746,10 @@ func (c *DWNClient) buildMapResponse() *MapResponse {
 		DNSConfig: c.buildDNSConfig(),
 	}
 
-	// Sort DIDs for deterministic NodeID assignment. Go map iteration
-	// order is random, and magicsock panics if the same public key
-	// appears under different NodeIDs across successive polls.
+	// Keep response ordering deterministic for logs, status output, and tests.
+	// Node IDs themselves are derived from each DID below; assigning IDs from
+	// this sorted position would renumber existing WireGuard keys whenever a
+	// peer joins or leaves, which magicsock explicitly rejects.
 	dids := make([]string, 0, len(c.nodes))
 	for did := range c.nodes {
 		dids = append(dids, did)
@@ -753,7 +757,6 @@ func (c *DWNClient) buildMapResponse() *MapResponse {
 	sort.Strings(dids)
 
 	now := time.Now().UTC()
-	var nodeID int64 = 1
 	for _, did := range dids {
 		rec := c.nodes[did]
 		if nodeRecordExpired(rec, now) {
@@ -770,8 +773,9 @@ func (c *DWNClient) buildMapResponse() *MapResponse {
 			)
 			continue
 		}
+		nodeID, stableID := nodeIdentityForDID(c.networkRecordID, did)
 		node := nodeRecordToNode(nodeID, did, rec)
-		nodeID++
+		node.StableID = stableID
 		c.applyFallbackMeshIP(node)
 
 		// Skip peers whose mesh IP cannot be read or derived. These
@@ -807,6 +811,23 @@ func (c *DWNClient) buildMapResponse() *MapResponse {
 	}
 
 	return resp
+}
+
+// nodeIdentityForDID returns meshnet identifiers that remain stable as the
+// membership set changes. The versioned input includes the immutable network
+// record ID so independent control planes have separate identity domains.
+// The NodeID is constrained to the positive 53-bit integer range so it remains
+// exactly representable anywhere it crosses a JSON/JavaScript boundary.
+// StableID uses a longer digest for diagnostics and identity lookups. A zero
+// truncated NodeID is reserved by meshnet, so map it to 1.
+func nodeIdentityForDID(networkRecordID, did string) (int64, string) {
+	digest := sha256.Sum256([]byte("meshd node identity v1\x00" + networkRecordID + "\x00" + did))
+	const maxExactInteger = uint64(1<<53) - 1
+	id := int64(binary.BigEndian.Uint64(digest[:8]) & maxExactInteger)
+	if id == 0 {
+		id = 1
+	}
+	return id, "dwn-" + hex.EncodeToString(digest[:16])
 }
 
 func nodeRecordExpired(rec *NodeRecord, now time.Time) bool {

--- a/internal/control/node_identity_test.go
+++ b/internal/control/node_identity_test.go
@@ -1,0 +1,126 @@
+package control
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBuildMapResponseNodeIdentityStableAcrossMembershipChanges(t *testing.T) {
+	const (
+		addedDID = "did:jwk:a"
+		selfDID  = "did:jwk:b"
+		peerDID  = "did:jwk:c"
+	)
+	c := NewDWNClient("https://dwn.example", "did:example:anchor", "network-1", selfDID, nil)
+	c.network = &NetworkConfig{Name: "test", MeshCIDR: "10.200.0.0/16"}
+	c.nodes[selfDID] = &NodeRecord{DID: selfDID, MeshIP: "10.200.0.2", RecordID: "self-record"}
+	c.nodes[peerDID] = &NodeRecord{DID: peerDID, MeshIP: "10.200.0.3", RecordID: "peer-record"}
+
+	before := c.buildMapResponse()
+	if before == nil || before.Node == nil || len(before.Peers) != 1 {
+		t.Fatalf("initial map = %#v, want self and one peer", before)
+	}
+	selfID, selfStableID := before.Node.ID, before.Node.StableID
+	peerID, peerStableID := before.Peers[0].ID, before.Peers[0].StableID
+	if selfID == 0 || peerID == 0 || selfStableID == "" || peerStableID == "" {
+		t.Fatalf("initial identities are not usable: self=(%d,%q) peer=(%d,%q)",
+			selfID, selfStableID, peerID, peerStableID)
+	}
+
+	// Insert a DID before both existing DIDs. Rank-based IDs renumbered the
+	// existing peer here and left magicsock's key/NodeID indexes inconsistent.
+	c.nodes[addedDID] = &NodeRecord{DID: addedDID, MeshIP: "10.200.0.4", RecordID: "added-record"}
+	after := c.buildMapResponse()
+	if after == nil || after.Node == nil || len(after.Peers) != 2 {
+		t.Fatalf("expanded map = %#v, want self and two peers", after)
+	}
+	if after.Node.ID != selfID || after.Node.StableID != selfStableID {
+		t.Fatalf("self identity changed after peer joined: before=(%d,%q) after=(%d,%q)",
+			selfID, selfStableID, after.Node.ID, after.Node.StableID)
+	}
+	existing := peerByDID(t, after, peerDID)
+	if existing.ID != peerID || existing.StableID != peerStableID {
+		t.Fatalf("peer identity changed after peer joined: before=(%d,%q) after=(%d,%q)",
+			peerID, peerStableID, existing.ID, existing.StableID)
+	}
+	if after.Peers[0].ID == after.Peers[1].ID || after.Peers[0].StableID == after.Peers[1].StableID {
+		t.Fatalf("expanded peers have colliding identities: %+v", after.Peers)
+	}
+
+	delete(c.nodes, addedDID)
+	again := c.buildMapResponse()
+	if again == nil || again.Node.ID != selfID || again.Node.StableID != selfStableID ||
+		len(again.Peers) != 1 || again.Peers[0].ID != peerID || again.Peers[0].StableID != peerStableID {
+		t.Fatalf("identities changed after peer left: got %#v", again)
+	}
+
+	// Expire the earlier-sorting peer while both later nodes survive. The old
+	// rank allocator renumbered both survivors when it skipped the expired DID.
+	c.nodes[addedDID] = &NodeRecord{DID: addedDID, MeshIP: "10.200.0.4", RecordID: "added-record"}
+	beforeExpiry := c.buildMapResponse()
+	addedBeforeExpiry := peerByDID(t, beforeExpiry, addedDID)
+	existingBeforeExpiry := peerByDID(t, beforeExpiry, peerDID)
+	c.nodes[addedDID].ExpiresAt = time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
+	expired := c.buildMapResponse()
+	if expired == nil || expired.Node == nil || len(expired.Peers) != 1 {
+		t.Fatalf("expired map = %#v, want self and one surviving peer", expired)
+	}
+	if expired.Node.ID != beforeExpiry.Node.ID || expired.Node.StableID != beforeExpiry.Node.StableID {
+		t.Fatalf("self identity changed after earlier peer expired: before=%#v after=%#v",
+			beforeExpiry.Node, expired.Node)
+	}
+	existingAfterExpiry := peerByDID(t, expired, peerDID)
+	if existingAfterExpiry.ID != existingBeforeExpiry.ID ||
+		existingAfterExpiry.StableID != existingBeforeExpiry.StableID {
+		t.Fatalf("surviving peer identity changed after earlier peer expired: before=%#v after=%#v",
+			existingBeforeExpiry, existingAfterExpiry)
+	}
+	c.nodes[addedDID].ExpiresAt = ""
+	reappeared := c.buildMapResponse()
+	addedAfterExpiry := peerByDID(t, reappeared, addedDID)
+	if addedAfterExpiry.ID != addedBeforeExpiry.ID || addedAfterExpiry.StableID != addedBeforeExpiry.StableID {
+		t.Fatalf("peer identity changed after expiry cleared: before=%#v after=%#v",
+			addedBeforeExpiry, addedAfterExpiry)
+	}
+}
+
+func TestNodeIdentityForDIDStableAndNetworkScoped(t *testing.T) {
+	id, stableID := nodeIdentityForDID("network-1", "did:jwk:node")
+	const wantID int64 = 6072770578351070
+	const wantStableID = "dwn-b1759327152003de5a78be829ef8427d"
+	if id != wantID || stableID != wantStableID {
+		t.Fatalf("identity vector changed: got=(%d,%q) want=(%d,%q)",
+			id, stableID, wantID, wantStableID)
+	}
+	if id <= 0 || id > 1<<53-1 {
+		t.Fatalf("NodeID = %d, want positive exactly representable integer", id)
+	}
+	if againID, againStableID := nodeIdentityForDID("network-1", "did:jwk:node"); againID != id || againStableID != stableID {
+		t.Fatalf("identity is not deterministic: first=(%d,%q) second=(%d,%q)",
+			id, stableID, againID, againStableID)
+	}
+	otherID, otherStableID := nodeIdentityForDID("network-1", "did:jwk:other")
+	if otherID == id || otherStableID == stableID {
+		t.Fatalf("different DIDs collided: first=(%d,%q) other=(%d,%q)",
+			id, stableID, otherID, otherStableID)
+	}
+	otherNetworkID, otherNetworkStableID := nodeIdentityForDID("network-2", "did:jwk:node")
+	if otherNetworkID == id || otherNetworkStableID == stableID {
+		t.Fatalf("different networks share identity: first=(%d,%q) other=(%d,%q)",
+			id, stableID, otherNetworkID, otherNetworkStableID)
+	}
+}
+
+func peerByDID(t *testing.T, resp *MapResponse, did string) *Node {
+	t.Helper()
+	if resp == nil {
+		t.Fatal("map response is nil")
+	}
+	for _, peer := range resp.Peers {
+		if peer.DID == did {
+			return peer
+		}
+	}
+	t.Fatalf("peer %s missing from map", did)
+	return nil
+}

--- a/internal/control/types.go
+++ b/internal/control/types.go
@@ -17,8 +17,13 @@ import (
 // Node represents a peer in the mesh network.
 // Maps to tailcfg.Node in meshnet.
 type Node struct {
-	// ID is a unique identifier for this node (derived from record ID).
+	// ID is a unique, immutable identifier derived from the network and node DID.
 	ID int64
+
+	// StableID is the immutable identity meshnet uses for this node across
+	// network-map updates. It must not change when other nodes join or leave.
+	// Static callers may omit it; the engine then derives "dwn-<ID>".
+	StableID string
 
 	// Name is the hostname or label for this node.
 	Name string

--- a/internal/engine/convert.go
+++ b/internal/engine/convert.go
@@ -70,6 +70,9 @@ func (c *Converter) Convert(resp *control.MapResponse) (*netmap.NetworkMap, erro
 	if resp == nil {
 		return nil, fmt.Errorf("nil MapResponse")
 	}
+	if err := validateNodeIdentities(resp); err != nil {
+		return nil, fmt.Errorf("validating node identities: %w", err)
+	}
 
 	nm := &netmap.NetworkMap{
 		Domain: c.Domain,
@@ -162,7 +165,7 @@ func (c *Converter) Convert(resp *control.MapResponse) (*netmap.NetworkMap, erro
 func (c *Converter) convertNode(n *control.Node) (*tailcfg.Node, error) {
 	node := &tailcfg.Node{
 		ID:       tailcfg.NodeID(n.ID),
-		StableID: tailcfg.StableNodeID(fmt.Sprintf("dwn-%d", n.ID)),
+		StableID: tailcfg.StableNodeID(nodeStableID(n)),
 		Name:     c.fqdn(n.Name),
 		HomeDERP: n.PreferredDERP,
 		Hostinfo: (&tailcfg.Hostinfo{
@@ -235,6 +238,62 @@ func (c *Converter) convertNode(n *control.Node) (*tailcfg.Node, error) {
 	}
 
 	return node, nil
+}
+
+func validateNodeIdentities(resp *control.MapResponse) error {
+	type candidate struct {
+		label string
+		node  *control.Node
+	}
+
+	nodes := make([]candidate, 0, 1+len(resp.Peers))
+	if resp.Node != nil {
+		nodes = append(nodes, candidate{label: "self node", node: resp.Node})
+	}
+	for i, peer := range resp.Peers {
+		if peer == nil {
+			return fmt.Errorf("peer %d is nil", i)
+		}
+		nodes = append(nodes, candidate{
+			label: fmt.Sprintf("peer %d", i),
+			node:  peer,
+		})
+	}
+
+	seenIDs := make(map[int64]string, len(nodes))
+	seenStableIDs := make(map[string]string, len(nodes))
+	for _, candidate := range nodes {
+		node := candidate.node
+		label := candidate.label
+		if node.DID != "" {
+			label += fmt.Sprintf(" (DID=%s)", node.DID)
+		} else if node.Name != "" {
+			label += fmt.Sprintf(" (name=%s)", node.Name)
+		}
+		if node.ID <= 0 {
+			return fmt.Errorf("%s has invalid NodeID %d; NodeIDs must be positive", label, node.ID)
+		}
+		if previous, ok := seenIDs[node.ID]; ok {
+			return fmt.Errorf("duplicate NodeID %d for %s and %s", node.ID, previous, label)
+		}
+		stableID := nodeStableID(node)
+		if previous, ok := seenStableIDs[stableID]; ok {
+			return fmt.Errorf("duplicate StableID %q for %s and %s", stableID, previous, label)
+		}
+		seenIDs[node.ID] = label
+		seenStableIDs[stableID] = label
+	}
+	return nil
+}
+
+func nodeStableID(n *control.Node) string {
+	if n.StableID != "" {
+		return n.StableID
+	}
+	// Static/embedded callers may construct control.Node directly. Preserve
+	// their existing behavior while production DWN nodes provide the immutable
+	// network-and-DID-derived StableID.
+	return fmt.Sprintf("dwn-%d", n.ID)
 }
 
 // parseWireGuardKey parses a base64-encoded WireGuard public key (32 bytes)

--- a/internal/engine/live_membership_test.go
+++ b/internal/engine/live_membership_test.go
@@ -1,0 +1,224 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/netip"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/enboxorg/meshd/internal/control"
+	"github.com/enboxorg/meshnet/types/key"
+	"github.com/enboxorg/meshnet/types/netmap"
+)
+
+type liveMembershipNode struct {
+	id      int64
+	stable  string
+	name    string
+	did     string
+	meshIP  netip.Addr
+	private key.NodePrivate
+}
+
+func TestMinimalLiveThirdNodeConnectivity(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	derpMap, stopDERP := startLocalDERP(t)
+	defer stopDERP()
+	disco := NewInMemoryDiscoRegistry()
+
+	nodeA := newLiveMembershipNode(101, "a", "10.200.0.2")
+	nodeB := newLiveMembershipNode(102, "b", "10.200.0.3")
+	nodeC := newLiveMembershipNode(103, "c", "10.200.0.4")
+	var includeA atomic.Bool
+
+	mapFor := func(self liveMembershipNode, initialPeer liveMembershipNode) func(context.Context) (*netmap.NetworkMap, error) {
+		return func(context.Context) (*netmap.NetworkMap, error) {
+			peers := []liveMembershipNode{initialPeer}
+			if includeA.Load() && self.did != nodeA.did && initialPeer.did != nodeA.did {
+				peers = append(peers, nodeA)
+			}
+			return liveMembershipMap(t, self, peers, derpMap)
+		}
+	}
+
+	stackB, err := newMinimalStack(t, logger, nodeB.private, mapFor(nodeB, nodeC), disco)
+	if err != nil {
+		t.Fatalf("creating stack B: %v", err)
+	}
+	defer stackB.close()
+	stackC, err := newMinimalStack(t, logger, nodeC.private, mapFor(nodeC, nodeB), disco)
+	if err != nil {
+		t.Fatalf("creating stack C: %v", err)
+	}
+	defer stackC.close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	if err := stackB.start(ctx); err != nil {
+		t.Fatalf("starting B: %v", err)
+	}
+	if err := stackC.start(ctx); err != nil {
+		t.Fatalf("starting C: %v", err)
+	}
+	waitForMinimalPeerCount(t, ctx, stackB, 1)
+	waitForMinimalPeerCount(t, ctx, stackC, 1)
+	assertMinimalTCPEcho(t, ctx, stackB, stackC, nodeC.meshIP, 10001)
+
+	// The control-layer identity test catches the former rank-based allocator.
+	// Here, add A while B and C remain running to verify meshnet applies the
+	// corrected live membership update without breaking existing connectivity.
+	includeA.Store(true)
+	stackA, err := newMinimalStack(t, logger, nodeA.private, func(context.Context) (*netmap.NetworkMap, error) {
+		return liveMembershipMap(t, nodeA, []liveMembershipNode{nodeB, nodeC}, derpMap)
+	}, disco)
+	if err != nil {
+		t.Fatalf("creating stack A: %v", err)
+	}
+	defer stackA.close()
+	if err := stackA.start(ctx); err != nil {
+		t.Fatalf("starting A: %v", err)
+	}
+	if stackB.control == nil || stackC.control == nil {
+		t.Fatal("existing stacks did not expose their control clients")
+	}
+	stackB.control.Notify()
+	stackC.control.Notify()
+
+	waitForMinimalPeerCount(t, ctx, stackA, 2)
+	waitForMinimalPeerCount(t, ctx, stackB, 2)
+	waitForMinimalPeerCount(t, ctx, stackC, 2)
+	assertMinimalTCPEcho(t, ctx, stackB, stackA, nodeA.meshIP, 10002)
+	assertMinimalTCPEcho(t, ctx, stackC, stackA, nodeA.meshIP, 10003)
+	assertMinimalTCPEcho(t, ctx, stackB, stackC, nodeC.meshIP, 10004)
+}
+
+func newLiveMembershipNode(id int64, name, meshIP string) liveMembershipNode {
+	return liveMembershipNode{
+		id:      id,
+		stable:  fmt.Sprintf("dwn-test-%s", name),
+		name:    "node-" + name,
+		did:     "did:jwk:" + name,
+		meshIP:  netip.MustParseAddr(meshIP),
+		private: key.NewNode(),
+	}
+}
+
+func liveMembershipMap(
+	t *testing.T,
+	self liveMembershipNode,
+	peers []liveMembershipNode,
+	derpMap *control.DERPMap,
+) (*netmap.NetworkMap, error) {
+	t.Helper()
+	toControlNode := func(node liveMembershipNode) *control.Node {
+		return &control.Node{
+			ID:            node.id,
+			StableID:      node.stable,
+			Name:          node.name,
+			DID:           node.did,
+			Key:           pubKeyToBase64(node.private.Public()),
+			MeshIP:        node.meshIP,
+			PreferredDERP: 900,
+			Online:        true,
+		}
+	}
+	controlPeers := make([]*control.Node, 0, len(peers))
+	for _, peer := range peers {
+		controlPeers = append(controlPeers, toControlNode(peer))
+	}
+	return NewConverter("live-membership-test").Convert(
+		control.BuildStaticMapResponse(toControlNode(self), controlPeers, derpMap),
+	)
+}
+
+func waitForMinimalPeerCount(t *testing.T, ctx context.Context, stack *minimalStack, want int) {
+	t.Helper()
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if nm := stack.backend.NetMap(); nm != nil && len(nm.Peers) == want {
+			allDisco := true
+			for _, peer := range nm.Peers {
+				if peer.DiscoKey().IsZero() {
+					allDisco = false
+					break
+				}
+			}
+			if allDisco {
+				return
+			}
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("waiting for %d peers: %v", want, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func assertMinimalTCPEcho(
+	t *testing.T,
+	ctx context.Context,
+	from, to *minimalStack,
+	toIP netip.Addr,
+	port uint16,
+) {
+	t.Helper()
+	listener, err := to.ns.ListenTCP("tcp4", fmt.Sprintf("0.0.0.0:%d", port))
+	if err != nil {
+		t.Fatalf("listen on %d: %v", port, err)
+	}
+	defer listener.Close()
+
+	serverDone := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer conn.Close()
+		payload, err := io.ReadAll(io.LimitReader(conn, 32))
+		if err == nil {
+			_, err = conn.Write(payload)
+		}
+		serverDone <- err
+	}()
+
+	dialCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	conn, err := from.ns.DialContextTCP(dialCtx, netip.AddrPortFrom(toIP, port))
+	if err != nil {
+		t.Fatalf("dial %s:%d: %v", toIP, port, err)
+	}
+	payload := []byte("meshd live membership")
+	if _, err := conn.Write(payload); err != nil {
+		conn.Close()
+		t.Fatalf("write to %s:%d: %v", toIP, port, err)
+	}
+	if err := conn.CloseWrite(); err != nil {
+		conn.Close()
+		t.Fatalf("close write to %s:%d: %v", toIP, port, err)
+	}
+	got, err := io.ReadAll(conn)
+	conn.Close()
+	if err != nil {
+		t.Fatalf("read echo from %s:%d: %v", toIP, port, err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("echo from %s:%d = %q, want %q", toIP, port, got, payload)
+	}
+	select {
+	case err := <-serverDone:
+		if err != nil {
+			t.Fatalf("server on %s:%d: %v", toIP, port, err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("server on %s:%d did not finish", toIP, port)
+	}
+}

--- a/internal/engine/minimal_test.go
+++ b/internal/engine/minimal_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/enboxorg/meshnet/net/tsdial"
 	"github.com/enboxorg/meshnet/tsd"
 	"github.com/enboxorg/meshnet/types/key"
-	"github.com/enboxorg/meshnet/types/logid"
 	"github.com/enboxorg/meshnet/types/logger"
+	"github.com/enboxorg/meshnet/types/logid"
 	"github.com/enboxorg/meshnet/types/netmap"
 	"github.com/enboxorg/meshnet/wgengine"
 	"github.com/enboxorg/meshnet/wgengine/netstack"
@@ -289,6 +289,7 @@ type minimalStack struct {
 	ns      *netstack.Impl
 	eng     wgengine.Engine
 	nm      *netmon.Monitor
+	control *DWNControl
 }
 
 func (s *minimalStack) start(ctx context.Context) error {
@@ -400,25 +401,30 @@ func newMinimalStack(
 		return nil, fmt.Errorf("starting netstack: %w", err)
 	}
 
+	stack := &minimalStack{
+		backend: lb,
+		ns:      ns,
+		eng:     eng,
+		nm:      nm,
+	}
+
 	// Wire DWNControl with hard-coded map and disco registry.
 	dwnCfg := &DWNControlConfig{
-		MapResponseFunc: mapFn,
-		PollInterval:    30 * time.Second, // slow polling — initial push is enough for static config
-		NodePrivateKey:  nodeKey,
+		MapResponseFunc:  mapFn,
+		PollInterval:     30 * time.Second, // slow polling — initial push is enough for static config
+		NodePrivateKey:   nodeKey,
 		DiscoKeyRegistry: discoReg,
-		Logf:            logf,
+		Logf:             logf,
+		OnCreated: func(control *DWNControl) {
+			stack.control = control
+		},
 	}
 
 	lb.SetControlClientGetterForTesting(
 		NewDWNControlFactory(dwnCfg),
 	)
 
-	return &minimalStack{
-		backend: lb,
-		ns:      ns,
-		eng:     eng,
-		nm:      nm,
-	}, nil
+	return stack, nil
 }
 
 // minimalLogf logs meshnet messages at Info level so we can see important
@@ -490,8 +496,8 @@ func startLocalDERP(t *testing.T) (*control.DERPMap, func()) {
 						RegionID: 900,
 						HostName: u.Hostname(),
 						DERPPort: port,
-					// Self-signed TLS — InsecureForTests skips cert verification.
-					InsecureForTests: true,
+						// Self-signed TLS — InsecureForTests skips cert verification.
+						InsecureForTests: true,
 					},
 				},
 			},

--- a/internal/engine/stable_id_test.go
+++ b/internal/engine/stable_id_test.go
@@ -1,0 +1,94 @@
+package engine
+
+import (
+	"net/netip"
+	"strings"
+	"testing"
+
+	"github.com/enboxorg/meshd/internal/control"
+)
+
+func TestConvertUsesControlStableID(t *testing.T) {
+	node := &control.Node{
+		ID:       42,
+		StableID: "dwn-immutable-node",
+		Name:     "node",
+		DID:      "did:jwk:node",
+		Key:      testWireGuardKey(),
+		MeshIP:   netip.MustParseAddr("10.200.0.42"),
+	}
+
+	converted, err := NewConverter("test").convertNode(node)
+	if err != nil {
+		t.Fatalf("convertNode: %v", err)
+	}
+	if got := string(converted.StableID); got != node.StableID {
+		t.Fatalf("StableID = %q, want %q", got, node.StableID)
+	}
+}
+
+func TestConvertNodeUsesStaticStableIDFallback(t *testing.T) {
+	node := &control.Node{
+		ID:     42,
+		Name:   "node",
+		Key:    testWireGuardKey(),
+		MeshIP: netip.MustParseAddr("10.200.0.42"),
+	}
+
+	converted, err := NewConverter("test").convertNode(node)
+	if err != nil {
+		t.Fatalf("convertNode: %v", err)
+	}
+	if got, want := string(converted.StableID), "dwn-42"; got != want {
+		t.Fatalf("StableID = %q, want %q", got, want)
+	}
+}
+
+func TestConvertRejectsInvalidNodeIdentities(t *testing.T) {
+	newNode := func(id int64, stableID, name string) *control.Node {
+		return &control.Node{
+			ID:       id,
+			StableID: stableID,
+			Name:     name,
+			DID:      "did:jwk:" + name,
+			Key:      testWireGuardKey(),
+			MeshIP:   netip.MustParseAddr("10.200.0.42"),
+		}
+	}
+	tests := []struct {
+		name    string
+		resp    *control.MapResponse
+		wantErr string
+	}{
+		{
+			name:    "nonpositive ID",
+			resp:    &control.MapResponse{Node: newNode(0, "dwn-self", "self")},
+			wantErr: "invalid NodeID 0",
+		},
+		{
+			name: "duplicate NodeID",
+			resp: &control.MapResponse{
+				Node:  newNode(1, "dwn-self", "self"),
+				Peers: []*control.Node{newNode(1, "dwn-peer", "peer")},
+			},
+			wantErr: "duplicate NodeID 1",
+		},
+		{
+			name: "duplicate StableID",
+			resp: &control.MapResponse{
+				Node:  newNode(1, "dwn-shared", "self"),
+				Peers: []*control.Node{newNode(2, "dwn-shared", "peer")},
+			},
+			wantErr: `duplicate StableID "dwn-shared"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewConverter("test").Convert(tt.resp)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Convert error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- derive immutable, network-scoped meshnet NodeID and StableID values from each node DID instead of its sorted membership position
- reject zero or colliding identities before an ambiguous network map reaches meshnet
- add control regressions for join, leave, expiry, hash stability, and collision handling
- add a live local-DERP test that proves existing traffic survives a two-node to three-node membership update

This fixes the stale magicsock key/NodeID indexes that could leave peers listed while ping and SSH stopped working after a third node joined.

Closes #234

## Verification

- go build ./...
- go vet ./...
- go test ./... -count=1 -race
- go test ./internal/engine -run TestMinimalLiveThirdNodeConnectivity -count=5

No vendor files were changed.