### PR TITLE
fix: fail when required TUN cannot start

### DIFF
--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -3456,9 +3456,8 @@ func supportsRealTUN(goos string) bool {
 	return goos == "darwin" || goos == "linux"
 }
 
-func shouldReexecWithSudoForTun(f upFlags, uid int, goos string, stdinTTY bool) bool {
-	guiPrompt := goos == "darwin" && os.Getenv(trayConnectEnv) == "1"
-	if uid == 0 || f.noTun || (!stdinTTY && !guiPrompt) || !supportsRealTUN(goos) {
+func shouldReexecWithSudoForTun(f upFlags, uid int, goos string) bool {
+	if uid == 0 || f.noTun || !supportsRealTUN(goos) {
 		return false
 	}
 	return true
@@ -3503,7 +3502,7 @@ func reexecUpWithSudo(args []string, flagProfile, stateDir string) error {
 	return cmd.Run()
 }
 
-func startUpInBackground(ctx context.Context, args []string, flagProfile, stateDir string, needsSudo bool) error {
+func startUpInBackground(ctx context.Context, args []string, flagProfile, stateDir string, needsSudo, requireTUN bool) error {
 	socketPath := daemon.DefaultSocketPath()
 	if daemon.NewClient(socketPath).IsRunning() {
 		fmt.Println("meshd is already running.")
@@ -3577,9 +3576,12 @@ func startUpInBackground(ctx context.Context, args []string, flagProfile, stateD
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("starting background meshd: %w", err)
 	}
-	_ = cmd.Process.Release()
+	childExit := make(chan error, 1)
+	go func() {
+		childExit <- cmd.Wait()
+	}()
 
-	status, err := waitForDaemonStart(ctx, socketPath, backgroundWait)
+	status, err := waitForDaemonStart(ctx, socketPath, backgroundWait, requireTUN, childExit)
 	if err != nil {
 		return fmt.Errorf("%w; see %s", err, logPath)
 	}
@@ -3604,22 +3606,63 @@ func startUpInBackground(ctx context.Context, args []string, flagProfile, stateD
 	return nil
 }
 
-func waitForDaemonStart(ctx context.Context, socketPath string, timeout time.Duration) (*daemon.Status, error) {
+func waitForDaemonStart(
+	ctx context.Context,
+	socketPath string,
+	timeout time.Duration,
+	requireTUN bool,
+	childExit <-chan error,
+) (*daemon.Status, error) {
 	client := daemon.NewClient(socketPath)
-	deadline := time.Now().Add(timeout)
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
 	var lastErr error
-	for time.Now().Before(deadline) {
+	for {
 		status, err := client.GetStatus(ctx)
 		if err == nil {
+			select {
+			case exitErr := <-childExit:
+				if exitErr != nil {
+					return nil, fmt.Errorf("background meshd exited before startup completed: %w", exitErr)
+				}
+				return nil, fmt.Errorf("background meshd exited before startup completed")
+			default:
+			}
+			if err := validateDaemonStartStatus(status, requireTUN); err != nil {
+				return nil, err
+			}
 			return status, nil
 		}
 		lastErr = err
-		time.Sleep(250 * time.Millisecond)
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case exitErr := <-childExit:
+			if exitErr != nil {
+				return nil, fmt.Errorf("background meshd exited before opening its control socket: %w", exitErr)
+			}
+			return nil, fmt.Errorf("background meshd exited before opening its control socket")
+		case <-timer.C:
+			if lastErr != nil {
+				return nil, fmt.Errorf("daemon did not start within %s: %w", timeout, lastErr)
+			}
+			return nil, fmt.Errorf("daemon did not start within %s", timeout)
+		case <-ticker.C:
+		}
 	}
-	if lastErr != nil {
-		return nil, fmt.Errorf("daemon did not start within %s: %w", timeout, lastErr)
+}
+
+func validateDaemonStartStatus(status *daemon.Status, requireTUN bool) error {
+	if status == nil {
+		return fmt.Errorf("daemon returned empty startup status")
 	}
-	return nil, fmt.Errorf("daemon did not start within %s", timeout)
+	if requireTUN && status.TUNDevice == "" {
+		return fmt.Errorf("daemon started without the required TUN device")
+	}
+	return nil
 }
 
 func daemonLogPath(stateDir string) string {
@@ -3695,7 +3738,8 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 			return nil
 		}
 	}
-	shouldElevate := shouldReexecWithSudoForTun(f, os.Getuid(), runtime.GOOS, stdinIsTerminal())
+	requireTUN := f.tunName != "" || (!f.noTun && supportsRealTUN(runtime.GOOS))
+	shouldElevate := shouldReexecWithSudoForTun(f, os.Getuid(), runtime.GOOS)
 
 	// ── Step 1: Ensure identity exists ──────────────────────────────
 	stateDir, identity, err := ensureIdentityForCommand(ctx, flagProfile, f.endpoint)
@@ -3772,12 +3816,12 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 	}
 	if shouldElevate {
 		if !backgroundChild && !f.foreground {
-			return startUpInBackground(ctx, args, flagProfile, stateDir, true)
+			return startUpInBackground(ctx, args, flagProfile, stateDir, true, requireTUN)
 		}
 		return reexecUpWithSudo(args, flagProfile, stateDir)
 	}
 	if !backgroundChild && !f.foreground {
-		return startUpInBackground(ctx, args, flagProfile, stateDir, false)
+		return startUpInBackground(ctx, args, flagProfile, stateDir, false, requireTUN)
 	}
 
 	// ── Step 3: Start the engine ────────────────────────────────────

--- a/cmd/meshd/main_test.go
+++ b/cmd/meshd/main_test.go
@@ -693,30 +693,60 @@ func TestParseUpFlagsForeground(t *testing.T) {
 
 func TestShouldReexecWithSudoForTun(t *testing.T) {
 	t.Setenv(trayConnectEnv, "")
-	if !shouldReexecWithSudoForTun(upFlags{}, 501, "darwin", true) {
-		t.Fatal("expected interactive non-root darwin up to reexec with sudo")
+	if !shouldReexecWithSudoForTun(upFlags{}, 501, "darwin") {
+		t.Fatal("expected non-root darwin up to reexec with sudo")
 	}
-	if !shouldReexecWithSudoForTun(upFlags{}, 1000, "linux", true) {
-		t.Fatal("expected interactive non-root linux up to reexec with sudo")
+	if !shouldReexecWithSudoForTun(upFlags{}, 1000, "linux") {
+		t.Fatal("expected non-root linux up to reexec with sudo")
 	}
-	if shouldReexecWithSudoForTun(upFlags{}, 0, "linux", true) {
+	if shouldReexecWithSudoForTun(upFlags{}, 0, "linux") {
 		t.Fatal("did not expect root to reexec with sudo")
 	}
-	if shouldReexecWithSudoForTun(upFlags{noTun: true}, 1000, "linux", true) {
+	if shouldReexecWithSudoForTun(upFlags{noTun: true}, 1000, "linux") {
 		t.Fatal("did not expect --no-tun to reexec with sudo")
 	}
-	if shouldReexecWithSudoForTun(upFlags{}, 1000, "linux", false) {
-		t.Fatal("did not expect non-interactive up to reexec with sudo")
-	}
-	if shouldReexecWithSudoForTun(upFlags{}, 1000, "freebsd", true) {
+	if shouldReexecWithSudoForTun(upFlags{}, 1000, "freebsd") {
 		t.Fatal("did not expect unsupported OS to reexec with sudo")
 	}
 	t.Setenv(trayConnectEnv, "1")
-	if !shouldReexecWithSudoForTun(upFlags{}, 501, "darwin", false) {
+	if !shouldReexecWithSudoForTun(upFlags{}, 501, "darwin") {
 		t.Fatal("expected non-interactive tray connect on darwin to request GUI elevation")
 	}
-	if shouldReexecWithSudoForTun(upFlags{}, 1000, "linux", false) {
-		t.Fatal("did not expect the macOS tray marker to elevate on linux")
+	if !shouldReexecWithSudoForTun(upFlags{}, 1000, "linux") {
+		t.Fatal("expected Linux TUN elevation to be independent of stdin TTY")
+	}
+}
+
+func TestWaitForDaemonStartReturnsWhenChildExits(t *testing.T) {
+	childExit := make(chan error, 1)
+	childExit <- errors.New("TUN startup failed")
+
+	started := time.Now()
+	_, err := waitForDaemonStart(
+		context.Background(),
+		filepath.Join(t.TempDir(), "missing.sock"),
+		30*time.Second,
+		true,
+		childExit,
+	)
+	if err == nil || !strings.Contains(err.Error(), "TUN startup failed") {
+		t.Fatalf("waitForDaemonStart error = %v, want child failure", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("waitForDaemonStart took %s after child exit", elapsed)
+	}
+}
+
+func TestValidateDaemonStartStatusRequiresRequestedTUN(t *testing.T) {
+	if err := validateDaemonStartStatus(&daemon.Status{}, false); err != nil {
+		t.Fatalf("explicit userspace status rejected: %v", err)
+	}
+	if err := validateDaemonStartStatus(&daemon.Status{TUNDevice: "meshd0"}, true); err != nil {
+		t.Fatalf("TUN status rejected: %v", err)
+	}
+	if err := validateDaemonStartStatus(&daemon.Status{}, true); err == nil ||
+		!strings.Contains(err.Error(), "required TUN device") {
+		t.Fatalf("missing TUN error = %v", err)
 	}
 }
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"log/slog"
 	"net"
 	"net/netip"
+	"runtime"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/enboxorg/meshd/internal/control"
@@ -167,7 +170,8 @@ type Config struct {
 	// applications (ping, ssh, curl) to route through the mesh tunnel.
 	//
 	// Requires root or CAP_NET_ADMIN. If the TUN device cannot be created,
-	// the engine falls back to userspace-only mode with a warning.
+	// engine creation fails. Callers that want userspace-only mode must leave
+	// TUNName empty explicitly.
 	//
 	// When empty (default), the engine runs in userspace-only mode where
 	// only netstack-internal code can communicate through the mesh.
@@ -176,6 +180,8 @@ type Config struct {
 	// Logger is the structured logger. Nil = default.
 	Logger *slog.Logger
 }
+
+var newTUNDevice = tstun.New
 
 // New creates a new Engine from the given config.
 //
@@ -284,7 +290,8 @@ func New(cfg Config) (*Engine, error) {
 	// Two modes:
 	//   1. Real TUN mode (cfg.TUNName set): creates a kernel TUN device so
 	//      regular applications can route through the mesh. Requires root
-	//      or CAP_NET_ADMIN. Falls back to userspace mode on failure.
+	//      or CAP_NET_ADMIN. Creation failure is fatal because silently using
+	//      netstack would leave host ping, SSH, and routing non-functional.
 	//   2. Userspace mode (default): fake TUN + netstack. Only code using
 	//      the netstack dialer can communicate through the mesh tunnel.
 	var tunDev tun.Device
@@ -294,25 +301,22 @@ func New(cfg Config) (*Engine, error) {
 	userspaceOnly := true
 
 	if cfg.TUNName != "" {
-		dev, devName, tunErr := tstun.New(logf, cfg.TUNName)
+		dev, devName, tunErr := newTUNDevice(logf, cfg.TUNName)
 		if tunErr != nil {
-			l.Warn("failed to create TUN device, falling back to userspace mode",
-				slog.String("tunName", cfg.TUNName),
-				slog.Any("error", tunErr),
-			)
-		} else {
-			tunDev = dev
-			tunName = devName
-			userspaceOnly = false
-			l.Info("created TUN device", slog.String("name", tunName))
+			nm.Close()
+			return nil, tunCreationError(runtime.GOOS, cfg.TUNName, tunErr)
+		}
+		tunDev = dev
+		tunName = devName
+		userspaceOnly = false
+		l.Info("created TUN device", slog.String("name", tunName))
 
-			// Create an OS router to manage addresses and routes on the
-			// TUN interface. Unsupported platforms return nil and fall back
-			// to the fake router (no OS routing).
-			if rtr := newOSRouter(logf, tunName); rtr != nil {
-				osRouter = newSynchronizedRouter(rtr)
-				wgRouter = osRouter
-			}
+		// Create an OS router to manage addresses and routes on the
+		// TUN interface. Unsupported platforms return nil and fall back
+		// to the fake router (no OS routing).
+		if rtr := newOSRouter(logf, tunName); rtr != nil {
+			osRouter = newSynchronizedRouter(rtr)
+			wgRouter = osRouter
 		}
 	}
 
@@ -464,6 +468,19 @@ func New(cfg Config) (*Engine, error) {
 		osRouter:   osRouter,
 		logger:     l,
 	}, nil
+}
+
+func tunCreationError(goos, name string, err error) error {
+	if goos == "linux" && errors.Is(err, syscall.EBUSY) {
+		return fmt.Errorf(
+			"creating TUN device %q: %w; another process or persistent interface already owns %q; identify the exact owner by finding %q in /proc/*/fdinfo/*",
+			name,
+			err,
+			name,
+			"iff: "+name,
+		)
+	}
+	return fmt.Errorf("creating TUN device %q: %w", name, err)
 }
 
 // Start brings up the WireGuard tunnel.

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1,9 +1,14 @@
 package engine
 
 import (
+	"errors"
+	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/enboxorg/meshd/internal/dwn"
+	"github.com/enboxorg/meshnet/types/logger"
+	"github.com/tailscale/wireguard-go/tun"
 )
 
 func TestNewEngineValidation(t *testing.T) {
@@ -109,6 +114,53 @@ func TestEngineStartStop(t *testing.T) {
 	// Stop should be safe to call even before Start.
 	if err := eng.Stop(); err != nil {
 		t.Fatalf("Stop before Start: %v", err)
+	}
+}
+
+func TestNewEngineFailsWhenRequestedTUNUnavailable(t *testing.T) {
+	originalNewTUNDevice := newTUNDevice
+	t.Cleanup(func() {
+		newTUNDevice = originalNewTUNDevice
+	})
+
+	newTUNDevice = func(logger.Logf, string) (tun.Device, string, error) {
+		return nil, "", syscall.EBUSY
+	}
+
+	eng, err := New(Config{
+		AnchorEndpoint:  "https://example.com",
+		AnchorTenant:    "did:dht:anchor",
+		NetworkRecordID: "record123",
+		SelfDID:         "did:dht:self",
+		Signer:          &dwn.Signer{DID: "did:dht:self"},
+		TUNName:         "meshd0",
+	})
+	if eng != nil {
+		t.Fatal("New returned an engine after requested TUN creation failed")
+	}
+	if !errors.Is(err, syscall.EBUSY) {
+		t.Fatalf("New error = %v, want wrapped EBUSY", err)
+	}
+	if !strings.Contains(err.Error(), `creating TUN device "meshd0"`) {
+		t.Fatalf("New error = %q, want TUN device context", err)
+	}
+}
+
+func TestTUNCreationErrorBusyGuidance(t *testing.T) {
+	linuxErr := tunCreationError("linux", "meshd0", syscall.EBUSY)
+	if !errors.Is(linuxErr, syscall.EBUSY) {
+		t.Fatalf("Linux error = %v, want wrapped EBUSY", linuxErr)
+	}
+	if !strings.Contains(linuxErr.Error(), `"iff: meshd0" in /proc/*/fdinfo/*`) {
+		t.Fatalf("Linux error = %q, want exact TUN owner guidance", linuxErr)
+	}
+
+	darwinErr := tunCreationError("darwin", "utun", syscall.EBUSY)
+	if !errors.Is(darwinErr, syscall.EBUSY) {
+		t.Fatalf("Darwin error = %v, want wrapped EBUSY", darwinErr)
+	}
+	if strings.Contains(darwinErr.Error(), "/proc/") {
+		t.Fatalf("Darwin error contains Linux guidance: %q", darwinErr)
 	}
 }
 


### PR DESCRIPTION
## Summary

- make a requested kernel TUN a hard startup requirement instead of silently falling back to userspace mode
- surface Linux EBUSY failures with exact, non-destructive owner-identification guidance
- make background startup report child failures immediately and validate that the requested TUN is present
- preserve explicit userspace behavior through --no-tun

Closes #239.

## Validation

- go build ./...
- go vet ./...
- go test ./... -count=1 -race

All required checks pass locally. No vendored files were changed.