### PR TITLE
fix: enforce a single daemon lifecycle

### DIFF
--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -143,12 +143,15 @@ var version = "dev"
 var errMacOSTrayElevationUnsupported = errors.New("macOS tray Connect cannot safely request administrator privileges from a user-writable installation; run 'meshd up' in a terminal to authorize system routing")
 
 const (
-	sudoChildEnv    = "MESHD_SUDO_CHILD"
-	upBackgroundEnv = "MESHD_UP_BACKGROUND_CHILD"
-	trayConnectEnv  = "MESHD_TRAY_CONNECT"
-	backgroundWait  = 30 * time.Second
-	daemonLogName   = "meshd.log"
-	walletWaitTime  = 10 * time.Minute
+	sudoChildEnv       = "MESHD_SUDO_CHILD"
+	upBackgroundEnv    = "MESHD_UP_BACKGROUND_CHILD"
+	startupInstanceEnv = "MESHD_STARTUP_INSTANCE"
+	trayConnectEnv     = "MESHD_TRAY_CONNECT"
+	backgroundWait     = 30 * time.Second
+	daemonStopWait     = 10 * time.Second
+	daemonStopPoll     = 100 * time.Millisecond
+	daemonLogName      = "meshd.log"
+	walletWaitTime     = 10 * time.Minute
 
 	walletResponseEndpointEnv     = "MESHD_WALLET_RESPONSE_ENDPOINT"
 	defaultWalletResponseEndpoint = "https://dev.aws.dwn.enbox.id"
@@ -3539,6 +3542,10 @@ func startUpInBackground(ctx context.Context, args []string, flagProfile, stateD
 		cmdArgs = append(cmdArgs, "--profile", flagProfile)
 	}
 	cmdArgs = append(cmdArgs, args...)
+	instanceID, err := daemon.NewInstanceID()
+	if err != nil {
+		return fmt.Errorf("preparing background daemon identity: %w", err)
+	}
 
 	var cmd *exec.Cmd
 	if needsSudo {
@@ -3562,11 +3569,15 @@ func startUpInBackground(ctx context.Context, args []string, flagProfile, stateD
 		sudoArgs := []string{"-n", "env"}
 		sudoArgs = append(sudoArgs, sudoEnvironmentAssignments()...)
 		sudoArgs = append(sudoArgs, upBackgroundEnv+"=1")
+		sudoArgs = append(sudoArgs, startupInstanceEnv+"="+instanceID)
 		sudoArgs = append(sudoArgs, cmdArgs...)
 		cmd = exec.Command(sudoPath, sudoArgs...)
 	} else {
 		cmd = exec.Command(cmdArgs[0], cmdArgs[1:]...)
-		cmd.Env = append(os.Environ(), upBackgroundEnv+"=1")
+		cmd.Env = append(os.Environ(),
+			upBackgroundEnv+"=1",
+			startupInstanceEnv+"="+instanceID,
+		)
 	}
 	cmd.Stdin = nil
 	cmd.Stdout = logFile
@@ -3581,7 +3592,7 @@ func startUpInBackground(ctx context.Context, args []string, flagProfile, stateD
 		childExit <- cmd.Wait()
 	}()
 
-	status, err := waitForDaemonStart(ctx, socketPath, backgroundWait, requireTUN, childExit)
+	status, err := waitForDaemonStart(ctx, socketPath, backgroundWait, requireTUN, instanceID, childExit)
 	if err != nil {
 		return fmt.Errorf("%w; see %s", err, logPath)
 	}
@@ -3611,6 +3622,7 @@ func waitForDaemonStart(
 	socketPath string,
 	timeout time.Duration,
 	requireTUN bool,
+	instanceID string,
 	childExit <-chan error,
 ) (*daemon.Status, error) {
 	client := daemon.NewClient(socketPath)
@@ -3630,7 +3642,7 @@ func waitForDaemonStart(
 				return nil, fmt.Errorf("background meshd exited before startup completed")
 			default:
 			}
-			if err := validateDaemonStartStatus(status, requireTUN); err != nil {
+			if err := validateDaemonStartStatus(status, requireTUN, instanceID); err != nil {
 				return nil, err
 			}
 			return status, nil
@@ -3655,14 +3667,26 @@ func waitForDaemonStart(
 	}
 }
 
-func validateDaemonStartStatus(status *daemon.Status, requireTUN bool) error {
+func validateDaemonStartStatus(status *daemon.Status, requireTUN bool, instanceID string) error {
 	if status == nil {
 		return fmt.Errorf("daemon returned empty startup status")
+	}
+	if instanceID != "" && status.InstanceID != instanceID {
+		return fmt.Errorf("daemon startup instance mismatch: got %q, want %q", status.InstanceID, instanceID)
 	}
 	if requireTUN && status.TUNDevice == "" {
 		return fmt.Errorf("daemon started without the required TUN device")
 	}
 	return nil
+}
+
+func resolveDaemonInstanceID(backgroundChild bool, startupID string) (string, error) {
+	if backgroundChild {
+		if instanceID := strings.TrimSpace(startupID); instanceID != "" {
+			return instanceID, nil
+		}
+	}
+	return daemon.NewInstanceID()
 }
 
 func daemonLogPath(stateDir string) string {
@@ -3979,6 +4003,17 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 		engCfg.AudienceSource = delegateSession.AudienceSource
 		engCfg.ProtocolDefinition = delegateSession.ProtocolDefinition
 	}
+	socketPath := daemon.DefaultSocketPath()
+	instanceID, err := resolveDaemonInstanceID(backgroundChild, os.Getenv(startupInstanceEnv))
+	if err != nil {
+		return fmt.Errorf("generating daemon instance ID: %w", err)
+	}
+	instanceLock, err := daemon.AcquireInstanceLock(socketPath)
+	if err != nil {
+		return fmt.Errorf("acquiring daemon instance lock: %w", err)
+	}
+	defer instanceLock.Close()
+
 	eng, err := engine.New(engCfg)
 	if err != nil {
 		return fmt.Errorf("creating engine: %w", err)
@@ -3990,7 +4025,6 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 	}
 
 	// ── Step 4: Start the daemon control socket ────────────────────
-	socketPath := daemon.DefaultSocketPath()
 	daemonSrv := daemon.NewServer(socketPath, func() daemon.Status {
 		return daemon.Status{
 			TUNDevice:       eng.TUNDeviceName(),
@@ -4001,6 +4035,7 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 			Peers:           daemonPeerStatuses(eng.PeerSnapshots()),
 		}
 	}, logger)
+	daemonSrv.SetInstanceID(instanceID)
 
 	if err := daemonSrv.Start(); err != nil {
 		_ = eng.Stop()
@@ -4038,6 +4073,8 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 	case <-sigCh:
 	case <-daemonSrv.ShutdownCh():
 	}
+	signal.Stop(sigCh)
+	signal.Reset(syscall.SIGINT, syscall.SIGTERM)
 
 	fmt.Printf("\nShutting down...\n")
 	if err := eng.Stop(); err != nil {
@@ -4680,28 +4717,70 @@ func cmdDown(ctx context.Context, args []string) error {
 	socketPath := daemon.DefaultSocketPath()
 	client := daemon.NewClient(socketPath)
 
-	if !client.IsRunning() {
-		fmt.Println("meshd is not running.")
-		return nil
+	status, err := client.GetStatus(ctx)
+	if err != nil {
+		if !client.IsRunning() {
+			fmt.Println("meshd is not running.")
+			return nil
+		}
+		return fmt.Errorf("querying daemon status before shutdown: %w", err)
+	}
+	if status == nil || status.PID <= 0 {
+		return fmt.Errorf("daemon status did not include a valid process ID; refusing an unverified shutdown")
 	}
 
 	fmt.Printf("Stopping meshd (socket: %s)...\n", socketPath)
-	if err := client.Shutdown(ctx); err != nil {
+	if err := shutdownDaemonProcess(ctx, client, status, daemon.WaitForProcessExit, daemon.ProcessAlive); err != nil {
+		return err
+	}
+	fmt.Println("Stopped.")
+	return nil
+}
+
+type daemonShutdownClient interface {
+	Shutdown(context.Context) error
+	ShutdownInstance(context.Context, string) error
+}
+
+type daemonProcessWaiter func(context.Context, int, time.Duration) error
+type daemonProcessChecker func(int) (bool, error)
+
+func shutdownDaemonProcess(
+	ctx context.Context,
+	client daemonShutdownClient,
+	status *daemon.Status,
+	waitForExit daemonProcessWaiter,
+	processAlive daemonProcessChecker,
+) error {
+	if status == nil || status.PID <= 0 {
+		return fmt.Errorf("daemon status did not include a valid process ID; refusing an unverified shutdown")
+	}
+
+	var err error
+	if status.InstanceID != "" {
+		err = client.ShutdownInstance(ctx, status.InstanceID)
+	} else {
+		// A daemon already running during an in-place upgrade may predate
+		// instance IDs. Limit the untargeted request to that observed status
+		// and still verify the exact captured PID below.
+		err = client.Shutdown(ctx)
+	}
+	if err != nil {
+		alive, aliveErr := processAlive(status.PID)
+		if aliveErr == nil && !alive {
+			return nil
+		}
+		if aliveErr != nil {
+			return fmt.Errorf("shutdown failed: %w (could not verify process %d: %v)", err, status.PID, aliveErr)
+		}
 		return fmt.Errorf("shutdown failed: %w", err)
 	}
 
-	// Wait for the daemon to actually stop (socket goes away).
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		if !client.IsRunning() {
-			fmt.Println("Stopped.")
-			return nil
-		}
-		time.Sleep(200 * time.Millisecond)
+	waitCtx, cancel := context.WithTimeout(ctx, daemonStopWait)
+	defer cancel()
+	if err := waitForExit(waitCtx, status.PID, daemonStopPoll); err != nil {
+		return fmt.Errorf("shutdown request accepted, but daemon process %d did not exit: %w", status.PID, err)
 	}
-
-	fmt.Println("Shutdown request sent but daemon is still running.")
-	fmt.Println("You may need to send SIGTERM manually.")
 	return nil
 }
 

--- a/cmd/meshd/main_test.go
+++ b/cmd/meshd/main_test.go
@@ -727,6 +727,7 @@ func TestWaitForDaemonStartReturnsWhenChildExits(t *testing.T) {
 		filepath.Join(t.TempDir(), "missing.sock"),
 		30*time.Second,
 		true,
+		"startup-instance",
 		childExit,
 	)
 	if err == nil || !strings.Contains(err.Error(), "TUN startup failed") {
@@ -738,15 +739,164 @@ func TestWaitForDaemonStartReturnsWhenChildExits(t *testing.T) {
 }
 
 func TestValidateDaemonStartStatusRequiresRequestedTUN(t *testing.T) {
-	if err := validateDaemonStartStatus(&daemon.Status{}, false); err != nil {
+	if err := validateDaemonStartStatus(&daemon.Status{}, false, ""); err != nil {
 		t.Fatalf("explicit userspace status rejected: %v", err)
 	}
-	if err := validateDaemonStartStatus(&daemon.Status{TUNDevice: "meshd0"}, true); err != nil {
+	if err := validateDaemonStartStatus(&daemon.Status{TUNDevice: "meshd0"}, true, ""); err != nil {
 		t.Fatalf("TUN status rejected: %v", err)
 	}
-	if err := validateDaemonStartStatus(&daemon.Status{}, true); err == nil ||
+	if err := validateDaemonStartStatus(&daemon.Status{}, true, ""); err == nil ||
 		!strings.Contains(err.Error(), "required TUN device") {
 		t.Fatalf("missing TUN error = %v", err)
+	}
+}
+
+func TestValidateDaemonStartStatusRequiresMatchingInstance(t *testing.T) {
+	status := &daemon.Status{InstanceID: "different-instance", TUNDevice: "meshd0"}
+	err := validateDaemonStartStatus(status, true, "launched-instance")
+	if err == nil || !strings.Contains(err.Error(), "startup instance mismatch") {
+		t.Fatalf("instance mismatch error = %v", err)
+	}
+	if err := validateDaemonStartStatus(
+		&daemon.Status{InstanceID: "launched-instance", TUNDevice: "meshd0"},
+		true,
+		"launched-instance",
+	); err != nil {
+		t.Fatalf("matching startup instance rejected: %v", err)
+	}
+}
+
+func TestResolveDaemonInstanceIDOnlyTrustsBackgroundChild(t *testing.T) {
+	got, err := resolveDaemonInstanceID(true, "  launched-instance  ")
+	if err != nil || got != "launched-instance" {
+		t.Fatalf("background instance ID = %q, %v", got, err)
+	}
+
+	got, err = resolveDaemonInstanceID(false, "user-exported-internal-value")
+	if err != nil {
+		t.Fatalf("foreground instance ID: %v", err)
+	}
+	if got == "" || got == "user-exported-internal-value" {
+		t.Fatalf("foreground trusted internal environment value: %q", got)
+	}
+}
+
+type fakeDaemonShutdownClient struct {
+	shutdownCalls int
+	targets       []string
+	shutdownErr   error
+	targetErr     error
+}
+
+func (c *fakeDaemonShutdownClient) Shutdown(context.Context) error {
+	c.shutdownCalls++
+	return c.shutdownErr
+}
+
+func (c *fakeDaemonShutdownClient) ShutdownInstance(_ context.Context, instanceID string) error {
+	c.targets = append(c.targets, instanceID)
+	return c.targetErr
+}
+
+func TestShutdownDaemonProcessTargetsCapturedInstanceAndPID(t *testing.T) {
+	client := &fakeDaemonShutdownClient{}
+	var gotPID int
+	var gotPoll time.Duration
+	var hadDeadline bool
+	err := shutdownDaemonProcess(
+		context.Background(),
+		client,
+		&daemon.Status{PID: 4242, InstanceID: "instance-4242"},
+		func(ctx context.Context, pid int, poll time.Duration) error {
+			gotPID = pid
+			gotPoll = poll
+			_, hadDeadline = ctx.Deadline()
+			return nil
+		},
+		func(int) (bool, error) { return true, nil },
+	)
+	if err != nil {
+		t.Fatalf("shutdownDaemonProcess: %v", err)
+	}
+	if !reflect.DeepEqual(client.targets, []string{"instance-4242"}) || client.shutdownCalls != 0 {
+		t.Fatalf("targeted calls = %v, legacy calls = %d", client.targets, client.shutdownCalls)
+	}
+	if gotPID != 4242 || gotPoll != daemonStopPoll || !hadDeadline {
+		t.Fatalf("wait = pid %d poll %s deadline %v", gotPID, gotPoll, hadDeadline)
+	}
+}
+
+func TestShutdownDaemonProcessLegacyStatusUsesUntargetedRequest(t *testing.T) {
+	client := &fakeDaemonShutdownClient{}
+	err := shutdownDaemonProcess(
+		context.Background(),
+		client,
+		&daemon.Status{PID: 73},
+		func(context.Context, int, time.Duration) error { return nil },
+		func(int) (bool, error) { return true, nil },
+	)
+	if err != nil {
+		t.Fatalf("shutdownDaemonProcess legacy: %v", err)
+	}
+	if client.shutdownCalls != 1 || len(client.targets) != 0 {
+		t.Fatalf("legacy calls = %d, targeted calls = %v", client.shutdownCalls, client.targets)
+	}
+}
+
+func TestShutdownDaemonProcessReturnsWaitFailure(t *testing.T) {
+	client := &fakeDaemonShutdownClient{}
+	err := shutdownDaemonProcess(
+		context.Background(),
+		client,
+		&daemon.Status{PID: 8181, InstanceID: "survivor"},
+		func(context.Context, int, time.Duration) error { return context.DeadlineExceeded },
+		func(int) (bool, error) { return true, nil },
+	)
+	if err == nil || !strings.Contains(err.Error(), "process 8181 did not exit") {
+		t.Fatalf("wait failure = %v", err)
+	}
+}
+
+func TestShutdownDaemonProcessNeverFallsBackAfterTargetedFailure(t *testing.T) {
+	client := &fakeDaemonShutdownClient{targetErr: daemon.ErrInstanceMismatch}
+	waitCalled := false
+	err := shutdownDaemonProcess(
+		context.Background(),
+		client,
+		&daemon.Status{PID: 9191, InstanceID: "stale-instance"},
+		func(context.Context, int, time.Duration) error {
+			waitCalled = true
+			return nil
+		},
+		func(int) (bool, error) { return true, nil },
+	)
+	if !errors.Is(err, daemon.ErrInstanceMismatch) {
+		t.Fatalf("targeted failure = %v", err)
+	}
+	if client.shutdownCalls != 0 || waitCalled {
+		t.Fatalf("targeted failure fell back: legacy calls = %d wait = %v", client.shutdownCalls, waitCalled)
+	}
+}
+
+func TestShutdownDaemonProcessAcceptsRequestRaceOnlyWhenCapturedPIDExited(t *testing.T) {
+	client := &fakeDaemonShutdownClient{targetErr: errors.New("socket closed")}
+	err := shutdownDaemonProcess(
+		context.Background(),
+		client,
+		&daemon.Status{PID: 3131, InstanceID: "exited-instance"},
+		func(context.Context, int, time.Duration) error {
+			t.Fatal("wait should not run after the process was already verified gone")
+			return nil
+		},
+		func(pid int) (bool, error) {
+			if pid != 3131 {
+				t.Fatalf("process check PID = %d, want 3131", pid)
+			}
+			return false, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("shutdown race returned error: %v", err)
 	}
 }
 

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -34,9 +34,26 @@ func NewClient(socketPath string) *Client {
 
 // Shutdown sends a shutdown request to the running daemon.
 func (c *Client) Shutdown(ctx context.Context) error {
+	return c.shutdown(ctx, "")
+}
+
+// ShutdownInstance sends a shutdown request only to the daemon with the
+// supplied instance ID. A different daemon at the same socket path rejects
+// the request with ErrInstanceMismatch.
+func (c *Client) ShutdownInstance(ctx context.Context, instanceID string) error {
+	if instanceID == "" {
+		return fmt.Errorf("shutdown instance: instance ID is required")
+	}
+	return c.shutdown(ctx, instanceID)
+}
+
+func (c *Client) shutdown(ctx context.Context, instanceID string) error {
 	req, err := http.NewRequestWithContext(ctx, "POST", "http://meshd/api/v0/shutdown", nil)
 	if err != nil {
 		return fmt.Errorf("creating request: %w", err)
+	}
+	if instanceID != "" {
+		req.Header.Set(instanceIDHeader, instanceID)
 	}
 
 	resp, err := c.httpClient.Do(req)
@@ -47,6 +64,9 @@ func (c *Client) Shutdown(ctx context.Context) error {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusConflict {
+			return fmt.Errorf("%w: %s", ErrInstanceMismatch, string(body))
+		}
 		return fmt.Errorf("daemon returned %d: %s", resp.StatusCode, string(body))
 	}
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -50,6 +50,7 @@ func DefaultSocketPath() string {
 // Status is the JSON response from GET /api/v0/status.
 type Status struct {
 	Running         bool         `json:"running"`
+	InstanceID      string       `json:"instanceID,omitempty"`
 	TUNDevice       string       `json:"tunDevice,omitempty"`
 	MeshIP          string       `json:"meshIP,omitempty"`
 	Network         string       `json:"network,omitempty"`
@@ -80,9 +81,13 @@ type Server struct {
 	statusFn   StatusFunc
 	startTime  time.Time
 
-	mu       sync.Mutex
-	listener net.Listener
-	srv      *http.Server
+	mu         sync.Mutex
+	listener   net.Listener
+	srv        *http.Server
+	socketInfo os.FileInfo
+
+	instanceMu sync.RWMutex
+	instanceID string
 
 	// shutdownCh is closed once when a shutdown request is received.
 	shutdownCh   chan struct{}
@@ -118,6 +123,20 @@ func (s *Server) SocketPath() string {
 	return s.socketPath
 }
 
+// SetInstanceID sets the identifier returned by status and used to target
+// shutdown requests. It should be called before Start.
+func (s *Server) SetInstanceID(instanceID string) {
+	s.instanceMu.Lock()
+	defer s.instanceMu.Unlock()
+	s.instanceID = instanceID
+}
+
+func (s *Server) currentInstanceID() string {
+	s.instanceMu.RLock()
+	defer s.instanceMu.RUnlock()
+	return s.instanceID
+}
+
 // Start begins listening on the Unix socket and serving HTTP requests.
 func (s *Server) Start() error {
 	s.mu.Lock()
@@ -143,22 +162,36 @@ func (s *Server) Start() error {
 	if err != nil {
 		return fmt.Errorf("listening on %s: %w", s.socketPath, err)
 	}
+	unixListener, ok := listener.(*net.UnixListener)
+	if !ok {
+		_ = listener.Close()
+		return fmt.Errorf("listener for %s is not a Unix listener", s.socketPath)
+	}
+	// UnixListener.Close otherwise unlinks by pathname even when that path was
+	// replaced by a newer daemon. Guarded cleanup below owns all unlinking.
+	unixListener.SetUnlinkOnClose(false)
+	socketInfo, err := os.Lstat(s.socketPath)
+	if err != nil {
+		_ = listener.Close()
+		return fmt.Errorf("inspect listening socket %s: %w", s.socketPath, err)
+	}
 
 	uid, gid, changeOwner := sudoSocketOwner(os.Geteuid(), os.Getenv("SUDO_UID"), os.Getenv("SUDO_GID"))
 	if err := secureSocketFile(s.socketPath, uid, gid, changeOwner); err != nil {
-		listener.Close()
-		_ = os.Remove(s.socketPath)
+		_ = listener.Close()
+		_ = removeSocketIfSame(s.socketPath, socketInfo)
 		return err
 	}
 
 	s.listener = listener
+	s.socketInfo = socketInfo
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/v0/shutdown", s.handleShutdown)
 	mux.HandleFunc("GET /api/v0/status", s.handleStatus)
 
 	allowedUIDs := authorizedSocketUIDs(os.Geteuid(), os.Getenv("SUDO_UID"), os.Getenv("SUDO_GID"))
-	s.srv = &http.Server{
+	httpServer := &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if authorized, _ := r.Context().Value(peerAuthorizedContextKey{}).(bool); !authorized {
 				http.Error(w, "forbidden", http.StatusForbidden)
@@ -170,9 +203,10 @@ func (s *Server) Start() error {
 			return context.WithValue(ctx, peerAuthorizedContextKey{}, socketPeerAuthorized(conn, allowedUIDs))
 		},
 	}
+	s.srv = httpServer
 
 	go func() {
-		if err := s.srv.Serve(listener); err != nil && err != http.ErrServerClosed {
+		if err := httpServer.Serve(listener); err != nil && err != http.ErrServerClosed {
 			s.logger.Warn("daemon server error", slog.Any("error", err))
 		}
 	}()
@@ -294,11 +328,35 @@ func (s *Server) Stop() {
 		_ = s.listener.Close()
 	}
 
-	_ = os.Remove(s.socketPath)
+	_ = removeSocketIfSame(s.socketPath, s.socketInfo)
+	s.srv = nil
+	s.listener = nil
+	s.socketInfo = nil
 	s.logger.Info("daemon control socket closed")
 }
 
+func removeSocketIfSame(path string, owned os.FileInfo) error {
+	if owned == nil {
+		return nil
+	}
+	current, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !os.SameFile(owned, current) {
+		return nil
+	}
+	return os.Remove(path)
+}
+
 func (s *Server) handleShutdown(w http.ResponseWriter, r *http.Request) {
+	if target := r.Header.Get(instanceIDHeader); target != s.currentInstanceID() {
+		http.Error(w, ErrInstanceMismatch.Error(), http.StatusConflict)
+		return
+	}
 	s.logger.Info("shutdown requested via control socket")
 
 	w.Header().Set("Content-Type", "application/json")
@@ -321,6 +379,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		status.Running = true
 		status.PID = os.Getpid()
 	}
+	status.InstanceID = s.currentInstanceID()
 	status.Uptime = time.Since(s.startTime).Round(time.Second).String()
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/daemon/instance.go
+++ b/internal/daemon/instance.go
@@ -1,0 +1,24 @@
+package daemon
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+)
+
+const instanceIDHeader = "X-Meshd-Instance-ID"
+
+// ErrInstanceMismatch indicates that a request reached a different daemon
+// instance than the caller intended to control.
+var ErrInstanceMismatch = errors.New("daemon instance does not match")
+
+// NewInstanceID returns a random identifier suitable for matching a launched
+// daemon child with status and shutdown requests.
+func NewInstanceID() (string, error) {
+	var id [16]byte
+	if _, err := rand.Read(id[:]); err != nil {
+		return "", fmt.Errorf("generate daemon instance ID: %w", err)
+	}
+	return hex.EncodeToString(id[:]), nil
+}

--- a/internal/daemon/instance_test.go
+++ b/internal/daemon/instance_test.go
@@ -1,0 +1,72 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestTargetedShutdownRejectsDifferentInstance(t *testing.T) {
+	socket := testSocketPath(t)
+	server := NewServer(socket, nil, nil)
+	server.SetInstanceID("instance-a")
+	if err := server.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer server.Stop()
+
+	client := NewClient(socket)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	status, err := client.GetStatus(ctx)
+	if err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	if status.InstanceID != "instance-a" {
+		t.Fatalf("instance ID = %q, want instance-a", status.InstanceID)
+	}
+
+	err = client.Shutdown(ctx)
+	if !errors.Is(err, ErrInstanceMismatch) {
+		t.Fatalf("headerless shutdown error = %v, want ErrInstanceMismatch", err)
+	}
+	select {
+	case <-server.ShutdownCh():
+		t.Fatal("headerless request signaled instance-bearing server")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	err = client.ShutdownInstance(ctx, "instance-b")
+	if !errors.Is(err, ErrInstanceMismatch) {
+		t.Fatalf("wrong-instance shutdown error = %v, want ErrInstanceMismatch", err)
+	}
+	select {
+	case <-server.ShutdownCh():
+		t.Fatal("wrong-instance request signaled shutdown")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	if err := client.ShutdownInstance(ctx, "instance-a"); err != nil {
+		t.Fatalf("matching shutdown: %v", err)
+	}
+	select {
+	case <-server.ShutdownCh():
+	case <-time.After(time.Second):
+		t.Fatal("matching shutdown did not signal server")
+	}
+}
+
+func TestNewInstanceID(t *testing.T) {
+	first, err := NewInstanceID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := NewInstanceID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 32 || len(second) != 32 || first == second {
+		t.Fatalf("instance IDs = %q, %q", first, second)
+	}
+}

--- a/internal/daemon/lock.go
+++ b/internal/daemon/lock.go
@@ -1,0 +1,75 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// ErrAlreadyRunning is returned when another meshd process holds the
+// instance lock associated with a control socket.
+var ErrAlreadyRunning = errors.New("another meshd instance is already running")
+
+var errInstanceLockContended = errors.New("instance lock is held")
+
+// InstanceLock is a process-scoped, kernel-released singleton lock. The lock
+// file intentionally remains on disk after Close; only the kernel lock, not
+// file existence, represents ownership.
+type InstanceLock struct {
+	path    string
+	release func() error
+	once    sync.Once
+	err     error
+}
+
+// AcquireInstanceLock acquires the singleton lock associated with socketPath.
+// The caller must keep the returned lock open for the daemon's entire
+// lifetime. The kernel releases the lock if the process exits unexpectedly.
+func AcquireInstanceLock(socketPath string) (*InstanceLock, error) {
+	socketPath = strings.TrimSpace(socketPath)
+	if socketPath == "" {
+		return nil, fmt.Errorf("instance lock: socket path is required")
+	}
+	socketPath = filepath.Clean(socketPath)
+	if err := ensurePrivateSocketDirectory(filepath.Dir(socketPath)); err != nil {
+		return nil, fmt.Errorf("instance lock directory: %w", err)
+	}
+
+	path := instanceLockPath(socketPath)
+	release, err := acquirePlatformInstanceLock(path)
+	if errors.Is(err, errInstanceLockContended) {
+		return nil, fmt.Errorf("%w (lock: %s)", ErrAlreadyRunning, path)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("acquire instance lock %s: %w", path, err)
+	}
+	return &InstanceLock{path: path, release: release}, nil
+}
+
+func instanceLockPath(socketPath string) string {
+	return socketPath + ".lock"
+}
+
+// Path returns the persistent lock-file path.
+func (l *InstanceLock) Path() string {
+	if l == nil {
+		return ""
+	}
+	return l.path
+}
+
+// Close releases the singleton lock. It is safe to call Close more than once.
+func (l *InstanceLock) Close() error {
+	if l == nil {
+		return nil
+	}
+	l.once.Do(func() {
+		if l.release != nil {
+			l.err = l.release()
+			l.release = nil
+		}
+	})
+	return l.err
+}

--- a/internal/daemon/lock_test.go
+++ b/internal/daemon/lock_test.go
@@ -1,0 +1,127 @@
+package daemon
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	instanceLockHelperEnv    = "MESHD_TEST_INSTANCE_LOCK_HELPER"
+	instanceLockHelperSocket = "MESHD_TEST_INSTANCE_LOCK_SOCKET"
+)
+
+func TestInstanceLockExclusiveAndReusable(t *testing.T) {
+	socket := testSocketPath(t)
+	first, err := AcquireInstanceLock(socket)
+	if err != nil {
+		t.Fatalf("AcquireInstanceLock first: %v", err)
+	}
+	if first.Path() != socket+".lock" {
+		t.Fatalf("lock path = %q, want %q", first.Path(), socket+".lock")
+	}
+
+	second, err := AcquireInstanceLock(socket)
+	if second != nil || !errors.Is(err, ErrAlreadyRunning) {
+		t.Fatalf("second lock = %v, %v; want ErrAlreadyRunning", second, err)
+	}
+	if !strings.Contains(err.Error(), first.Path()) {
+		t.Fatalf("contention error %q does not identify lock path", err)
+	}
+
+	if err := first.Close(); err != nil {
+		t.Fatalf("Close first lock: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+
+	third, err := AcquireInstanceLock(socket)
+	if err != nil {
+		t.Fatalf("reacquire after Close: %v", err)
+	}
+	if err := third.Close(); err != nil {
+		t.Fatalf("Close third lock: %v", err)
+	}
+
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(instanceLockPath(socket))
+		if err != nil {
+			t.Fatalf("Stat lock file: %v", err)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Fatalf("lock mode = %o, want 0600", info.Mode().Perm())
+		}
+	}
+}
+
+func TestInstanceLockReleasedWhenProcessExits(t *testing.T) {
+	socket := testSocketPath(t)
+	cmd := exec.Command(os.Args[0], "-test.run=^TestInstanceLockHelperProcess$")
+	cmd.Env = append(os.Environ(),
+		instanceLockHelperEnv+"=1",
+		instanceLockHelperSocket+"="+socket,
+	)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	scanner := bufio.NewScanner(stdout)
+	if !scanner.Scan() || scanner.Text() != "locked" {
+		t.Fatalf("helper output = %q, error = %v", scanner.Text(), scanner.Err())
+	}
+	if lock, err := AcquireInstanceLock(socket); lock != nil || !errors.Is(err, ErrAlreadyRunning) {
+		t.Fatalf("lock while helper alive = %v, %v; want contention", lock, err)
+	}
+
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill helper: %v", err)
+	}
+	if err := cmd.Wait(); err == nil {
+		t.Fatal("killed helper exited successfully")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		lock, err := AcquireInstanceLock(socket)
+		if err == nil {
+			if closeErr := lock.Close(); closeErr != nil {
+				t.Fatalf("Close recovered lock: %v", closeErr)
+			}
+			break
+		}
+		if !errors.Is(err, ErrAlreadyRunning) || time.Now().After(deadline) {
+			t.Fatalf("reacquire after helper exit: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestInstanceLockHelperProcess(t *testing.T) {
+	if os.Getenv(instanceLockHelperEnv) != "1" {
+		return
+	}
+	lock, err := AcquireInstanceLock(os.Getenv(instanceLockHelperSocket))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "helper lock: %v\n", err)
+		os.Exit(2)
+	}
+	defer lock.Close()
+	fmt.Println("locked")
+	select {}
+}

--- a/internal/daemon/lock_unix.go
+++ b/internal/daemon/lock_unix.go
@@ -1,0 +1,72 @@
+//go:build linux || darwin || freebsd
+
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func acquirePlatformInstanceLock(path string) (func() error, error) {
+	fd, err := unix.Open(path, unix.O_CREAT|unix.O_RDWR|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(fd), path)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("create lock file handle")
+	}
+	closeFile := func() { _ = file.Close() }
+
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		closeFile()
+		return nil, fmt.Errorf("inspect lock file: %w", err)
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFREG {
+		closeFile()
+		return nil, fmt.Errorf("lock path is not a regular file")
+	}
+	if stat.Nlink != 1 {
+		closeFile()
+		return nil, fmt.Errorf("lock file must have exactly one link")
+	}
+
+	if err := unix.Flock(fd, unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		closeFile()
+		if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+			return nil, errInstanceLockContended
+		}
+		return nil, err
+	}
+	locked := true
+	cleanup := func() {
+		if locked {
+			_ = unix.Flock(fd, unix.LOCK_UN)
+			locked = false
+		}
+		closeFile()
+	}
+
+	if err := unix.Fchmod(fd, 0o600); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("secure lock file permissions: %w", err)
+	}
+	if uid, gid, ok := sudoSocketOwner(os.Geteuid(), os.Getenv("SUDO_UID"), os.Getenv("SUDO_GID")); ok {
+		if err := unix.Fchown(fd, uid, gid); err != nil {
+			cleanup()
+			return nil, fmt.Errorf("set lock file owner: %w", err)
+		}
+	}
+
+	return func() error {
+		unlockErr := unix.Flock(fd, unix.LOCK_UN)
+		locked = false
+		closeErr := file.Close()
+		return errors.Join(unlockErr, closeErr)
+	}, nil
+}

--- a/internal/daemon/lock_windows.go
+++ b/internal/daemon/lock_windows.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+package daemon
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func acquirePlatformInstanceLock(path string) (func() error, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		if errors.Is(err, windows.ERROR_SHARING_VIOLATION) || errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+			return nil, errInstanceLockContended
+		}
+		return nil, err
+	}
+
+	overlapped := &windows.Overlapped{}
+	err = windows.LockFileEx(
+		windows.Handle(file.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		1,
+		0,
+		overlapped,
+	)
+	if err != nil {
+		_ = file.Close()
+		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) || errors.Is(err, windows.ERROR_IO_PENDING) {
+			return nil, errInstanceLockContended
+		}
+		return nil, err
+	}
+
+	return func() error {
+		unlockErr := windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, overlapped)
+		closeErr := file.Close()
+		return errors.Join(unlockErr, closeErr)
+	}, nil
+}

--- a/internal/daemon/process.go
+++ b/internal/daemon/process.go
@@ -1,0 +1,46 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+const defaultProcessPollInterval = 100 * time.Millisecond
+
+// ProcessAlive reports whether pid still identifies a live process. Lack of
+// permission to inspect an elevated process counts as alive.
+func ProcessAlive(pid int) (bool, error) {
+	if pid <= 0 {
+		return false, fmt.Errorf("process PID must be positive")
+	}
+	return processAlivePlatform(pid)
+}
+
+// WaitForProcessExit waits until pid is no longer alive. It deliberately does
+// not consult the control socket, which may disappear or be replaced while the
+// original daemon is still shutting down.
+func WaitForProcessExit(ctx context.Context, pid int, pollInterval time.Duration) error {
+	if pollInterval <= 0 {
+		pollInterval = defaultProcessPollInterval
+	}
+	for {
+		alive, err := ProcessAlive(pid)
+		if err != nil {
+			return fmt.Errorf("check process %d: %w", pid, err)
+		}
+		if !alive {
+			return nil
+		}
+
+		timer := time.NewTimer(pollInterval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return fmt.Errorf("wait for process %d exit: %w", pid, ctx.Err())
+		case <-timer.C:
+		}
+	}
+}

--- a/internal/daemon/process_test.go
+++ b/internal/daemon/process_test.go
@@ -1,0 +1,44 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestWaitForProcessExitTimesOutWhileExactPIDLives(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	err := WaitForProcessExit(ctx, os.Getpid(), time.Millisecond)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("WaitForProcessExit error = %v, want deadline exceeded", err)
+	}
+}
+
+func TestWaitForProcessExitReturnsAfterExit(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestExitedProcessHelper$")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	pid := cmd.Process.Pid
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("helper exit: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := WaitForProcessExit(ctx, pid, time.Millisecond); err != nil {
+		t.Fatalf("WaitForProcessExit: %v", err)
+	}
+}
+
+func TestExitedProcessHelper(t *testing.T) {}
+
+func TestProcessAliveRejectsInvalidPID(t *testing.T) {
+	if _, err := ProcessAlive(0); err == nil {
+		t.Fatal("ProcessAlive accepted PID 0")
+	}
+}

--- a/internal/daemon/process_unix.go
+++ b/internal/daemon/process_unix.go
@@ -1,0 +1,23 @@
+//go:build linux || darwin || freebsd
+
+package daemon
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+func processAlivePlatform(pid int) (bool, error) {
+	err := unix.Kill(pid, 0)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, unix.ESRCH):
+		return false, nil
+	case errors.Is(err, unix.EPERM):
+		return true, nil
+	default:
+		return false, err
+	}
+}

--- a/internal/daemon/process_windows.go
+++ b/internal/daemon/process_windows.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package daemon
+
+import (
+	"errors"
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+func processAlivePlatform(pid int) (bool, error) {
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(pid))
+	if err != nil {
+		switch {
+		case errors.Is(err, windows.ERROR_INVALID_PARAMETER), errors.Is(err, windows.ERROR_NOT_FOUND):
+			return false, nil
+		case errors.Is(err, windows.ERROR_ACCESS_DENIED):
+			return true, nil
+		default:
+			return false, err
+		}
+	}
+	defer windows.CloseHandle(handle)
+
+	result, err := windows.WaitForSingleObject(handle, 0)
+	if err != nil {
+		return false, err
+	}
+	switch result {
+	case windows.WAIT_OBJECT_0:
+		return false, nil
+	case uint32(windows.WAIT_TIMEOUT):
+		return true, nil
+	default:
+		return false, fmt.Errorf("unexpected process wait result %#x", result)
+	}
+}

--- a/internal/daemon/socket_ownership_test.go
+++ b/internal/daemon/socket_ownership_test.go
@@ -1,0 +1,50 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestDetachedServerStopPreservesReplacementSocket(t *testing.T) {
+	socket := testSocketPath(t)
+	first := NewServer(socket, nil, nil)
+	first.SetInstanceID("first")
+	if err := first.Start(); err != nil {
+		t.Fatalf("start first server: %v", err)
+	}
+	defer first.Stop()
+
+	// Detach the first listener from the filesystem namespace, then bind a
+	// replacement at the same textual path. ss still reports that path for the
+	// detached listener, but only the replacement is reachable by new clients.
+	if err := os.Remove(socket); err != nil {
+		t.Fatalf("detach first socket: %v", err)
+	}
+	second := NewServer(socket, nil, nil)
+	second.SetInstanceID("second")
+	if err := second.Start(); err != nil {
+		t.Fatalf("start replacement server: %v", err)
+	}
+	defer second.Stop()
+
+	first.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	status, err := NewClient(socket).GetStatus(ctx)
+	if err != nil {
+		t.Fatalf("replacement socket was removed by first Stop: %v", err)
+	}
+	if status.InstanceID != "second" {
+		t.Fatalf("reachable instance = %q, want second", status.InstanceID)
+	}
+
+	// A repeated Stop must not retain stale inode identity that could match a
+	// future filesystem entry after inode reuse.
+	first.Stop()
+	if _, err := os.Lstat(socket); err != nil {
+		t.Fatalf("repeated first Stop removed replacement: %v", err)
+	}
+}

--- a/internal/trayapp/service.go
+++ b/internal/trayapp/service.go
@@ -3,7 +3,6 @@ package trayapp
 import (
 	"context"
 	"fmt"
-	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,6 +19,8 @@ import (
 const defaultDisconnectPoll = 150 * time.Millisecond
 
 type commandRunner func(context.Context, string, []string, []string) ([]byte, error)
+type processWaiter func(context.Context, int, time.Duration) error
+type processChecker func(int) (bool, error)
 
 // Service performs the side effects requested from the tray menu.
 type Service struct {
@@ -31,6 +32,8 @@ type Service struct {
 	launchConnect  commandRunner
 	openURL        func(string) error
 	writeClipboard func(context.Context, string) error
+	waitForExit    processWaiter
+	processAlive   processChecker
 	disconnectPoll time.Duration
 }
 
@@ -46,6 +49,8 @@ func NewService(profile string) *Service {
 		launchConnect:  connectCommand,
 		openURL:        openurl.Open,
 		writeClipboard: clipboard.WriteText,
+		waitForExit:    daemon.WaitForProcessExit,
+		processAlive:   daemon.ProcessAlive,
 		disconnectPoll: defaultDisconnectPoll,
 	}
 }
@@ -79,15 +84,44 @@ func (s *Service) Connect(ctx context.Context) error {
 	return nil
 }
 
-// Disconnect requests a graceful daemon shutdown and waits until its control
-// socket no longer accepts connections.
+// Disconnect requests a graceful shutdown of the observed daemon instance and
+// waits for that exact process to exit.
 func (s *Service) Disconnect(ctx context.Context) error {
-	if err := s.client.Shutdown(ctx); err != nil {
+	status, err := s.client.GetStatus(ctx)
+	if err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("read meshd status: %w", ctx.Err())
+		}
+		if !s.client.IsRunning() {
+			return nil
+		}
+		return fmt.Errorf("read meshd status: %w", err)
+	}
+	if status == nil || status.PID <= 0 {
+		return fmt.Errorf("meshd status did not include a valid process ID; refusing an unverified disconnect")
+	}
+
+	if status.InstanceID != "" {
+		err = s.client.ShutdownInstance(ctx, status.InstanceID)
+	} else {
+		// A daemon already running during an in-place upgrade may predate
+		// instance IDs. The exact captured PID is still verified below.
+		err = s.client.Shutdown(ctx)
+	}
+	if err != nil {
 		if ctx.Err() != nil {
 			return fmt.Errorf("request shutdown: %w", ctx.Err())
 		}
-		if !socketReachable(ctx, s.socket) {
+		processAlive := s.processAlive
+		if processAlive == nil {
+			processAlive = daemon.ProcessAlive
+		}
+		alive, aliveErr := processAlive(status.PID)
+		if aliveErr == nil && !alive {
 			return nil
+		}
+		if aliveErr != nil {
+			return fmt.Errorf("request shutdown: %w (could not verify process %d: %v)", err, status.PID, aliveErr)
 		}
 		return fmt.Errorf("request shutdown: %w", err)
 	}
@@ -96,34 +130,14 @@ func (s *Service) Disconnect(ctx context.Context) error {
 	if poll <= 0 {
 		poll = defaultDisconnectPoll
 	}
-	ticker := time.NewTicker(poll)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("wait for meshd shutdown: %w", ctx.Err())
-		case <-ticker.C:
-			if !socketReachable(ctx, s.socket) {
-				if ctx.Err() != nil {
-					return fmt.Errorf("wait for meshd shutdown: %w", ctx.Err())
-				}
-				return nil
-			}
-		}
+	waitForExit := s.waitForExit
+	if waitForExit == nil {
+		waitForExit = daemon.WaitForProcessExit
 	}
-}
-
-func socketReachable(ctx context.Context, socketPath string) bool {
-	if ctx.Err() != nil {
-		return false
+	if err := waitForExit(ctx, status.PID, poll); err != nil {
+		return fmt.Errorf("wait for meshd process %d shutdown: %w", status.PID, err)
 	}
-	var dialer net.Dialer
-	conn, err := dialer.DialContext(ctx, "unix", socketPath)
-	if err != nil {
-		return false
-	}
-	_ = conn.Close()
-	return true
+	return nil
 }
 
 // DashboardURL builds the dashboard URL from live daemon context when

--- a/internal/trayapp/service_test.go
+++ b/internal/trayapp/service_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -51,9 +52,10 @@ func TestServiceConnectReportsCommandOutput(t *testing.T) {
 	}
 }
 
-func TestServiceDisconnectWaitsForSocketToClose(t *testing.T) {
+func TestServiceDisconnectWaitsForExactProcess(t *testing.T) {
 	socket := privateSocketPath(t)
 	server := daemon.NewServer(socket, nil, nil)
+	server.SetInstanceID("tray-instance")
 	if err := server.Start(); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -67,10 +69,20 @@ func TestServiceDisconnectWaitsForSocketToClose(t *testing.T) {
 	service.socket = socket
 	service.client = daemon.NewClient(socket)
 	service.disconnectPoll = time.Millisecond
+	var gotPID int
+	var gotPoll time.Duration
+	service.waitForExit = func(_ context.Context, pid int, poll time.Duration) error {
+		gotPID = pid
+		gotPoll = poll
+		return nil
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	if err := service.Disconnect(ctx); err != nil {
 		t.Fatalf("Disconnect: %v", err)
+	}
+	if gotPID != os.Getpid() || gotPoll != time.Millisecond {
+		t.Fatalf("process wait = pid %d poll %s, want pid %d poll 1ms", gotPID, gotPoll, os.Getpid())
 	}
 }
 
@@ -109,7 +121,11 @@ func TestServiceDisconnectDoesNotHideResponsiveServerError(t *testing.T) {
 	}
 	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/v0/status" {
-			_, _ = w.Write([]byte("{"))
+			_ = json.NewEncoder(w).Encode(daemon.Status{
+				Running:    true,
+				PID:        os.Getpid(),
+				InstanceID: "responsive-instance",
+			})
 			return
 		}
 		http.Error(w, "shutdown rejected", http.StatusInternalServerError)
@@ -124,6 +140,102 @@ func TestServiceDisconnectDoesNotHideResponsiveServerError(t *testing.T) {
 	defer cancel()
 	if err := service.Disconnect(ctx); err == nil || !strings.Contains(err.Error(), "shutdown rejected") {
 		t.Fatalf("Disconnect error = %v, want responsive server error", err)
+	}
+}
+
+func TestServiceDisconnectAcceptsRequestRaceWhenCapturedProcessExited(t *testing.T) {
+	socket := privateSocketPath(t)
+	listener, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v0/status" {
+			_ = json.NewEncoder(w).Encode(daemon.Status{
+				Running:    true,
+				PID:        5151,
+				InstanceID: "exited-instance",
+			})
+			return
+		}
+		http.Error(w, "socket closing", http.StatusInternalServerError)
+	})}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Close() })
+
+	service := NewService("")
+	service.socket = socket
+	service.client = daemon.NewClient(socket)
+	service.processAlive = func(pid int) (bool, error) {
+		if pid != 5151 {
+			t.Fatalf("process check PID = %d, want 5151", pid)
+		}
+		return false, nil
+	}
+	if err := service.Disconnect(context.Background()); err != nil {
+		t.Fatalf("Disconnect request race: %v", err)
+	}
+}
+
+func TestServiceDisconnectTargetsObservedInstance(t *testing.T) {
+	socket := privateSocketPath(t)
+	listener, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	targets := make(chan string, 1)
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v0/status" {
+			_ = json.NewEncoder(w).Encode(daemon.Status{
+				Running:    true,
+				PID:        4242,
+				InstanceID: "observed-instance",
+			})
+			return
+		}
+		targets <- r.Header.Get("X-Meshd-Instance-ID")
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "shutting down"})
+	})}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Close() })
+
+	service := NewService("")
+	service.socket = socket
+	service.client = daemon.NewClient(socket)
+	var gotPID int
+	service.waitForExit = func(_ context.Context, pid int, _ time.Duration) error {
+		gotPID = pid
+		return nil
+	}
+	if err := service.Disconnect(context.Background()); err != nil {
+		t.Fatalf("Disconnect: %v", err)
+	}
+	if got := <-targets; got != "observed-instance" {
+		t.Fatalf("shutdown target = %q, want observed-instance", got)
+	}
+	if gotPID != 4242 {
+		t.Fatalf("process wait PID = %d, want 4242", gotPID)
+	}
+}
+
+func TestServiceDisconnectReportsProcessWaitFailure(t *testing.T) {
+	socket := privateSocketPath(t)
+	server := daemon.NewServer(socket, nil, nil)
+	server.SetInstanceID("surviving-instance")
+	if err := server.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer server.Stop()
+
+	service := NewService("")
+	service.socket = socket
+	service.client = daemon.NewClient(socket)
+	service.waitForExit = func(context.Context, int, time.Duration) error {
+		return context.DeadlineExceeded
+	}
+	err := service.Disconnect(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "process "+strconv.Itoa(os.Getpid())) {
+		t.Fatalf("Disconnect wait error = %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- acquire a kernel-released singleton lock before creating the engine or TUN, with Unix and Windows implementations
- identify each launched daemon with a random instance ID and require exact instance matching for startup and shutdown
- wait for the captured daemon PID to exit instead of treating socket disappearance as success in the CLI and tray
- disable automatic UnixListener pathname unlinking and remove a socket only when it is still the server-owned filesystem entry
- restore default signal handling before engine teardown so a later termination signal is not swallowed

This prevents duplicate/pathname-detached daemons from coexisting and retaining a TUN while another process owns the visible control socket.

Closes #243.

## Validation

- go build ./...
- go vet ./...
- go test ./... -count=1 -race
- focused lifecycle regressions repeated 10-20 times under race detection
- Windows amd64, Darwin arm64, and FreeBSD amd64 cross-compilation
- two independent blocker-only reviews

All required checks pass locally. No dependencies or vendored files changed.