### PR TITLE
fix: wait for mesh routing readiness

### DIFF
--- a/cmd/meshd/main.go
+++ b/cmd/meshd/main.go
@@ -2819,17 +2819,44 @@ func cmdStatus(ctx context.Context, args []string, flagProfile string) error {
 			fmt.Printf("\nDaemon: running (status query failed: %v)\n", err)
 		} else {
 			fmt.Printf("\nDaemon:\n")
-			fmt.Printf("  Running: yes (PID %d)\n", live.PID)
-			fmt.Printf("  Uptime: %s\n", live.Uptime)
-			if live.TUNDevice != "" {
-				fmt.Printf("  TUN device: %s\n", live.TUNDevice)
-			}
+			printDaemonRuntimeStatus(os.Stdout, live)
 		}
 	} else {
 		fmt.Printf("\nDaemon: not running\n")
 	}
 
 	return nil
+}
+
+func printDaemonRuntimeStatus(w io.Writer, live *daemon.Status) {
+	fmt.Fprintf(w, "  Running: yes (PID %d)\n", live.PID)
+	fmt.Fprintf(w, "  Uptime: %s\n", live.Uptime)
+	if live.TUNDevice != "" {
+		fmt.Fprintf(w, "  TUN device: %s\n", live.TUNDevice)
+	}
+	if live.RoutingRequired {
+		readiness := "syncing"
+		degraded := live.RoutingReady && routingPhaseIs(live, engine.RoutingPhaseError)
+		if live.RoutingReady {
+			readiness = "ready"
+		} else if routingPhaseIs(live, engine.RoutingPhaseError) {
+			readiness = "error"
+		}
+		if phase := strings.TrimSpace(live.RoutingPhase); degraded && phase != "" {
+			fmt.Fprintf(w, "  Routing: %s (degraded; phase: %s)\n", readiness, phase)
+		} else if degraded {
+			fmt.Fprintf(w, "  Routing: %s (degraded)\n", readiness)
+		} else if phase != "" {
+			fmt.Fprintf(w, "  Routing: %s (phase: %s)\n", readiness, phase)
+		} else {
+			fmt.Fprintf(w, "  Routing: %s\n", readiness)
+		}
+		if lastError := strings.TrimSpace(live.RoutingError); lastError != "" {
+			fmt.Fprintf(w, "  Last routing error: %s\n", lastError)
+		}
+	} else if live.RoutingReady {
+		fmt.Fprintln(w, "  Routing: userspace ready")
+	}
 }
 
 type doctorLevel string
@@ -3005,6 +3032,9 @@ func collectDoctorChecks(ctx context.Context, flagProfile string) []doctorCheck 
 		})
 		return checks
 	}
+	if routingStillSyncing(live) {
+		return checks
+	}
 
 	checks = append(checks, interfaceDoctorChecks(ctx, live.TUNDevice, firstNonEmpty(live.MeshIP, ns.MeshIP))...)
 	routeChecks := peerRouteDoctorChecks(ctx, stateDir, ns, identity, meta, selfNodeDID, live.TUNDevice)
@@ -3124,7 +3154,61 @@ func daemonDoctorChecks(ctx context.Context, ns *state.NetworkState) (*daemon.St
 			Next:   "Run 'meshd down' and then 'meshd up'.",
 		})
 	}
+	if live.RoutingRequired {
+		detail := strings.TrimSpace(live.RoutingPhase)
+		if lastError := strings.TrimSpace(live.RoutingError); lastError != "" {
+			if detail != "" {
+				detail += ": "
+			}
+			detail += lastError
+		}
+		switch {
+		case live.RoutingReady && routingPhaseIs(live, engine.RoutingPhaseError):
+			checks = append(checks, doctorCheck{
+				Level:  doctorWarn,
+				Title:  "Mesh routing ready (degraded)",
+				Detail: detail,
+				Next:   "Installed routes remain active; meshd will retry the failed control refresh automatically.",
+			})
+		case live.RoutingReady:
+			checks = append(checks, doctorCheck{
+				Level:  doctorOK,
+				Title:  "Mesh routing ready",
+				Detail: detail,
+			})
+		case routingPhaseIs(live, engine.RoutingPhaseError):
+			checks = append(checks, doctorCheck{
+				Level:  doctorFail,
+				Title:  "Mesh routing error",
+				Detail: detail,
+				Next:   "Fix the reported routing error; meshd will keep retrying. After correcting it, run 'meshd down' and then 'meshd up'.",
+			})
+		case routingPhaseIs(live, engine.RoutingPhaseSyncing):
+			checks = append(checks, doctorCheck{
+				Level:  doctorWarn,
+				Title:  "Mesh routing still syncing",
+				Detail: detail,
+				Next:   "Keep meshd running and retry 'meshd doctor' after synchronization completes.",
+			})
+		default:
+			checks = append(checks, doctorCheck{
+				Level:  doctorWarn,
+				Title:  "Mesh routing not ready",
+				Detail: detail,
+				Next:   "Inspect the daemon log and retry 'meshd doctor'.",
+			})
+		}
+	}
 	return live, checks
+}
+
+func routingPhaseIs(status *daemon.Status, phase string) bool {
+	return status != nil && strings.EqualFold(strings.TrimSpace(status.RoutingPhase), phase)
+}
+
+func routingStillSyncing(status *daemon.Status) bool {
+	return status != nil && status.RoutingRequired && !status.RoutingReady &&
+		routingPhaseIs(status, engine.RoutingPhaseSyncing)
 }
 
 func interfaceDoctorChecks(ctx context.Context, tunName string, meshIP string) []doctorCheck {
@@ -3631,6 +3715,7 @@ func waitForDaemonStart(
 	ticker := time.NewTicker(250 * time.Millisecond)
 	defer ticker.Stop()
 	var lastErr error
+	var liveStatus *daemon.Status
 	for {
 		status, err := client.GetStatus(ctx)
 		if err == nil {
@@ -3645,9 +3730,14 @@ func waitForDaemonStart(
 			if err := validateDaemonStartStatus(status, requireTUN, instanceID); err != nil {
 				return nil, err
 			}
-			return status, nil
+			liveStatus = status
+			lastErr = nil
+			if !requireTUN || status.RoutingReady {
+				return status, nil
+			}
+		} else {
+			lastErr = err
 		}
-		lastErr = err
 
 		select {
 		case <-ctx.Done():
@@ -3658,6 +3748,9 @@ func waitForDaemonStart(
 			}
 			return nil, fmt.Errorf("background meshd exited before opening its control socket")
 		case <-timer.C:
+			if liveStatus != nil && requireTUN && !liveStatus.RoutingReady {
+				return nil, routingSyncTimeoutError(liveStatus, timeout)
+			}
 			if lastErr != nil {
 				return nil, fmt.Errorf("daemon did not start within %s: %w", timeout, lastErr)
 			}
@@ -3677,7 +3770,24 @@ func validateDaemonStartStatus(status *daemon.Status, requireTUN bool, instanceI
 	if requireTUN && status.TUNDevice == "" {
 		return fmt.Errorf("daemon started without the required TUN device")
 	}
+	if requireTUN && !status.RoutingRequired {
+		return fmt.Errorf("daemon did not report the required system-routing state")
+	}
 	return nil
+}
+
+func routingSyncTimeoutError(status *daemon.Status, timeout time.Duration) error {
+	message := fmt.Sprintf("daemon running, mesh still syncing after %s", timeout)
+	if routingPhaseIs(status, engine.RoutingPhaseError) {
+		message = fmt.Sprintf("daemon running, mesh routing failed after %s", timeout)
+	}
+	if phase := strings.TrimSpace(status.RoutingPhase); phase != "" {
+		message += fmt.Sprintf(" (phase: %s)", phase)
+	}
+	if lastError := strings.TrimSpace(status.RoutingError); lastError != "" {
+		message += ": " + lastError
+	}
+	return errors.New(message)
 }
 
 func resolveDaemonInstanceID(backgroundChild bool, startupID string) (string, error) {
@@ -4026,6 +4136,7 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 
 	// ── Step 4: Start the daemon control socket ────────────────────
 	daemonSrv := daemon.NewServer(socketPath, func() daemon.Status {
+		routing := eng.RoutingStatus()
 		return daemon.Status{
 			TUNDevice:       eng.TUNDeviceName(),
 			MeshIP:          ns.MeshIP,
@@ -4033,6 +4144,10 @@ func cmdUp(ctx context.Context, args []string, flagProfile string) error {
 			OwnerDID:        networkOwnerDID(ns, meta.OwnerDID),
 			NetworkRecordID: ns.NetworkRecordID,
 			Peers:           daemonPeerStatuses(eng.PeerSnapshots()),
+			RoutingRequired: routing.Required,
+			RoutingReady:    routing.Ready,
+			RoutingPhase:    routing.Phase,
+			RoutingError:    routing.LastError,
 		}
 	}, logger)
 	daemonSrv.SetInstanceID(instanceID)

--- a/cmd/meshd/main_test.go
+++ b/cmd/meshd/main_test.go
@@ -13,6 +13,7 @@ import (
 	"net/netip"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -261,6 +262,60 @@ func TestPrintDoctorCheck(t *testing.T) {
 	}
 }
 
+func TestPrintDaemonRuntimeStatusIncludesRoutingState(t *testing.T) {
+	var output bytes.Buffer
+	printDaemonRuntimeStatus(&output, &daemon.Status{
+		PID:             42,
+		Uptime:          "10s",
+		TUNDevice:       "meshd0",
+		RoutingRequired: true,
+		RoutingReady:    false,
+		RoutingPhase:    "syncing",
+		RoutingError:    "waiting for network map",
+	})
+
+	for _, want := range []string{
+		"Running: yes (PID 42)",
+		"TUN device: meshd0",
+		"Routing: syncing (phase: syncing)",
+		"Last routing error: waiting for network map",
+	} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("daemon status output missing %q:\n%s", want, output.String())
+		}
+	}
+
+	output.Reset()
+	printDaemonRuntimeStatus(&output, &daemon.Status{RoutingReady: true, RoutingPhase: "userspace"})
+	if !strings.Contains(output.String(), "Routing: userspace ready") {
+		t.Fatalf("userspace status output = %q", output.String())
+	}
+
+	output.Reset()
+	printDaemonRuntimeStatus(&output, &daemon.Status{
+		RoutingRequired: true,
+		RoutingReady:    true,
+		RoutingPhase:    "error",
+		RoutingError:    "control map unavailable",
+	})
+	if !strings.Contains(output.String(), "Routing: ready (degraded; phase: error)") ||
+		!strings.Contains(output.String(), "Last routing error: control map unavailable") {
+		t.Fatalf("degraded routing status output = %q", output.String())
+	}
+
+	output.Reset()
+	printDaemonRuntimeStatus(&output, &daemon.Status{
+		RoutingRequired: true,
+		RoutingReady:    false,
+		RoutingPhase:    "error",
+		RoutingError:    "route installation failed",
+	})
+	if !strings.Contains(output.String(), "Routing: error (phase: error)") ||
+		!strings.Contains(output.String(), "Last routing error: route installation failed") {
+		t.Fatalf("failed routing status output = %q", output.String())
+	}
+}
+
 func TestBuildAdminURL(t *testing.T) {
 	rawURL := buildAdminURL("https://admin.meshd.sh/", adminContext{
 		OwnerDID:        "did:dht:wallet",
@@ -327,6 +382,81 @@ func TestCollectDoctorChecksNoProfile(t *testing.T) {
 	}
 	if !doctorHasLevel(checks, doctorFail) {
 		t.Fatal("expected doctor failure level")
+	}
+}
+
+func TestDaemonDoctorChecksReportsRoutingReadiness(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		ready     bool
+		phase     string
+		lastError string
+		level     doctorLevel
+		title     string
+	}{
+		{
+			name:      "syncing",
+			phase:     "syncing",
+			lastError: "waiting for network map",
+			level:     doctorWarn,
+			title:     "Mesh routing still syncing",
+		},
+		{
+			name:  "ready",
+			ready: true,
+			phase: "ready",
+			level: doctorOK,
+			title: "Mesh routing ready",
+		},
+		{
+			name:      "degraded",
+			ready:     true,
+			phase:     "error",
+			lastError: "loading control map: permission denied",
+			level:     doctorWarn,
+			title:     "Mesh routing ready (degraded)",
+		},
+		{
+			name:      "error",
+			phase:     "error",
+			lastError: "installing routes: permission denied",
+			level:     doctorFail,
+			title:     "Mesh routing error",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := privateDaemonSocketDir(t)
+			t.Setenv("ENBOX_HOME", home)
+			server := daemon.NewServer(daemon.DefaultSocketPath(), func() daemon.Status {
+				return daemon.Status{
+					RoutingRequired: true,
+					RoutingReady:    tc.ready,
+					RoutingPhase:    tc.phase,
+					RoutingError:    tc.lastError,
+				}
+			}, nil)
+			if err := server.Start(); err != nil {
+				t.Fatalf("Start daemon server: %v", err)
+			}
+			defer server.Stop()
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			_, checks := daemonDoctorChecks(ctx, nil)
+			for _, check := range checks {
+				if check.Title != tc.title {
+					continue
+				}
+				if check.Level != tc.level || (tc.lastError != "" && !strings.Contains(check.Detail, tc.lastError)) {
+					t.Fatalf("routing check = %+v", check)
+				}
+				if tc.level != doctorOK && strings.TrimSpace(check.Next) == "" {
+					t.Fatalf("routing check has no actionable next step: %+v", check)
+				}
+				return
+			}
+			t.Fatalf("checks = %+v, want %q", checks, tc.title)
+		})
 	}
 }
 
@@ -742,7 +872,7 @@ func TestValidateDaemonStartStatusRequiresRequestedTUN(t *testing.T) {
 	if err := validateDaemonStartStatus(&daemon.Status{}, false, ""); err != nil {
 		t.Fatalf("explicit userspace status rejected: %v", err)
 	}
-	if err := validateDaemonStartStatus(&daemon.Status{TUNDevice: "meshd0"}, true, ""); err != nil {
+	if err := validateDaemonStartStatus(&daemon.Status{TUNDevice: "meshd0", RoutingRequired: true}, true, ""); err != nil {
 		t.Fatalf("TUN status rejected: %v", err)
 	}
 	if err := validateDaemonStartStatus(&daemon.Status{}, true, ""); err == nil ||
@@ -752,18 +882,212 @@ func TestValidateDaemonStartStatusRequiresRequestedTUN(t *testing.T) {
 }
 
 func TestValidateDaemonStartStatusRequiresMatchingInstance(t *testing.T) {
-	status := &daemon.Status{InstanceID: "different-instance", TUNDevice: "meshd0"}
+	status := &daemon.Status{InstanceID: "different-instance", TUNDevice: "meshd0", RoutingRequired: true}
 	err := validateDaemonStartStatus(status, true, "launched-instance")
 	if err == nil || !strings.Contains(err.Error(), "startup instance mismatch") {
 		t.Fatalf("instance mismatch error = %v", err)
 	}
 	if err := validateDaemonStartStatus(
-		&daemon.Status{InstanceID: "launched-instance", TUNDevice: "meshd0"},
+		&daemon.Status{InstanceID: "launched-instance", TUNDevice: "meshd0", RoutingRequired: true},
 		true,
 		"launched-instance",
 	); err != nil {
 		t.Fatalf("matching startup instance rejected: %v", err)
 	}
+}
+
+func TestWaitForDaemonStartWaitsForRoutingReady(t *testing.T) {
+	socket := filepath.Join(privateDaemonSocketDir(t), "meshd.sock")
+	readyAt := time.Now().Add(400 * time.Millisecond)
+	server := daemon.NewServer(socket, func() daemon.Status {
+		ready := time.Now().After(readyAt)
+		phase := "syncing"
+		if ready {
+			phase = "ready"
+		}
+		return daemon.Status{
+			TUNDevice:       "meshd0",
+			RoutingRequired: true,
+			RoutingReady:    ready,
+			RoutingPhase:    phase,
+		}
+	}, nil)
+	server.SetInstanceID("startup-instance")
+	if err := server.Start(); err != nil {
+		t.Fatalf("Start daemon server: %v", err)
+	}
+	defer server.Stop()
+
+	started := time.Now()
+	status, err := waitForDaemonStart(
+		context.Background(), socket, 2*time.Second, true, "startup-instance", make(chan error),
+	)
+	if err != nil {
+		t.Fatalf("waitForDaemonStart: %v", err)
+	}
+	if status == nil || !status.RoutingReady {
+		t.Fatalf("startup status = %+v, want routing ready", status)
+	}
+	if elapsed := time.Since(started); elapsed < 350*time.Millisecond {
+		t.Fatalf("startup returned before delayed routing readiness after %s", elapsed)
+	}
+}
+
+func TestWaitForDaemonStartReportsRunningSyncTimeout(t *testing.T) {
+	socket := filepath.Join(privateDaemonSocketDir(t), "meshd.sock")
+	server := daemon.NewServer(socket, func() daemon.Status {
+		return daemon.Status{
+			TUNDevice:       "meshd0",
+			RoutingRequired: true,
+			RoutingReady:    false,
+			RoutingPhase:    "syncing",
+			RoutingError:    "no usable network map addresses yet",
+		}
+	}, nil)
+	server.SetInstanceID("startup-instance")
+	if err := server.Start(); err != nil {
+		t.Fatalf("Start daemon server: %v", err)
+	}
+	defer server.Stop()
+	child, childExit := startStartupChildProcess(t)
+
+	_, err := waitForDaemonStart(
+		context.Background(), socket, 50*time.Millisecond, true, "startup-instance", childExit,
+	)
+	if err == nil || !strings.Contains(err.Error(), "daemon running, mesh still syncing") ||
+		!strings.Contains(err.Error(), "no usable network map addresses yet") {
+		t.Fatalf("sync timeout error = %v", err)
+	}
+	if !daemon.NewClient(socket).IsRunning() {
+		t.Fatal("startup timeout stopped the still-syncing daemon")
+	}
+	select {
+	case exitErr := <-childExit:
+		t.Fatalf("startup timeout stopped or reaped the child: %v", exitErr)
+	default:
+	}
+	alive, aliveErr := daemon.ProcessAlive(child.Process.Pid)
+	if aliveErr != nil || !alive {
+		t.Fatalf("startup child %d alive = %t, %v", child.Process.Pid, alive, aliveErr)
+	}
+}
+
+const startupChildTestEnv = "MESHD_TEST_STARTUP_CHILD"
+
+func TestWaitForDaemonStartChildProcess(t *testing.T) {
+	if os.Getenv(startupChildTestEnv) != "1" {
+		return
+	}
+	time.Sleep(30 * time.Second)
+}
+
+func startStartupChildProcess(t *testing.T) (*exec.Cmd, chan error) {
+	t.Helper()
+	child := exec.Command(os.Args[0], "-test.run=^TestWaitForDaemonStartChildProcess$")
+	child.Env = append(os.Environ(), startupChildTestEnv+"=1")
+	if err := child.Start(); err != nil {
+		t.Fatalf("start startup child: %v", err)
+	}
+	childExit := make(chan error, 1)
+	reaped := make(chan error, 1)
+	go func() {
+		err := child.Wait()
+		reaped <- err
+		childExit <- err
+	}()
+	t.Cleanup(func() {
+		_ = child.Process.Kill()
+		select {
+		case <-reaped:
+		case <-time.After(5 * time.Second):
+			t.Errorf("startup child %d was not reaped", child.Process.Pid)
+		}
+	})
+	return child, childExit
+}
+
+func TestRoutingSyncTimeoutErrorDistinguishesErrorPhase(t *testing.T) {
+	err := routingSyncTimeoutError(&daemon.Status{
+		RoutingRequired: true,
+		RoutingPhase:    "error",
+		RoutingError:    "installing routes: permission denied",
+	}, 30*time.Second)
+	if err == nil || !strings.Contains(err.Error(), "daemon running, mesh routing failed") ||
+		strings.Contains(err.Error(), "still syncing") ||
+		!strings.Contains(err.Error(), "installing routes: permission denied") {
+		t.Fatalf("routing error timeout = %v", err)
+	}
+}
+
+func TestRoutingStillSyncingOnlyForSyncPhase(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status *daemon.Status
+		want   bool
+	}{
+		{
+			name: "syncing",
+			status: &daemon.Status{
+				RoutingRequired: true,
+				RoutingPhase:    "syncing",
+			},
+			want: true,
+		},
+		{
+			name: "error",
+			status: &daemon.Status{
+				RoutingRequired: true,
+				RoutingPhase:    "error",
+			},
+		},
+		{
+			name: "ready",
+			status: &daemon.Status{
+				RoutingRequired: true,
+				RoutingReady:    true,
+				RoutingPhase:    "syncing",
+			},
+		},
+		{name: "missing phase", status: &daemon.Status{RoutingRequired: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := routingStillSyncing(tc.status); got != tc.want {
+				t.Fatalf("routingStillSyncing(%+v) = %t, want %t", tc.status, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWaitForDaemonStartAcceptsUserspaceReadiness(t *testing.T) {
+	socket := filepath.Join(privateDaemonSocketDir(t), "meshd.sock")
+	server := daemon.NewServer(socket, func() daemon.Status {
+		return daemon.Status{
+			RoutingRequired: false,
+			RoutingReady:    true,
+			RoutingPhase:    "userspace",
+		}
+	}, nil)
+	server.SetInstanceID("startup-instance")
+	if err := server.Start(); err != nil {
+		t.Fatalf("Start daemon server: %v", err)
+	}
+	defer server.Stop()
+
+	status, err := waitForDaemonStart(
+		context.Background(), socket, time.Second, false, "startup-instance", make(chan error),
+	)
+	if err != nil || status == nil || !status.RoutingReady || status.RoutingRequired {
+		t.Fatalf("userspace startup status = %+v, %v", status, err)
+	}
+}
+
+func privateDaemonSocketDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("Chmod socket directory: %v", err)
+	}
+	return dir
 }
 
 func TestResolveDaemonInstanceIDOnlyTrustsBackgroundChild(t *testing.T) {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -57,6 +57,10 @@ type Status struct {
 	OwnerDID        string       `json:"ownerDID,omitempty"`
 	NetworkRecordID string       `json:"networkRecordID,omitempty"`
 	Peers           []PeerStatus `json:"peers,omitempty"`
+	RoutingRequired bool         `json:"routingRequired"`
+	RoutingReady    bool         `json:"routingReady"`
+	RoutingPhase    string       `json:"routingPhase,omitempty"`
+	RoutingError    string       `json:"routingError,omitempty"`
 	Uptime          string       `json:"uptime,omitempty"`
 	PID             int          `json:"pid"`
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -201,6 +201,10 @@ func TestStatusEndpoint(t *testing.T) {
 			OwnerDID:        "did:example:owner",
 			NetworkRecordID: "network-1",
 			Peers:           []PeerStatus{{Name: "peer-a", MeshIP: "10.200.0.2", Online: true}},
+			RoutingRequired: true,
+			RoutingReady:    false,
+			RoutingPhase:    "syncing",
+			RoutingError:    "waiting for a usable network map",
 		}
 	}, nil)
 
@@ -241,6 +245,9 @@ func TestStatusEndpoint(t *testing.T) {
 	}
 	if len(status.Peers) != 1 || status.Peers[0].Name != "peer-a" || status.Peers[0].MeshIP != "10.200.0.2" || !status.Peers[0].Online {
 		t.Fatalf("Peers = %+v, want peer-a online at 10.200.0.2", status.Peers)
+	}
+	if !status.RoutingRequired || status.RoutingReady || status.RoutingPhase != "syncing" || status.RoutingError != "waiting for a usable network map" {
+		t.Fatalf("routing status = required=%t ready=%t phase=%q error=%q", status.RoutingRequired, status.RoutingReady, status.RoutingPhase, status.RoutingError)
 	}
 	if status.Uptime == "" {
 		t.Error("expected non-empty Uptime")

--- a/internal/engine/dwncontrol.go
+++ b/internal/engine/dwncontrol.go
@@ -41,6 +41,12 @@ type DWNControlConfig struct {
 	//   - When explicitly triggered via Notify()
 	MapResponseFunc func(ctx context.Context) (*netmap.NetworkMap, error)
 
+	// OnMapResult observes every completed map load. It is called after the
+	// control-client observer has received the result, and is useful for
+	// reconciling host routing readiness with the exact map that was loaded.
+	// A nil map and nil error means the load completed without usable state.
+	OnMapResult func(ctx context.Context, nm *netmap.NetworkMap, err error)
+
 	// EndpointUpdateFunc is called when magicsock discovers new endpoints
 	// (via STUN, local interface enumeration, etc). The implementation
 	// should write these back to the anchor DWN so peers can discover
@@ -112,9 +118,9 @@ type DWNControl struct {
 	logf     logger.Logf
 	clientID int64
 
-	mu     sync.Mutex
-	disco  key.DiscoPublic
-	paused atomic.Bool
+	mu           sync.Mutex
+	disco        key.DiscoPublic
+	paused       atomic.Bool
 	shutdown     chan struct{}
 	shutdownOnce sync.Once
 	cancel       context.CancelFunc
@@ -162,6 +168,7 @@ func NewDWNControl(config *DWNControlConfig, opts controlclient.Options) (*DWNCo
 	cc := &DWNControl{
 		config: DWNControlConfig{
 			MapResponseFunc:    config.MapResponseFunc,
+			OnMapResult:        config.OnMapResult,
 			EndpointUpdateFunc: config.EndpointUpdateFunc,
 			PollInterval:       pollInterval,
 			NodePrivateKey:     config.NodePrivateKey,
@@ -291,10 +298,16 @@ func (cc *DWNControl) loadAndPush(ctx context.Context) {
 				Persist: cc.persist.View(),
 			})
 		}
+		if cc.config.OnMapResult != nil {
+			cc.config.OnMapResult(ctx, nil, err)
+		}
 		return
 	}
 
 	if nm == nil {
+		if cc.config.OnMapResult != nil {
+			cc.config.OnMapResult(ctx, nil, nil)
+		}
 		return
 	}
 
@@ -335,6 +348,9 @@ func (cc *DWNControl) loadAndPush(ctx context.Context) {
 			Persist:   cc.persist.View(),
 		}
 		cc.observer.SetControlClientStatus(cc, s)
+	}
+	if cc.config.OnMapResult != nil {
+		cc.config.OnMapResult(ctx, nm, nil)
 	}
 }
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -34,6 +34,7 @@ import (
 	"github.com/enboxorg/meshnet/types/key"
 	"github.com/enboxorg/meshnet/types/logger"
 	"github.com/enboxorg/meshnet/types/logid"
+	"github.com/enboxorg/meshnet/types/netmap"
 	"github.com/enboxorg/meshnet/wgengine"
 	"github.com/enboxorg/meshnet/wgengine/netstack"
 	"github.com/enboxorg/meshnet/wgengine/router"
@@ -63,6 +64,12 @@ type Engine struct {
 	mu      sync.Mutex
 	running bool
 	cancel  context.CancelFunc
+
+	routeApplyMu sync.Mutex
+	routeConfig  *router.Config
+
+	routingMu sync.RWMutex
+	routing   routingState
 }
 
 // Config holds the configuration for creating an Engine.
@@ -425,10 +432,16 @@ func New(cfg Config) (*Engine, error) {
 	// MapResponseFunc closes over our DWNClient and Converter to produce
 	// NetworkMaps from DWN records.
 	mapFn := MapResponseFunc(dwnClient, converter)
+	var engineRef *Engine
 	dwnControlConfig := &DWNControlConfig{
 		MapResponseFunc: mapFn,
 		PollInterval:    pollInterval,
 		Logf:            logf,
+		OnMapResult: func(ctx context.Context, nm *netmap.NetworkMap, err error) {
+			if engineRef != nil {
+				engineRef.handleControlMapResult(ctx, nm, err)
+			}
+		},
 		// Capture the DWNControl reference so the subscription watcher
 		// can call Notify() to trigger immediate re-polls.
 		OnCreated: subWatcher.SetDWNControl,
@@ -458,7 +471,7 @@ func New(cfg Config) (*Engine, error) {
 		NewDWNControlFactory(dwnControlConfig),
 	)
 
-	return &Engine{
+	engineRef = &Engine{
 		backend:    lb,
 		netMon:     nm,
 		ns:         ns,
@@ -467,7 +480,9 @@ func New(cfg Config) (*Engine, error) {
 		tunName:    tunName,
 		osRouter:   osRouter,
 		logger:     l,
-	}, nil
+	}
+	engineRef.initializeRoutingStatus(cfg.TUNName != "")
+	return engineRef, nil
 }
 
 func tunCreationError(goos, name string, err error) error {

--- a/internal/engine/routing_status.go
+++ b/internal/engine/routing_status.go
@@ -1,0 +1,134 @@
+package engine
+
+import (
+	"context"
+	"log/slog"
+)
+
+const (
+	RoutingPhaseUserspace = "userspace"
+	RoutingPhaseSyncing   = "syncing"
+	RoutingPhaseReady     = "ready"
+	RoutingPhaseError     = "error"
+)
+
+// RoutingStatus describes whether applications can use the mesh through the
+// host operating system. Ready remains true across transient control refresh
+// failures when the last successfully installed route set is still active.
+type RoutingStatus struct {
+	Required  bool
+	Ready     bool
+	Phase     string
+	LastError string
+}
+
+type routingState struct {
+	required      bool
+	routerReady   bool
+	controlError  string
+	routeError    string
+	routePhase    string
+	controlWarned bool
+	routeWarned   bool
+}
+
+func (e *Engine) initializeRoutingStatus(required bool) {
+	e.routingMu.Lock()
+	defer e.routingMu.Unlock()
+	e.routing = routingState{required: required}
+	if !required {
+		e.routing.routerReady = true
+	}
+}
+
+// RoutingStatus returns a concurrency-safe snapshot of host routing readiness.
+func (e *Engine) RoutingStatus() RoutingStatus {
+	e.routingMu.RLock()
+	defer e.routingMu.RUnlock()
+	return e.routingStatusLocked()
+}
+
+func (e *Engine) routingStatusLocked() RoutingStatus {
+	if !e.routing.required {
+		return RoutingStatus{Ready: true, Phase: RoutingPhaseUserspace}
+	}
+
+	status := RoutingStatus{Required: true, Ready: e.routing.routerReady}
+	switch {
+	case e.routing.controlError != "":
+		status.Phase = RoutingPhaseError
+		status.LastError = e.routing.controlError
+	case e.routing.routeError != "":
+		status.Phase = e.routing.routePhase
+		status.LastError = e.routing.routeError
+	case e.routing.routerReady:
+		status.Phase = RoutingPhaseReady
+	default:
+		status.Phase = RoutingPhaseSyncing
+	}
+	return status
+}
+
+func (e *Engine) recordControlMapError(ctx context.Context, err error) {
+	e.updateRoutingStatus(ctx, func(state *routingState) {
+		state.controlError = "loading control map: " + err.Error()
+	})
+}
+
+func (e *Engine) recordRouteResult(ctx context.Context, err error, phase string, freshControlResult bool) {
+	e.updateRoutingStatus(ctx, func(state *routingState) {
+		if freshControlResult {
+			state.controlError = ""
+		}
+		if err == nil {
+			state.routerReady = true
+			state.routeError = ""
+			state.routePhase = ""
+			return
+		}
+		state.routerReady = false
+		state.routeError = err.Error()
+		state.routePhase = phase
+	})
+}
+
+func (e *Engine) updateRoutingStatus(ctx context.Context, update func(*routingState)) {
+	e.routingMu.Lock()
+	before := e.routingStatusLocked()
+	update(&e.routing)
+	after := e.routingStatusLocked()
+	warnControl := e.routing.controlError != "" && !e.routing.controlWarned
+	warnRoute := e.routing.routePhase == RoutingPhaseError && !e.routing.routeWarned
+	if warnControl {
+		e.routing.controlWarned = true
+	}
+	if warnRoute {
+		e.routing.routeWarned = true
+	}
+	controlError := e.routing.controlError
+	routeError := e.routing.routeError
+	hadFailure := e.routing.controlWarned || e.routing.routeWarned
+	recovered := after.Phase == RoutingPhaseReady && hadFailure
+	becameReady := after.Phase == RoutingPhaseReady && before.Phase != RoutingPhaseReady
+	if after.Phase == RoutingPhaseReady {
+		e.routing.controlWarned = false
+		e.routing.routeWarned = false
+	}
+	e.routingMu.Unlock()
+
+	if warnControl {
+		e.logger.WarnContext(ctx, "mesh control map load failed",
+			slog.String("error", controlError),
+		)
+	}
+	if warnRoute {
+		e.logger.WarnContext(ctx, "mesh OS route reconciliation failed",
+			slog.String("error", routeError),
+		)
+	}
+	if recovered {
+		e.logger.InfoContext(ctx, "mesh routing recovered")
+	} else if becameReady {
+		e.logger.InfoContext(ctx, "mesh routing ready")
+	}
+}

--- a/internal/engine/routing_status_test.go
+++ b/internal/engine/routing_status_test.go
@@ -1,0 +1,292 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/netip"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/enboxorg/meshnet/control/controlclient"
+	"github.com/enboxorg/meshnet/tailcfg"
+	"github.com/enboxorg/meshnet/types/netmap"
+	"github.com/enboxorg/meshnet/wgengine/router"
+)
+
+func TestRoutingStatusUserspaceReady(t *testing.T) {
+	eng := newRoutingTestEngine(false, nil, discardRoutingLogger())
+	ctx := context.Background()
+	want := RoutingStatus{Ready: true, Phase: RoutingPhaseUserspace}
+	if got := eng.RoutingStatus(); got != want {
+		t.Fatalf("RoutingStatus() = %+v, want %+v", got, want)
+	}
+	if err := eng.reconcileTUNRoutes(ctx); err != nil {
+		t.Fatalf("userspace reconcile = %v, want nil", err)
+	}
+	eng.handleControlMapResult(ctx, nil, errors.New("control unavailable"))
+	if got := eng.RoutingStatus(); got != want {
+		t.Fatalf("userspace status after control error = %+v, want %+v", got, want)
+	}
+}
+
+func TestRoutingStatusWaitsForUsableNetworkMap(t *testing.T) {
+	rtr := &scriptedRoutingRouter{}
+	eng := newRoutingTestEngine(true, rtr, discardRoutingLogger())
+	assertRoutingStatus(t, eng, RoutingStatus{Required: true, Phase: RoutingPhaseSyncing})
+
+	eng.handleControlMapResult(context.Background(), nil, nil)
+	status := eng.RoutingStatus()
+	if !status.Required || status.Ready || status.Phase != RoutingPhaseSyncing ||
+		status.LastError != "no usable network map addresses yet" {
+		t.Fatalf("status without network map = %+v", status)
+	}
+	if calls := rtr.SetCalls(); calls != 0 {
+		t.Fatalf("router Set calls without network map = %d, want 0", calls)
+	}
+
+	eng.handleControlMapResult(context.Background(), routingTestNetMap(), nil)
+	assertRoutingStatus(t, eng, RoutingStatus{Required: true, Ready: true, Phase: RoutingPhaseReady})
+	if calls := rtr.SetCalls(); calls != 1 {
+		t.Fatalf("router Set calls = %d, want 1", calls)
+	}
+}
+
+func TestRoutingStatusControlFailureThenRecovery(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logs, nil))
+	eng := newRoutingTestEngine(true, &scriptedRoutingRouter{}, logger)
+	ctx := context.Background()
+	mapErr := errors.New("DWN rate limited")
+
+	eng.handleControlMapResult(ctx, nil, mapErr)
+	eng.handleControlMapResult(ctx, nil, mapErr)
+	status := eng.RoutingStatus()
+	if status.Ready || status.Phase != RoutingPhaseError ||
+		status.LastError != "loading control map: DWN rate limited" {
+		t.Fatalf("status after control failure = %+v", status)
+	}
+	if got := strings.Count(logs.String(), `"msg":"mesh control map load failed"`); got != 1 {
+		t.Fatalf("control warning log count = %d, want 1; logs:\n%s", got, logs.String())
+	}
+
+	eng.handleControlMapResult(ctx, routingTestNetMap(), nil)
+	assertRoutingStatus(t, eng, RoutingStatus{Required: true, Ready: true, Phase: RoutingPhaseReady})
+	if got := strings.Count(logs.String(), `"msg":"mesh routing recovered"`); got != 1 {
+		t.Fatalf("recovery log count = %d, want 1; logs:\n%s", got, logs.String())
+	}
+}
+
+func TestRoutingStatusRouterFailureRetriesWithoutWarningSpam(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logs, nil))
+	rtr := &scriptedRoutingRouter{setErrors: []error{
+		errors.New("route command failed"),
+		errors.New("route command failed differently"),
+		nil,
+	}}
+	eng := newRoutingTestEngine(true, rtr, logger)
+	ctx := context.Background()
+	nm := routingTestNetMap()
+
+	eng.handleControlMapResult(ctx, nm, nil)
+	status := eng.RoutingStatus()
+	if status.Ready || status.Phase != RoutingPhaseError ||
+		!strings.Contains(status.LastError, "configuring OS routes: route command failed") {
+		t.Fatalf("status after router failure = %+v", status)
+	}
+	eng.handleControlMapResult(ctx, nm, nil)
+	if got := eng.RoutingStatus().LastError; !strings.Contains(got, "failed differently") {
+		t.Fatalf("retry error = %q, want latest router error", got)
+	}
+	eng.handleControlMapResult(ctx, nm, nil)
+	assertRoutingStatus(t, eng, RoutingStatus{Required: true, Ready: true, Phase: RoutingPhaseReady})
+
+	if got := strings.Count(logs.String(), `"level":"WARN"`); got != 1 {
+		t.Fatalf("warning log count = %d, want 1; logs:\n%s", got, logs.String())
+	}
+	if got := strings.Count(logs.String(), `"msg":"mesh routing recovered"`); got != 1 {
+		t.Fatalf("recovery log count = %d, want 1; logs:\n%s", got, logs.String())
+	}
+}
+
+func TestRoutingStatusWarnsForDistinctControlAndRouterFailures(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logs, nil))
+	rtr := &scriptedRoutingRouter{setErrors: []error{
+		errors.New("route command failed"),
+		nil,
+	}}
+	eng := newRoutingTestEngine(true, rtr, logger)
+	ctx := context.Background()
+
+	eng.handleControlMapResult(ctx, nil, errors.New("control unavailable"))
+	eng.handleControlMapResult(ctx, routingTestNetMap(), nil)
+	eng.handleControlMapResult(ctx, routingTestNetMap(), nil)
+
+	if got := strings.Count(logs.String(), `"level":"WARN"`); got != 2 {
+		t.Fatalf("warning log count = %d, want separate control and router warnings; logs:\n%s", got, logs.String())
+	}
+	if got := strings.Count(logs.String(), `"msg":"mesh routing recovered"`); got != 1 {
+		t.Fatalf("recovery log count = %d, want 1; logs:\n%s", got, logs.String())
+	}
+}
+
+func TestRoutingStatusCachedRetryDoesNotHideControlError(t *testing.T) {
+	eng := newRoutingTestEngine(true, &scriptedRoutingRouter{}, discardRoutingLogger())
+	ctx := context.Background()
+	nm := routingTestNetMap()
+
+	eng.handleControlMapResult(ctx, nm, nil)
+	eng.handleControlMapResult(ctx, nil, errors.New("control refresh failed"))
+	if err := eng.reconcileTUNRoutes(ctx); err != nil {
+		t.Fatalf("cached route retry: %v", err)
+	}
+	status := eng.RoutingStatus()
+	if !status.Ready || status.Phase != RoutingPhaseError ||
+		status.LastError != "loading control map: control refresh failed" {
+		t.Fatalf("status after cached retry = %+v", status)
+	}
+
+	eng.handleControlMapResult(ctx, nm, nil)
+	assertRoutingStatus(t, eng, RoutingStatus{Required: true, Ready: true, Phase: RoutingPhaseReady})
+}
+
+func TestRoutingStatusConcurrentSnapshots(t *testing.T) {
+	eng := newRoutingTestEngine(true, &scriptedRoutingRouter{}, discardRoutingLogger())
+	ctx := context.Background()
+	nm := routingTestNetMap()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			eng.handleControlMapResult(ctx, nil, errors.New("control retry"))
+			eng.handleControlMapResult(ctx, nm, nil)
+		}()
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				_ = eng.RoutingStatus()
+			}
+		}()
+	}
+	wg.Wait()
+	eng.handleControlMapResult(ctx, nm, nil)
+	if status := eng.RoutingStatus(); !status.Ready || status.Phase != RoutingPhaseReady {
+		t.Fatalf("final routing status = %+v", status)
+	}
+}
+
+func TestDWNControlReportsMapResults(t *testing.T) {
+	wantMap := routingTestNetMap()
+	mapErr := errors.New("map load failed")
+	var loads int
+	type result struct {
+		nm  *netmap.NetworkMap
+		err error
+	}
+	var results []result
+
+	cc, err := NewDWNControl(&DWNControlConfig{
+		MapResponseFunc: func(context.Context) (*netmap.NetworkMap, error) {
+			loads++
+			switch loads {
+			case 1:
+				return nil, mapErr
+			case 2:
+				return nil, nil
+			default:
+				return wantMap, nil
+			}
+		},
+		OnMapResult: func(_ context.Context, nm *netmap.NetworkMap, err error) {
+			results = append(results, result{nm: nm, err: err})
+		},
+		PollInterval: time.Hour,
+		Logf:         func(string, ...any) {},
+	}, controlclient.Options{SkipStartForTests: true})
+	if err != nil {
+		t.Fatalf("NewDWNControl: %v", err)
+	}
+	defer cc.Shutdown()
+
+	ctx := context.Background()
+	cc.loadAndPush(ctx)
+	cc.loadAndPush(ctx)
+	cc.loadAndPush(ctx)
+	if len(results) != 3 {
+		t.Fatalf("map result callbacks = %d, want 3", len(results))
+	}
+	if results[0].nm != nil || !errors.Is(results[0].err, mapErr) {
+		t.Fatalf("error result = %+v", results[0])
+	}
+	if results[1].nm != nil || results[1].err != nil {
+		t.Fatalf("nil result = %+v", results[1])
+	}
+	if results[2].nm != wantMap || results[2].err != nil {
+		t.Fatalf("map result = %+v, want map %p", results[2], wantMap)
+	}
+}
+
+type scriptedRoutingRouter struct {
+	mu        sync.Mutex
+	setErrors []error
+	setCalls  int
+}
+
+func (r *scriptedRoutingRouter) Up() error    { return nil }
+func (r *scriptedRoutingRouter) Close() error { return nil }
+
+func (r *scriptedRoutingRouter) Set(*router.Config) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	call := r.setCalls
+	r.setCalls++
+	if call < len(r.setErrors) {
+		return r.setErrors[call]
+	}
+	return nil
+}
+
+func (r *scriptedRoutingRouter) SetCalls() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.setCalls
+}
+
+func newRoutingTestEngine(required bool, r router.Router, logger *slog.Logger) *Engine {
+	eng := &Engine{logger: logger}
+	if r != nil {
+		eng.osRouter = newSynchronizedRouter(r)
+	}
+	eng.initializeRoutingStatus(required)
+	return eng
+}
+
+func discardRoutingLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func routingTestNetMap() *netmap.NetworkMap {
+	self := (&tailcfg.Node{
+		Addresses: []netip.Prefix{netip.MustParsePrefix("10.200.70.205/32")},
+	}).View()
+	peer := (&tailcfg.Node{
+		Addresses:  []netip.Prefix{netip.MustParsePrefix("10.200.176.93/32")},
+		AllowedIPs: []netip.Prefix{netip.MustParsePrefix("10.200.176.93/32")},
+	}).View()
+	return &netmap.NetworkMap{SelfNode: self, Peers: []tailcfg.NodeView{peer}}
+}
+
+func assertRoutingStatus(t *testing.T, eng *Engine, want RoutingStatus) {
+	t.Helper()
+	if got := eng.RoutingStatus(); got != want {
+		t.Fatalf("RoutingStatus() = %+v, want %+v", got, want)
+	}
+}

--- a/internal/engine/tun_routes.go
+++ b/internal/engine/tun_routes.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net/netip"
 	"sort"
 	"time"
@@ -69,26 +68,61 @@ func routerConfigFromNetMap(nm *netmap.NetworkMap) (*router.Config, bool) {
 }
 
 func (e *Engine) reconcileTUNRoutes(ctx context.Context) error {
-	if e.osRouter == nil {
+	if !e.RoutingStatus().Required {
 		return nil
 	}
-	nm := e.backend.NetMap()
-	cfg, ok := routerConfigFromNetMap(nm)
-	if !ok {
-		return fmt.Errorf("no usable network map addresses yet")
+
+	e.routeApplyMu.Lock()
+	defer e.routeApplyMu.Unlock()
+	return e.applyTUNRouteConfigLocked(ctx, e.routeConfig, e.routeConfig != nil, false)
+}
+
+func (e *Engine) handleControlMapResult(ctx context.Context, nm *netmap.NetworkMap, err error) {
+	if !e.RoutingStatus().Required {
+		return
 	}
-	if err := e.osRouter.Set(cfg); err != nil {
+
+	e.routeApplyMu.Lock()
+	defer e.routeApplyMu.Unlock()
+	if err != nil {
+		e.recordControlMapError(ctx, err)
+		return
+	}
+
+	cfg, ok := routerConfigFromNetMap(nm)
+	if ok {
+		e.routeConfig = cfg
+	} else {
+		e.routeConfig = nil
+	}
+	_ = e.applyTUNRouteConfigLocked(ctx, cfg, ok, true)
+}
+
+// applyTUNRouteConfigLocked installs a route snapshot and updates readiness.
+// Callers must hold routeApplyMu so an older retry cannot land after a newer
+// control result and overwrite either the OS routes or their reported state.
+func (e *Engine) applyTUNRouteConfigLocked(ctx context.Context, cfg *router.Config, usable bool, freshControlResult bool) error {
+	if e.osRouter == nil {
+		err := fmt.Errorf("OS router is unavailable")
+		e.recordRouteResult(ctx, err, RoutingPhaseError, freshControlResult)
 		return err
 	}
-	e.logger.DebugContext(ctx, "TUN routes reconciled",
-		slog.Int("localAddrs", len(cfg.LocalAddrs)),
-		slog.Int("routes", len(cfg.Routes)),
-	)
+	if !usable {
+		err := fmt.Errorf("no usable network map addresses yet")
+		e.recordRouteResult(ctx, err, RoutingPhaseSyncing, freshControlResult)
+		return err
+	}
+	if err := e.osRouter.Set(cfg); err != nil {
+		err = fmt.Errorf("configuring OS routes: %w", err)
+		e.recordRouteResult(ctx, err, RoutingPhaseError, freshControlResult)
+		return err
+	}
+	e.recordRouteResult(ctx, nil, RoutingPhaseReady, freshControlResult)
 	return nil
 }
 
 func (e *Engine) waitForInitialTUNRoutes(ctx context.Context, timeout time.Duration) {
-	if e.osRouter == nil {
+	if !e.RoutingStatus().Required {
 		return
 	}
 
@@ -97,21 +131,15 @@ func (e *Engine) waitForInitialTUNRoutes(ctx context.Context, timeout time.Durat
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
-	var lastErr error
 	for {
 		if err := e.reconcileTUNRoutes(ctx); err == nil {
 			return
-		} else {
-			lastErr = err
 		}
 
 		select {
 		case <-ctx.Done():
 			return
 		case <-deadline.C:
-			e.logger.WarnContext(ctx, "TUN routes not ready yet; will keep retrying in background",
-				slog.Any("error", lastErr),
-			)
 			return
 		case <-ticker.C:
 		}
@@ -119,7 +147,7 @@ func (e *Engine) waitForInitialTUNRoutes(ctx context.Context, timeout time.Durat
 }
 
 func (e *Engine) runTUNRouteReconciler(ctx context.Context) {
-	if e.osRouter == nil {
+	if !e.RoutingStatus().Required {
 		return
 	}
 
@@ -131,11 +159,7 @@ func (e *Engine) runTUNRouteReconciler(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if err := e.reconcileTUNRoutes(ctx); err != nil {
-				e.logger.DebugContext(ctx, "TUN route reconcile skipped",
-					slog.Any("error", err),
-				)
-			}
+			_ = e.reconcileTUNRoutes(ctx)
 		}
 	}
 }

--- a/internal/trayapp/model.go
+++ b/internal/trayapp/model.go
@@ -56,12 +56,16 @@ type PeerView struct {
 
 // View builds the current menu presentation.
 func (m Model) View() View {
-	connected := m.Status != nil && m.Status.Running
+	running := m.Status != nil && m.Status.Running
+	routingError := running && strings.EqualFold(strings.TrimSpace(m.Status.RoutingPhase), "error")
+	connectionError := routingError && !m.Status.RoutingReady
+	degraded := routingError && m.Status.RoutingReady
+	connected := running && m.Status.RoutingReady
 	view := View{
 		Connected:         connected,
-		ConnectEnabled:    !connected && m.Operation == OperationNone,
-		DisconnectEnabled: connected && m.Operation == OperationNone,
-		Error:             strings.TrimSpace(m.LastError),
+		ConnectEnabled:    !running && m.Operation == OperationNone,
+		DisconnectEnabled: running && m.Operation == OperationNone,
+		Error:             modelError(m.LastError, routingError, m.Status),
 	}
 
 	switch m.Operation {
@@ -72,13 +76,23 @@ func (m Model) View() View {
 		view.StatusTitle = "Disconnecting…"
 		view.Tooltip = "meshd — Disconnecting"
 	case OperationNone:
-		if connected {
+		switch {
+		case connectionError:
+			view.StatusTitle = "Connection error"
+			view.Tooltip = "meshd — Connection error"
+		case connected:
 			view.MeshIP = strings.TrimSpace(m.Status.MeshIP)
 			view.StatusTitle = connectedTitle(m.Status.Network, view.MeshIP)
+			if degraded {
+				view.StatusTitle += " — Degraded"
+			}
 			view.Tooltip = "meshd — " + view.StatusTitle
 			view.CopyIPEnabled = view.MeshIP != ""
 			view.Peers = peerViews(m.Status.Peers)
-		} else {
+		case running:
+			view.StatusTitle = syncingTitle(m.Status.Network)
+			view.Tooltip = "meshd — " + strings.TrimSuffix(view.StatusTitle, "…")
+		default:
 			view.StatusTitle = "Disconnected"
 			view.Tooltip = "meshd — Disconnected"
 		}
@@ -87,6 +101,29 @@ func (m Model) View() View {
 		view.Tooltip += ": " + view.Error
 	}
 	return view
+}
+
+func modelError(lastError string, routingError bool, status *daemon.Status) string {
+	lastError = strings.TrimSpace(lastError)
+	if !routingError || status == nil {
+		return lastError
+	}
+	routeError := strings.TrimSpace(status.RoutingError)
+	if routeError == "" || routeError == lastError {
+		return lastError
+	}
+	if lastError == "" {
+		return routeError
+	}
+	return lastError + "; " + routeError
+}
+
+func syncingTitle(network string) string {
+	network = safeMenuLabel(network, maxNetworkNameRunes)
+	if network != "" {
+		return "Syncing " + network + "…"
+	}
+	return "Syncing…"
 }
 
 func connectedTitle(network, meshIP string) string {

--- a/internal/trayapp/model_test.go
+++ b/internal/trayapp/model_test.go
@@ -21,9 +21,11 @@ func TestModelViewDisconnected(t *testing.T) {
 
 func TestModelViewConnected(t *testing.T) {
 	model := Model{Status: &daemon.Status{
-		Running: true,
-		Network: "home",
-		MeshIP:  "10.200.0.7",
+		Running:         true,
+		Network:         "home",
+		MeshIP:          "10.200.0.7",
+		RoutingRequired: true,
+		RoutingReady:    true,
 		Peers: []daemon.PeerStatus{
 			{Name: "zeta", MeshIP: "10.200.0.9"},
 			{Name: "Alpha", MeshIP: "10.200.0.2", Online: true},
@@ -41,6 +43,115 @@ func TestModelViewConnected(t *testing.T) {
 	wantPeerTitles := []string{"● Alpha · 10.200.0.2", "○ zeta · 10.200.0.9"}
 	if !reflect.DeepEqual(gotPeerTitles, wantPeerTitles) {
 		t.Fatalf("peer titles = %v, want %v", gotPeerTitles, wantPeerTitles)
+	}
+}
+
+func TestModelViewSyncingRoutes(t *testing.T) {
+	view := (Model{Status: &daemon.Status{
+		Running:         true,
+		Network:         "home",
+		MeshIP:          "10.200.0.7",
+		RoutingRequired: true,
+		RoutingReady:    false,
+		RoutingPhase:    "syncing",
+		Peers:           []daemon.PeerStatus{{Name: "peer", MeshIP: "10.200.0.8"}},
+	}}).View()
+
+	if view.Connected || view.StatusTitle != "Syncing home…" || view.Tooltip != "meshd — Syncing home" {
+		t.Fatalf("syncing view = %+v", view)
+	}
+	if view.ConnectEnabled || !view.DisconnectEnabled || view.CopyIPEnabled || len(view.Peers) != 0 {
+		t.Fatalf("syncing actions = %+v", view)
+	}
+}
+
+func TestModelViewRoutingError(t *testing.T) {
+	view := (Model{
+		Status: &daemon.Status{
+			Running:         true,
+			Network:         "home",
+			MeshIP:          "10.200.0.7",
+			RoutingRequired: true,
+			RoutingReady:    false,
+			RoutingPhase:    "error",
+			RoutingError:    "installing peer routes: permission denied",
+			Peers:           []daemon.PeerStatus{{Name: "peer", MeshIP: "10.200.0.8"}},
+		},
+		LastError: "meshd up timed out",
+	}).View()
+
+	if view.Connected || view.StatusTitle != "Connection error" {
+		t.Fatalf("routing error view = %+v", view)
+	}
+	if view.ConnectEnabled || !view.DisconnectEnabled || view.CopyIPEnabled || len(view.Peers) != 0 {
+		t.Fatalf("routing error actions = %+v", view)
+	}
+	for _, want := range []string{"meshd up timed out", "installing peer routes: permission denied"} {
+		if !strings.Contains(view.Error, want) || !strings.Contains(view.Tooltip, want) {
+			t.Fatalf("routing error view does not surface %q: %+v", want, view)
+		}
+	}
+}
+
+func TestModelViewClearsLiveRoutingErrorAfterRecovery(t *testing.T) {
+	model := Model{Status: &daemon.Status{
+		Running:         true,
+		RoutingRequired: true,
+		RoutingPhase:    "error",
+		RoutingError:    "configuring OS routes: permission denied",
+	}}
+	if view := model.View(); view.Error == "" || view.StatusTitle != "Connection error" {
+		t.Fatalf("routing error view = %+v", view)
+	}
+
+	model.Status = &daemon.Status{
+		Running:         true,
+		RoutingRequired: true,
+		RoutingReady:    true,
+		RoutingPhase:    "ready",
+	}
+	view := model.View()
+	if !view.Connected || view.Error != "" || strings.Contains(view.Tooltip, "permission denied") {
+		t.Fatalf("recovered routing view = %+v", view)
+	}
+}
+
+func TestModelViewDegradedRouting(t *testing.T) {
+	view := (Model{Status: &daemon.Status{
+		Running:         true,
+		Network:         "home",
+		MeshIP:          "10.200.0.7",
+		RoutingRequired: true,
+		RoutingReady:    true,
+		RoutingPhase:    "error",
+		RoutingError:    "refreshing control map: temporarily unavailable",
+		Peers:           []daemon.PeerStatus{{Name: "peer", MeshIP: "10.200.0.8"}},
+	}}).View()
+
+	if !view.Connected || view.StatusTitle != "Connected to home · 10.200.0.7 — Degraded" {
+		t.Fatalf("degraded view = %+v", view)
+	}
+	if view.ConnectEnabled || !view.DisconnectEnabled || !view.CopyIPEnabled || len(view.Peers) != 1 {
+		t.Fatalf("degraded actions = %+v", view)
+	}
+	if !strings.Contains(view.Error, "temporarily unavailable") ||
+		!strings.Contains(view.Tooltip, "temporarily unavailable") {
+		t.Fatalf("degraded view does not surface routing error: %+v", view)
+	}
+}
+
+func TestModelViewUserspaceReady(t *testing.T) {
+	view := (Model{Status: &daemon.Status{
+		Running:         true,
+		Network:         "home",
+		MeshIP:          "10.200.0.7",
+		RoutingRequired: false,
+		RoutingReady:    true,
+		RoutingPhase:    "userspace",
+	}}).View()
+
+	if !view.Connected || view.StatusTitle != "Connected to home · 10.200.0.7" {
+		t.Fatalf("userspace view = %+v", view)
 	}
 }
 
@@ -72,8 +183,9 @@ func TestModelViewIncludesErrorInTooltip(t *testing.T) {
 func TestModelViewSanitizesAndCapsLabels(t *testing.T) {
 	longName := "peer\n\t\u202e" + strings.Repeat("界", maxPeerNameRunes+20)
 	view := (Model{Status: &daemon.Status{
-		Running: true,
-		Network: "home\n\u202e network",
+		Running:      true,
+		Network:      "home\n\u202e network",
+		RoutingReady: true,
 		Peers: []daemon.PeerStatus{{
 			Name:   longName,
 			MeshIP: "10.200.0.8",

--- a/internal/trayapp/service.go
+++ b/internal/trayapp/service.go
@@ -16,7 +16,10 @@ import (
 	"github.com/enboxorg/meshd/internal/openurl"
 )
 
-const defaultDisconnectPoll = 150 * time.Millisecond
+const (
+	defaultDisconnectPoll       = 150 * time.Millisecond
+	connectHandoffStatusTimeout = 2 * time.Second
+)
 
 type commandRunner func(context.Context, string, []string, []string) ([]byte, error)
 type processWaiter func(context.Context, int, time.Duration) error
@@ -75,6 +78,17 @@ func (s *Service) Connect(ctx context.Context) error {
 	}
 	output, err := s.launchConnect(ctx, executable, args, os.Environ())
 	if err != nil {
+		// meshd up intentionally stops waiting after its routing-readiness
+		// deadline while leaving the daemon alive to finish syncing. The command
+		// therefore exits non-zero even though ownership of the connection has
+		// successfully moved to the daemon. Confirm that handoff independently:
+		// the command context may already be expired by the time it returns.
+		statusCtx, cancel := context.WithTimeout(context.Background(), connectHandoffStatusTimeout)
+		status, statusErr := s.client.GetStatus(statusCtx)
+		cancel()
+		if statusErr == nil && connectHandoffAccepted(status) {
+			return nil
+		}
 		detail := compactOutput(output)
 		if detail != "" {
 			return fmt.Errorf("meshd up: %w: %s", err, detail)
@@ -82,6 +96,10 @@ func (s *Service) Connect(ctx context.Context) error {
 		return fmt.Errorf("meshd up: %w", err)
 	}
 	return nil
+}
+
+func connectHandoffAccepted(status *daemon.Status) bool {
+	return status != nil && status.Running
 }
 
 // Disconnect requests a graceful shutdown of the observed daemon instance and

--- a/internal/trayapp/service_test.go
+++ b/internal/trayapp/service_test.go
@@ -42,6 +42,8 @@ func TestServiceConnectRunsSelectedProfile(t *testing.T) {
 
 func TestServiceConnectReportsCommandOutput(t *testing.T) {
 	service := NewService("")
+	service.socket = filepath.Join(t.TempDir(), "missing.sock")
+	service.client = daemon.NewClient(service.socket)
 	service.findMeshd = func() (string, error) { return "/opt/meshd", nil }
 	service.launchConnect = func(context.Context, string, []string, []string) ([]byte, error) {
 		return []byte("vault password required\nrun meshd vault remember"), errors.New("exit status 1")
@@ -49,6 +51,83 @@ func TestServiceConnectReportsCommandOutput(t *testing.T) {
 	err := service.Connect(context.Background())
 	if err == nil || !strings.Contains(err.Error(), "meshd vault remember") {
 		t.Fatalf("Connect error = %v", err)
+	}
+}
+
+func TestServiceConnectAcceptsDaemonHandoffAfterCommandDeadline(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  daemon.Status
+		wantErr bool
+	}{
+		{
+			name: "syncing",
+			status: daemon.Status{
+				Running:         true,
+				RoutingRequired: true,
+				RoutingReady:    false,
+				RoutingPhase:    "syncing",
+			},
+		},
+		{
+			name: "ready degraded",
+			status: daemon.Status{
+				Running:         true,
+				RoutingRequired: true,
+				RoutingReady:    true,
+				RoutingPhase:    "error",
+				RoutingError:    "refreshing control map: temporarily unavailable",
+			},
+		},
+		{
+			name: "non-ready error",
+			status: daemon.Status{
+				Running:         true,
+				RoutingRequired: true,
+				RoutingReady:    false,
+				RoutingPhase:    "error",
+				RoutingError:    "configuring OS routes: permission denied",
+			},
+		},
+		{
+			name: "daemon not running",
+			status: daemon.Status{
+				RoutingRequired: true,
+				RoutingPhase:    "syncing",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			socket := serveTrayStatus(t, tc.status)
+			service := NewService("")
+			service.socket = socket
+			service.client = daemon.NewClient(socket)
+			service.findMeshd = func() (string, error) { return "/opt/meshd", nil }
+			service.launchConnect = func(context.Context, string, []string, []string) ([]byte, error) {
+				return []byte("mesh still syncing after 30s (phase error): route setup failed"), errors.New("exit status 1")
+			}
+
+			connectCtx, cancel := context.WithCancel(context.Background())
+			cancel()
+			err := service.Connect(connectCtx)
+			if !tc.wantErr {
+				if err != nil {
+					t.Fatalf("Connect: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("Connect succeeded without a running daemon")
+			}
+			for _, want := range []string{"exit status 1", "route setup failed"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("Connect error = %q, want %q", err, want)
+				}
+			}
+		})
 	}
 }
 
@@ -358,6 +437,22 @@ func TestMacOSTerminalCommandKeepsPayloadOutOfScript(t *testing.T) {
 type countingListener struct {
 	net.Listener
 	accepts atomic.Int32
+}
+
+func serveTrayStatus(t *testing.T, status daemon.Status) string {
+	t.Helper()
+	socket := privateSocketPath(t)
+	listener, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(status)
+	})}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Close() })
+	return socket
 }
 
 func privateSocketPath(t *testing.T) string {


### PR DESCRIPTION
## Summary
- track host-routing readiness only after a usable control map is installed through the OS router
- expose syncing, ready, degraded, and error states through the daemon API, CLI status, and doctor
- wait for route readiness during background startup without terminating a daemon that is still syncing
- keep tray icon, actions, peer list, and live errors aligned with actual route readiness and recovery
- warn once for control/router failures and log recovery without retry spam

Fixes #244.

## Validation
- [x] go build ./...
- [x] go vet ./...
- [x] go test ./... -count=1 -race
- [x] Windows amd64 CLI and tray cross-build
- [x] macOS arm64 CLI cross-build
- [x] git diff --check