### PR TITLE
fix: cache audience delivery keys

### DIFF
--- a/internal/control/audiencekeycache.go
+++ b/internal/control/audiencekeycache.go
@@ -1,0 +1,102 @@
+package control
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// audienceKeyCacheKey identifies one role-audience key. A DWNClient is bound
+// to a single anchor tenant, network, and reader DID, so those values do not
+// need to be repeated in every cache key.
+type audienceKeyCacheKey struct {
+	protocol string
+	rolePath string
+	keyID    string
+}
+
+type audienceKeyCall struct {
+	done chan struct{}
+	err  error
+}
+
+// audienceKeyCache retains successfully delivered role-audience private keys
+// for the lifetime of a DWNClient and coalesces concurrent misses. Key IDs are
+// public-key thumbprints, so audience rotation naturally selects a new entry.
+// Failed lookups are deliberately not cached: a delivery can arrive later, or
+// a transient DWN error can recover on the next map refresh.
+type audienceKeyCache struct {
+	mu       sync.Mutex
+	keys     map[audienceKeyCacheKey][]byte
+	inflight map[audienceKeyCacheKey]*audienceKeyCall
+}
+
+// get takes ownership of the buffer returned by load and zeroes it after
+// retaining and returning independent copies.
+func (c *audienceKeyCache) get(
+	ctx context.Context,
+	key audienceKeyCacheKey,
+	load func(context.Context) ([]byte, error),
+) ([]byte, error) {
+	for {
+		c.mu.Lock()
+		if privateKey, ok := c.keys[key]; ok {
+			result := append([]byte(nil), privateKey...)
+			c.mu.Unlock()
+			return result, nil
+		}
+		if call, ok := c.inflight[key]; ok {
+			done := call.done
+			c.mu.Unlock()
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-done:
+				if call.err != nil {
+					// A short-lived leader must not cancel otherwise-live waiters.
+					// Re-enter the election; exactly one waiter becomes the new loader.
+					if ctx.Err() == nil && (errors.Is(call.err, context.Canceled) ||
+						errors.Is(call.err, context.DeadlineExceeded)) {
+						continue
+					}
+					return nil, call.err
+				}
+				// The successful loader populated the cache before closing done.
+				continue
+			}
+		}
+
+		if c.inflight == nil {
+			c.inflight = make(map[audienceKeyCacheKey]*audienceKeyCall)
+		}
+		call := &audienceKeyCall{done: make(chan struct{})}
+		c.inflight[key] = call
+		c.mu.Unlock()
+
+		privateKey, err := load(ctx)
+		if err == nil && len(privateKey) == 0 {
+			err = fmt.Errorf("delivered audience key is empty")
+		}
+
+		c.mu.Lock()
+		if err == nil {
+			if c.keys == nil {
+				c.keys = make(map[audienceKeyCacheKey][]byte)
+			}
+			c.keys[key] = append([]byte(nil), privateKey...)
+		}
+		call.err = err
+		delete(c.inflight, key)
+		close(call.done)
+		c.mu.Unlock()
+
+		if err != nil {
+			clear(privateKey)
+			return nil, err
+		}
+		result := append([]byte(nil), privateKey...)
+		clear(privateKey)
+		return result, nil
+	}
+}

--- a/internal/control/audiencekeycache_test.go
+++ b/internal/control/audiencekeycache_test.go
@@ -1,0 +1,331 @@
+package control
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestAudienceKeyCacheReusesSuccessfulLookupAndCopiesKey(t *testing.T) {
+	var cache audienceKeyCache
+	key := audienceKeyCacheKey{
+		protocol: "https://example.com/mesh",
+		rolePath: "network/node",
+		keyID:    "key-1",
+	}
+
+	source := []byte{1, 2, 3, 4}
+	var loads atomic.Int32
+	first, err := cache.get(context.Background(), key, func(context.Context) ([]byte, error) {
+		loads.Add(1)
+		return source, nil
+	})
+	if err != nil {
+		t.Fatalf("first get: %v", err)
+	}
+
+	// Neither the loader's buffer nor a caller's returned buffer may alias the
+	// retained cache entry: both are routinely cleared by the crypto callers.
+	source[0] = 99
+	clear(first)
+
+	second, err := cache.get(context.Background(), key, func(context.Context) ([]byte, error) {
+		return nil, errors.New("cached lookup unexpectedly called loader")
+	})
+	if err != nil {
+		t.Fatalf("second get: %v", err)
+	}
+	if want := []byte{1, 2, 3, 4}; !bytes.Equal(second, want) {
+		t.Fatalf("second key = %v, want %v", second, want)
+	}
+	if got := loads.Load(); got != 1 {
+		t.Fatalf("loader calls = %d, want 1", got)
+	}
+
+	second[1] = 88
+	third, err := cache.get(context.Background(), key, func(context.Context) ([]byte, error) {
+		return nil, errors.New("cached lookup unexpectedly called loader")
+	})
+	if err != nil {
+		t.Fatalf("third get: %v", err)
+	}
+	if want := []byte{1, 2, 3, 4}; !bytes.Equal(third, want) {
+		t.Fatalf("third key = %v, want %v", third, want)
+	}
+}
+
+func TestAudienceKeyCacheDoesNotCacheFailedLookup(t *testing.T) {
+	var cache audienceKeyCache
+	key := audienceKeyCacheKey{protocol: "p", rolePath: "r", keyID: "k"}
+	wantErr := errors.New("temporary delivery query failure")
+	var loads atomic.Int32
+
+	if _, err := cache.get(context.Background(), key, func(context.Context) ([]byte, error) {
+		loads.Add(1)
+		return nil, wantErr
+	}); !errors.Is(err, wantErr) {
+		t.Fatalf("failed get error = %v, want %v", err, wantErr)
+	}
+
+	wantKey := []byte{7, 8, 9}
+	got, err := cache.get(context.Background(), key, func(context.Context) ([]byte, error) {
+		loads.Add(1)
+		return append([]byte(nil), wantKey...), nil
+	})
+	if err != nil {
+		t.Fatalf("retry get: %v", err)
+	}
+	if !bytes.Equal(got, wantKey) {
+		t.Fatalf("retry key = %v, want %v", got, wantKey)
+	}
+	if got := loads.Load(); got != 2 {
+		t.Fatalf("loader calls = %d, want 2", got)
+	}
+}
+
+func TestAudienceKeyCacheCoalescesConcurrentLookup(t *testing.T) {
+	var cache audienceKeyCache
+	key := audienceKeyCacheKey{protocol: "p", rolePath: "r", keyID: "k"}
+	wantKey := []byte{11, 12, 13}
+
+	const callers = 32
+	start := make(chan struct{})
+	loadStarted := make(chan struct{})
+	releaseLoad := make(chan struct{})
+	var startOnce sync.Once
+	var loads atomic.Int32
+	results := make(chan error, callers)
+
+	loader := func(context.Context) ([]byte, error) {
+		loads.Add(1)
+		startOnce.Do(func() { close(loadStarted) })
+		<-releaseLoad
+		return append([]byte(nil), wantKey...), nil
+	}
+
+	var ready sync.WaitGroup
+	ready.Add(callers)
+	for range callers {
+		go func() {
+			ready.Done()
+			<-start
+			got, err := cache.get(context.Background(), key, loader)
+			if err == nil && !bytes.Equal(got, wantKey) {
+				err = fmt.Errorf("key = %v, want %v", got, wantKey)
+			}
+			results <- err
+		}()
+	}
+
+	ready.Wait()
+	close(start)
+	select {
+	case <-loadStarted:
+	case <-time.After(time.Second):
+		t.Fatal("loader did not start")
+	}
+
+	// Keep the one loader blocked long enough for the remaining callers to
+	// observe its in-flight promise rather than a populated cache entry.
+	time.Sleep(25 * time.Millisecond)
+	close(releaseLoad)
+
+	for range callers {
+		select {
+		case err := <-results:
+			if err != nil {
+				t.Errorf("concurrent get: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("concurrent get did not finish")
+		}
+	}
+	if got := loads.Load(); got != 1 {
+		t.Fatalf("loader calls = %d, want 1", got)
+	}
+}
+
+func TestAudienceKeyCacheScopesEntriesByFullTuple(t *testing.T) {
+	var cache audienceKeyCache
+	keys := []audienceKeyCacheKey{
+		{protocol: "p1", rolePath: "r1", keyID: "k1"},
+		{protocol: "p2", rolePath: "r1", keyID: "k1"},
+		{protocol: "p1", rolePath: "r2", keyID: "k1"},
+		{protocol: "p1", rolePath: "r1", keyID: "k2"},
+	}
+
+	var loads atomic.Int32
+	for i, key := range keys {
+		want := []byte{byte(i + 1)}
+		got, err := cache.get(context.Background(), key, func(context.Context) ([]byte, error) {
+			loads.Add(1)
+			return append([]byte(nil), want...), nil
+		})
+		if err != nil {
+			t.Fatalf("get tuple %d: %v", i, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("tuple %d key = %v, want %v", i, got, want)
+		}
+	}
+
+	for i, key := range keys {
+		want := []byte{byte(i + 1)}
+		got, err := cache.get(context.Background(), key, func(context.Context) ([]byte, error) {
+			return nil, errors.New("cached tuple unexpectedly called loader")
+		})
+		if err != nil {
+			t.Fatalf("cached get tuple %d: %v", i, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("cached tuple %d key = %v, want %v", i, got, want)
+		}
+	}
+	if got, want := loads.Load(), int32(len(keys)); got != want {
+		t.Fatalf("loader calls = %d, want %d", got, want)
+	}
+}
+
+func TestAudienceKeyCacheCanceledWaiterDoesNotCancelLeader(t *testing.T) {
+	var cache audienceKeyCache
+	key := audienceKeyCacheKey{protocol: "p", rolePath: "r", keyID: "k"}
+	wantKey := []byte{21, 22, 23}
+
+	loadStarted := make(chan struct{})
+	releaseLoad := make(chan struct{})
+	leaderResult := make(chan error, 1)
+	go func() {
+		got, err := cache.get(context.Background(), key, func(context.Context) ([]byte, error) {
+			close(loadStarted)
+			<-releaseLoad
+			return append([]byte(nil), wantKey...), nil
+		})
+		if err == nil && !bytes.Equal(got, wantKey) {
+			err = fmt.Errorf("leader key = %v, want %v", got, wantKey)
+		}
+		leaderResult <- err
+	}()
+
+	select {
+	case <-loadStarted:
+	case <-time.After(time.Second):
+		t.Fatal("leader loader did not start")
+	}
+
+	waiterCtx, cancelWaiter := context.WithCancel(context.Background())
+	waiterResult := make(chan error, 1)
+	var waiterLoads atomic.Int32
+	go func() {
+		_, err := cache.get(waiterCtx, key, func(context.Context) ([]byte, error) {
+			waiterLoads.Add(1)
+			return nil, errors.New("waiter unexpectedly became loader")
+		})
+		waiterResult <- err
+	}()
+	cancelWaiter()
+
+	select {
+	case err := <-waiterResult:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("waiter error = %v, want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled waiter did not return")
+	}
+	if got := waiterLoads.Load(); got != 0 {
+		t.Fatalf("waiter loader calls = %d, want 0", got)
+	}
+
+	close(releaseLoad)
+	select {
+	case err := <-leaderResult:
+		if err != nil {
+			t.Fatalf("leader get: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("leader did not finish")
+	}
+
+	got, err := cache.get(context.Background(), key, func(context.Context) ([]byte, error) {
+		return nil, errors.New("completed leader did not populate cache")
+	})
+	if err != nil {
+		t.Fatalf("cached get after canceled waiter: %v", err)
+	}
+	if !bytes.Equal(got, wantKey) {
+		t.Fatalf("cached key = %v, want %v", got, wantKey)
+	}
+}
+
+func TestAudienceKeyCacheCanceledLeaderAllowsLiveWaitersToRetry(t *testing.T) {
+	var cache audienceKeyCache
+	key := audienceKeyCacheKey{protocol: "p", rolePath: "r", keyID: "k"}
+	wantKey := []byte{31, 32, 33}
+
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	leaderStarted := make(chan struct{})
+	leaderResult := make(chan error, 1)
+	go func() {
+		_, err := cache.get(leaderCtx, key, func(ctx context.Context) ([]byte, error) {
+			close(leaderStarted)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		})
+		leaderResult <- err
+	}()
+
+	select {
+	case <-leaderStarted:
+	case <-time.After(time.Second):
+		t.Fatal("leader loader did not start")
+	}
+
+	const waiters = 16
+	startWaiters := make(chan struct{})
+	results := make(chan error, waiters)
+	var retryLoads atomic.Int32
+	for range waiters {
+		go func() {
+			<-startWaiters
+			got, err := cache.get(context.Background(), key, func(context.Context) ([]byte, error) {
+				retryLoads.Add(1)
+				return append([]byte(nil), wantKey...), nil
+			})
+			if err == nil && !bytes.Equal(got, wantKey) {
+				err = fmt.Errorf("key = %v, want %v", got, wantKey)
+			}
+			results <- err
+		}()
+	}
+	close(startWaiters)
+	time.Sleep(25 * time.Millisecond)
+	cancelLeader()
+
+	select {
+	case err := <-leaderResult:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("leader error = %v, want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled leader did not return")
+	}
+
+	for range waiters {
+		select {
+		case err := <-results:
+			if err != nil {
+				t.Errorf("live waiter: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("live waiter did not finish")
+		}
+	}
+	if got := retryLoads.Load(); got != 1 {
+		t.Fatalf("retry loader calls = %d, want 1", got)
+	}
+}

--- a/internal/control/delivery_cache_test.go
+++ b/internal/control/delivery_cache_test.go
@@ -1,0 +1,216 @@
+package control
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/enboxorg/meshd/internal/did"
+	"github.com/enboxorg/meshd/internal/dwn"
+	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
+)
+
+type deliveryTestMaterial struct {
+	manager        *dwncrypto.EncryptionKeyManager
+	deliveryEntry  json.RawMessage
+	audiencePublic []byte
+	protocol       string
+	rolePath       string
+}
+
+func newDeliveryTestMaterial(t *testing.T, protocol, rolePath string) *deliveryTestMaterial {
+	t.Helper()
+
+	holderRoot, _, err := dwncrypto.GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("GenerateX25519KeyPair(holder): %v", err)
+	}
+	holderRolePrivate, err := dwncrypto.DeriveRolePathKey(holderRoot, protocol, rolePath)
+	if err != nil {
+		t.Fatalf("DeriveRolePathKey(holder): %v", err)
+	}
+	holderRolePublic, err := dwncrypto.X25519PublicKey(holderRolePrivate)
+	clear(holderRolePrivate)
+	if err != nil {
+		t.Fatalf("X25519PublicKey(holder role): %v", err)
+	}
+
+	audience, err := dwncrypto.GenerateAudienceKey()
+	if err != nil {
+		t.Fatalf("GenerateAudienceKey: %v", err)
+	}
+	audiencePublic, err := base64.RawURLEncoding.DecodeString(audience.PublicKeyJwk.X)
+	if err != nil {
+		t.Fatalf("decode audience public key: %v", err)
+	}
+	payload := dwncrypto.DeliveryPayload{
+		Protocol:    protocol,
+		RolePath:    rolePath,
+		ContextID:   "network-record",
+		KeyID:       audience.KeyID,
+		KeyMaterial: *audience,
+	}
+	payloadJSON, err := json.Marshal(&payload)
+	if err != nil {
+		t.Fatalf("marshal delivery payload: %v", err)
+	}
+	deliveryData, deliveryEncryption, err := dwncrypto.EncryptData(payloadJSON, []dwncrypto.KeyEncryptionInput{
+		{PublicKey: holderRolePublic, DerivationScheme: dwncrypto.DerivationSchemeProtocolPath},
+	})
+	if err != nil {
+		t.Fatalf("encrypt delivery payload: %v", err)
+	}
+	deliveryEntry, err := json.Marshal(map[string]any{
+		"recordId":    "delivery-record",
+		"encodedData": base64.RawURLEncoding.EncodeToString(deliveryData),
+		"encryption":  deliveryEncryption,
+	})
+	if err != nil {
+		t.Fatalf("marshal delivery entry: %v", err)
+	}
+
+	return &deliveryTestMaterial{
+		manager: &dwncrypto.EncryptionKeyManager{
+			RootPrivateKey: holderRoot,
+			ProtocolURI:    protocol,
+		},
+		deliveryEntry:  deliveryEntry,
+		audiencePublic: audiencePublic,
+		protocol:       protocol,
+		rolePath:       rolePath,
+	}
+}
+
+func (m *deliveryTestMaterial) encryptRecord(t *testing.T, plaintext []byte) ([]byte, *dwncrypto.Encryption, *dwncrypto.RoleAudienceInfo) {
+	t.Helper()
+
+	ciphertext, encryption, err := dwncrypto.EncryptData(plaintext, []dwncrypto.KeyEncryptionInput{
+		{
+			PublicKey:        m.audiencePublic,
+			DerivationScheme: dwncrypto.DerivationSchemeRoleAudience,
+			Protocol:         m.protocol,
+			RolePath:         m.rolePath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("encrypt role-audience record: %v", err)
+	}
+	info := dwncrypto.RoleAudienceEntryInfo(encryption)
+	if info == nil {
+		t.Fatal("encrypted record has no role-audience info")
+	}
+	return ciphertext, encryption, info
+}
+
+func newDeliveryTestClient(t *testing.T, endpoint string, material *deliveryTestMaterial) *DWNClient {
+	t.Helper()
+
+	identity, err := did.Generate()
+	if err != nil {
+		t.Fatalf("generate query signer: %v", err)
+	}
+	signer := &dwn.Signer{DID: identity.URI, PrivateKey: identity.SigningKey}
+	return NewDWNClient(
+		endpoint,
+		"did:example:anchor",
+		"network-record",
+		identity.URI,
+		signer,
+		WithEncryptionKeyManager(material.manager),
+		WithProtocolRole(material.rolePath),
+	)
+}
+
+func TestDecryptViaDeliveryCachesAudienceKey(t *testing.T) {
+	material := newDeliveryTestMaterial(t, "https://example.com/mesh", "network/member")
+	var queries atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		queries.Add(1)
+		sealedMockReply(t, w, "query", dwn.Status{Code: http.StatusOK, Detail: "OK"}, []json.RawMessage{
+			material.deliveryEntry,
+		})
+	}))
+	defer server.Close()
+
+	client := newDeliveryTestClient(t, server.URL, material)
+	for _, plaintext := range [][]byte{[]byte("first record"), []byte("second record")} {
+		ciphertext, encryption, info := material.encryptRecord(t, plaintext)
+		got, err := client.decryptViaDelivery(context.Background(), ciphertext, encryption, info)
+		if err != nil {
+			t.Fatalf("decryptViaDelivery(%q): %v", plaintext, err)
+		}
+		if !bytes.Equal(got, plaintext) {
+			t.Fatalf("plaintext = %q, want %q", got, plaintext)
+		}
+	}
+	if got := queries.Load(); got != 1 {
+		t.Fatalf("delivery queries = %d, want 1 for shared audience key", got)
+	}
+}
+
+func TestDecryptViaDeliveryRetriesDWNReplyRateLimitThenCaches(t *testing.T) {
+	material := newDeliveryTestMaterial(t, "https://example.com/mesh", "network/member")
+	var queries atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if queries.Add(1) == 1 {
+			// The HTTP request succeeds; the DWN reply itself carries the 429.
+			sealedMockReply(t, w, "query", dwn.Status{
+				Code: http.StatusTooManyRequests, Detail: "RateLimitExceeded: retry after 0s",
+			}, nil)
+			return
+		}
+		sealedMockReply(t, w, "query", dwn.Status{Code: http.StatusOK, Detail: "OK"}, []json.RawMessage{
+			material.deliveryEntry,
+		})
+	}))
+	defer server.Close()
+
+	client := newDeliveryTestClient(t, server.URL, material)
+	for _, plaintext := range [][]byte{[]byte("after retry"), []byte("from cache")} {
+		ciphertext, encryption, info := material.encryptRecord(t, plaintext)
+		got, err := client.decryptViaDelivery(context.Background(), ciphertext, encryption, info)
+		if err != nil {
+			t.Fatalf("decryptViaDelivery(%q): %v", plaintext, err)
+		}
+		if !bytes.Equal(got, plaintext) {
+			t.Fatalf("plaintext = %q, want %q", got, plaintext)
+		}
+	}
+	if got := queries.Load(); got != 2 {
+		t.Fatalf("delivery queries = %d, want first 429 plus one successful retry", got)
+	}
+}
+
+func TestDecryptViaDeliveryDefersLongRetryToNextPoll(t *testing.T) {
+	material := newDeliveryTestMaterial(t, "https://example.com/mesh", "network/member")
+	var queries atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		queries.Add(1)
+		w.Header().Set("Retry-After", "6")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_ = json.NewEncoder(w).Encode(dwn.JsonRpcResponse{
+			JSONRPC: "2.0",
+			Error: &dwn.JsonRpcError{
+				Code:    dwn.JsonRpcTooManyRequests,
+				Message: "tenant rate limit exceeded",
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := newDeliveryTestClient(t, server.URL, material)
+	ciphertext, encryption, info := material.encryptRecord(t, []byte("record"))
+	_, err := client.decryptViaDelivery(context.Background(), ciphertext, encryption, info)
+	if !errors.Is(err, dwn.ErrRateLimited) {
+		t.Fatalf("decryptViaDelivery error = %v, want ErrRateLimited", err)
+	}
+	if got := queries.Load(); got != 1 {
+		t.Fatalf("delivery queries = %d, want 1 when Retry-After exceeds bound", got)
+	}
+}

--- a/internal/control/dwnclient.go
+++ b/internal/control/dwnclient.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"net/netip"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -34,6 +35,31 @@ var (
 	ErrNoNetwork = errors.New("network record not found")
 	ErrNoEntry   = errors.New("no data found in entry")
 )
+
+func shouldAbortStateLoad(ctx context.Context, err error) bool {
+	return ctx.Err() != nil ||
+		errors.Is(err, dwn.ErrRateLimited) ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded)
+}
+
+func endpointFailureClass(err error) string {
+	switch {
+	case errors.Is(err, dwn.ErrRateLimited):
+		return "rate-limit"
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return "context"
+	case errors.Is(err, dwn.ErrTransport):
+		return "transport"
+	}
+	message := strings.ToLower(err.Error())
+	if strings.Contains(message, "no delivery record") ||
+		strings.Contains(message, "role audience key unavailable") ||
+		strings.Contains(message, "no key material") {
+		return "key-unavailable"
+	}
+	return "parse"
+}
 
 // dwnClientOptions holds configuration for the DWN control client.
 type dwnClientOptions struct {
@@ -145,7 +171,16 @@ type DWNClient struct {
 	// audienceSource recovers role-audience private keys via seal unsealing.
 	audienceSource *SealedAudienceSource
 
-	mu      sync.RWMutex
+	// deliveredAudienceKeys caches successfully unwrapped delivery keys and
+	// coalesces concurrent lookups. It has its own lock because record parsing
+	// can run while c.mu is held.
+	deliveredAudienceKeys audienceKeyCache
+
+	// loadMu serializes complete state refreshes and blocks snapshot readers
+	// until a refresh either commits or rolls back.
+	loadMu sync.Mutex
+	mu     sync.RWMutex
+
 	network *NetworkConfig
 	members map[string]*MemberRecord
 	nodes   map[string]*NodeRecord
@@ -161,6 +196,12 @@ type DWNClient struct {
 	// from droppedPeers because a record can fail to decrypt yet still surface a
 	// mesh IP via fallback, or decrypt yet lack a usable IP.
 	undecryptablePeers atomic.Int64
+
+	// unreadableEndpoints counts endpoint records that could not be parsed or
+	// decrypted. endpointFailures suppresses repeated warnings until recovery;
+	// both are protected independently (atomic and c.mu, respectively).
+	unreadableEndpoints atomic.Int64
+	endpointFailures    map[string]string
 
 	// droppedPeers counts (cumulatively) peers omitted from the network map
 	// because no mesh IP could be read or derived for them.
@@ -193,22 +234,23 @@ func NewDWNClient(
 	}
 
 	return &DWNClient{
-		anchorDWN:       dwn.NewClient(anchorEndpoint, signer),
-		anchorTenant:    anchorTenant,
-		networkRecordID: networkRecordID,
-		selfDID:         selfDID,
-		signer:          signer,
-		logger:          options.logger,
-		resolver:        options.resolver,
-		encManager:      options.encManager,
-		protocolRole:    protocolRole,
-		grantID:         options.grantID,
-		delegatedGrant:  options.delegatedGrant,
-		grantKeys:       options.grantKeys,
-		audienceSource:  options.audienceSource,
-		members:         make(map[string]*MemberRecord),
-		nodes:           make(map[string]*NodeRecord),
-		peerEndpoints:   make(map[string]*PeerEndpointInfo),
+		anchorDWN:        dwn.NewClient(anchorEndpoint, signer),
+		anchorTenant:     anchorTenant,
+		networkRecordID:  networkRecordID,
+		selfDID:          selfDID,
+		signer:           signer,
+		logger:           options.logger,
+		resolver:         options.resolver,
+		encManager:       options.encManager,
+		protocolRole:     protocolRole,
+		grantID:          options.grantID,
+		delegatedGrant:   options.delegatedGrant,
+		grantKeys:        options.grantKeys,
+		audienceSource:   options.audienceSource,
+		members:          make(map[string]*MemberRecord),
+		nodes:            make(map[string]*NodeRecord),
+		peerEndpoints:    make(map[string]*PeerEndpointInfo),
+		endpointFailures: make(map[string]string),
 	}
 }
 
@@ -218,6 +260,13 @@ func NewDWNClient(
 // exist in the DWN but cannot be read, so they never enter the mesh map.
 func (c *DWNClient) UndecryptablePeerCount() int64 {
 	return c.undecryptablePeers.Load()
+}
+
+// UnreadableEndpointCount returns the cumulative number of endpoint records
+// that could not be parsed or decrypted. A growing value can explain peers
+// that are listed but have no usable direct or relay path.
+func (c *DWNClient) UnreadableEndpointCount() int64 {
+	return c.unreadableEndpoints.Load()
 }
 
 // DroppedPeerCount returns the cumulative number of peers omitted from the
@@ -235,6 +284,47 @@ func (c *DWNClient) readAuth(role string) dwn.MessageAuth {
 	return dwn.MessageAuth{ProtocolRole: role, PermissionGrantID: c.grantID}
 }
 
+type dwnClientStateSnapshot struct {
+	network *NetworkConfig
+	members map[string]*MemberRecord
+	nodes   map[string]*NodeRecord
+	relays  []*RelayData
+	acl     *ACLPolicyData
+}
+
+func cloneRecordMap[T any](source map[string]*T) map[string]*T {
+	if source == nil {
+		return nil
+	}
+	clone := make(map[string]*T, len(source))
+	for key, value := range source {
+		clone[key] = value
+	}
+	return clone
+}
+
+func (c *DWNClient) stateSnapshot() dwnClientStateSnapshot {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return dwnClientStateSnapshot{
+		network: c.network,
+		members: cloneRecordMap(c.members),
+		nodes:   cloneRecordMap(c.nodes),
+		relays:  append([]*RelayData(nil), c.relays...),
+		acl:     c.acl,
+	}
+}
+
+func (c *DWNClient) restoreState(snapshot dwnClientStateSnapshot) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.network = snapshot.network
+	c.members = snapshot.members
+	c.nodes = snapshot.nodes
+	c.relays = snapshot.relays
+	c.acl = snapshot.acl
+}
+
 // LoadState reads the current mesh state from the anchor DWN and builds
 // an initial MapResponse.
 //
@@ -245,6 +335,16 @@ func (c *DWNClient) readAuth(role string) dwn.MessageAuth {
 // Both paths have nodeInfo and endpoint child records. LoadState queries
 // all paths and merges them into a unified node map keyed by DID.
 func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
+	c.loadMu.Lock()
+	previous := c.stateSnapshot()
+	committed := false
+	defer func() {
+		if !committed {
+			c.restoreState(previous)
+		}
+		c.loadMu.Unlock()
+	}()
+
 	// Determine the protocol role for queries. The anchor (network owner)
 	// can read as author without a role. Non-anchor nodes use their node
 	// role. Both network/node and network/member roles grant read access
@@ -300,62 +400,90 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 	}
 
 	nodeDecryptor := c.makeDecryptor(ctx, "network/node")
+	var nodeLoadErr error
 	c.mu.Lock()
 	clear(c.nodes) // Clear stale nodes before repopulating.
 	for _, entry := range nodeEntries {
-		c.loadNodeEntry(ctx, entry, nodeDecryptor, "")
+		if err := c.loadNodeEntry(ctx, entry, nodeDecryptor, ""); shouldAbortStateLoad(ctx, err) {
+			nodeLoadErr = err
+			break
+		}
 	}
 	c.mu.Unlock()
+	if nodeLoadErr != nil {
+		return nil, fmt.Errorf("decrypting nodes: %w", nodeLoadErr)
+	}
 
 	c.logger.DebugContext(ctx, "loaded owner-provisioned nodes", slog.Int("count", len(nodeEntries)))
 
 	// 3. Query member records (network/member) to discover members.
 	c.logger.DebugContext(ctx, "querying members")
 
+	membersReady := true
 	membersResp, err := c.anchorDWN.RecordsQueryWithAuth(ctx, c.anchorTenant, dwn.RecordsFilter{
 		Protocol:     protocols.MeshProtocolURI,
 		ProtocolPath: "network/member",
 		ContextID:    c.networkRecordID,
 	}, "createdAscending", nil, c.readAuth(role))
 	if err != nil {
-		// Non-fatal: members are optional (a simple personal mesh may have none).
+		if shouldAbortStateLoad(ctx, err) {
+			return nil, fmt.Errorf("querying members: %w", err)
+		}
 		c.logger.DebugContext(ctx, "querying members failed", slog.Any("error", err))
-	} else {
-		memberEntries, err := dwn.QueryResult(membersResp)
+		membersReady = false
+	}
+	var memberEntries []json.RawMessage
+	if membersReady {
+		memberEntries, err = dwn.QueryResult(membersResp)
 		if err != nil {
+			if shouldAbortStateLoad(ctx, err) {
+				return nil, fmt.Errorf("parsing members: %w", err)
+			}
 			c.logger.DebugContext(ctx, "parsing member results", slog.Any("error", err))
-		} else {
-			memberDecryptor := c.makeDecryptor(ctx, "network/member")
-			c.mu.Lock()
-			clear(c.members) // Clear stale members before repopulating.
-			for _, entry := range memberEntries {
-				meta := extractEntryMetadata(entry)
-				memberDID := meta.Recipient
+			membersReady = false
+		}
+	}
 
-				var member MemberRecord
-				if err := ParseEntryData(entry, &member, memberDecryptor); err != nil {
-					c.logger.DebugContext(ctx, "parsing member entry",
-						slog.Any("error", err),
-						slog.String("memberDID", memberDID),
-					)
-					// Track the member even if we can't decrypt.
-					if memberDID != "" {
-						member.DID = memberDID
-						member.RecordID = meta.RecordID
-						c.members[memberDID] = &member
-					}
-					continue
+	if membersReady {
+		memberDecryptor := c.makeDecryptor(ctx, "network/member")
+		var memberLoadErr error
+		c.mu.Lock()
+		clear(c.members) // Clear stale members before repopulating.
+		for _, entry := range memberEntries {
+			meta := extractEntryMetadata(entry)
+			memberDID := meta.Recipient
+
+			var member MemberRecord
+			if err := ParseEntryData(entry, &member, memberDecryptor); err != nil {
+				c.logger.DebugContext(ctx, "parsing member entry",
+					slog.Any("error", err),
+					slog.String("memberDID", memberDID),
+				)
+				if shouldAbortStateLoad(ctx, err) {
+					memberLoadErr = err
+					break
 				}
-				member.DID = memberDID
-				member.RecordID = meta.RecordID
+				// Track a permanently unreadable member from its public metadata so
+				// later key delivery can still target it.
 				if memberDID != "" {
+					member.DID = memberDID
+					member.RecordID = meta.RecordID
 					c.members[memberDID] = &member
 				}
+				continue
 			}
-			c.mu.Unlock()
-
-			c.logger.DebugContext(ctx, "loaded members", slog.Int("count", len(memberEntries)))
+			member.DID = memberDID
+			member.RecordID = meta.RecordID
+			if memberDID != "" {
+				c.members[memberDID] = &member
+			}
 		}
+		c.mu.Unlock()
+		if memberLoadErr != nil {
+			return nil, fmt.Errorf("decrypting members: %w", memberLoadErr)
+		}
+
+		c.logger.DebugContext(ctx, "loaded members", slog.Int("count", len(memberEntries)))
 	}
 
 	// 4. Query member-associated node records (network/member/node).
@@ -369,7 +497,9 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 			ContextID:    query.ParentContextID,
 		}, "createdAscending", nil, c.readAuth(role))
 		if err != nil {
-			// Non-fatal: member nodes are optional.
+			if shouldAbortStateLoad(ctx, err) {
+				return nil, fmt.Errorf("querying member nodes for %s: %w", query.MemberRecordID, err)
+			}
 			c.logger.DebugContext(ctx, "querying member nodes failed",
 				slog.String("memberRecordId", query.MemberRecordID),
 				slog.Any("error", err),
@@ -379,6 +509,9 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 
 		memberNodeEntries, err := dwn.QueryResult(memberNodesResp)
 		if err != nil {
+			if shouldAbortStateLoad(ctx, err) {
+				return nil, fmt.Errorf("parsing member nodes for %s: %w", query.MemberRecordID, err)
+			}
 			c.logger.DebugContext(ctx, "parsing member node results",
 				slog.String("memberRecordId", query.MemberRecordID),
 				slog.Any("error", err),
@@ -387,11 +520,18 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 		}
 
 		memberNodeDecryptor := c.makeDecryptor(ctx, "network/member/node")
+		var memberNodeLoadErr error
 		c.mu.Lock()
 		for _, entry := range memberNodeEntries {
-			c.loadNodeEntry(ctx, entry, memberNodeDecryptor, query.MemberRecordID)
+			if err := c.loadNodeEntry(ctx, entry, memberNodeDecryptor, query.MemberRecordID); shouldAbortStateLoad(ctx, err) {
+				memberNodeLoadErr = err
+				break
+			}
 		}
 		c.mu.Unlock()
+		if memberNodeLoadErr != nil {
+			return nil, fmt.Errorf("decrypting member nodes for %s: %w", query.MemberRecordID, memberNodeLoadErr)
+		}
 		memberNodeCount += len(memberNodeEntries)
 	}
 	c.logger.DebugContext(ctx, "loaded member nodes", slog.Int("count", memberNodeCount))
@@ -412,54 +552,80 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 	}
 
 	relayDecryptor := c.makeDecryptor(ctx, "network/relay")
+	var relayLoadErr error
 	c.mu.Lock()
 	c.relays = nil // Clear stale relays before repopulating.
 	for _, entry := range relayEntries {
 		var relay RelayData
 		if err := ParseEntryData(entry, &relay, relayDecryptor); err != nil {
 			c.logger.DebugContext(ctx, "parsing relay entry", slog.Any("error", err))
+			if shouldAbortStateLoad(ctx, err) {
+				relayLoadErr = err
+				break
+			}
 			continue
 		}
 		c.relays = append(c.relays, &relay)
 	}
 	c.mu.Unlock()
+	if relayLoadErr != nil {
+		return nil, fmt.Errorf("decrypting relays: %w", relayLoadErr)
+	}
 
 	// 6. Query ACL policy record.
+	aclReady := true
 	aclResp, err := c.anchorDWN.RecordsQueryWithAuth(ctx, c.anchorTenant, dwn.RecordsFilter{
 		Protocol:     protocols.MeshProtocolURI,
 		ProtocolPath: "network/aclPolicy",
 		ContextID:    c.networkRecordID,
 	}, "createdDescending", nil, c.readAuth(role))
 	if err != nil {
-		// Non-fatal: ACL policy is optional. Default to allow-all.
+		if shouldAbortStateLoad(ctx, err) {
+			return nil, fmt.Errorf("querying ACL policy: %w", err)
+		}
 		c.logger.DebugContext(ctx, "querying ACL policy failed", slog.Any("error", err))
-	} else {
-		aclEntries, err := dwn.QueryResult(aclResp)
+		aclReady = false
+	}
+	var aclEntries []json.RawMessage
+	if aclReady {
+		aclEntries, err = dwn.QueryResult(aclResp)
 		if err != nil {
-			c.logger.DebugContext(ctx, "parsing ACL policy results", slog.Any("error", err))
-		} else if len(aclEntries) > 0 {
-			// ACL policies are squashed snapshots; take the newest visible entry.
-			aclDecryptor := c.makeDecryptor(ctx, "network/aclPolicy")
-			var policy ACLPolicyData
-			if err := ParseEntryData(aclEntries[0], &policy, aclDecryptor); err != nil {
-				c.logger.DebugContext(ctx, "parsing ACL policy entry", slog.Any("error", err))
-			} else {
-				c.mu.Lock()
-				c.acl = &policy
-				c.mu.Unlock()
-				c.logger.DebugContext(ctx, "loaded ACL policy",
-					slog.Int("version", policy.Version),
-					slog.Int("rules", len(policy.Rules)),
-				)
+			if shouldAbortStateLoad(ctx, err) {
+				return nil, fmt.Errorf("parsing ACL policy results: %w", err)
 			}
+			c.logger.DebugContext(ctx, "parsing ACL policy results", slog.Any("error", err))
+			aclReady = false
+		}
+	}
+	if aclReady && len(aclEntries) > 0 {
+		// ACL policies are squashed snapshots; take the newest visible entry.
+		aclDecryptor := c.makeDecryptor(ctx, "network/aclPolicy")
+		var policy ACLPolicyData
+		if err := ParseEntryData(aclEntries[0], &policy, aclDecryptor); err != nil {
+			if shouldAbortStateLoad(ctx, err) {
+				return nil, fmt.Errorf("decrypting ACL policy: %w", err)
+			}
+			c.logger.DebugContext(ctx, "parsing ACL policy entry", slog.Any("error", err))
+		} else {
+			c.mu.Lock()
+			c.acl = &policy
+			c.mu.Unlock()
+			c.logger.DebugContext(ctx, "loaded ACL policy",
+				slog.Int("version", policy.Version),
+				slog.Int("rules", len(policy.Rules)),
+			)
 		}
 	}
 
 	// 7. Query nodeInfo records under each node's direct parent context.
-	c.loadNodeChildRecords(ctx, "nodeInfo", role, c.loadNodeInfoEntry)
+	if err := c.loadNodeChildRecords(ctx, "nodeInfo", role, c.loadNodeInfoEntry); err != nil {
+		return nil, fmt.Errorf("loading node info: %w", err)
+	}
 
 	// 8. Query endpoint records under each node's direct parent context.
-	c.loadNodeChildRecords(ctx, "endpoint", role, c.loadEndpointEntry)
+	if err := c.loadNodeChildRecords(ctx, "endpoint", role, c.loadEndpointEntry); err != nil {
+		return nil, fmt.Errorf("loading endpoints: %w", err)
+	}
 
 	hasACL := c.acl != nil
 	c.logger.DebugContext(ctx, "mesh state loaded",
@@ -474,6 +640,7 @@ func (c *DWNClient) LoadState(ctx context.Context) (*MapResponse, error) {
 	if resp == nil {
 		return nil, fmt.Errorf("self DID %q not found in network node records", c.selfDID)
 	}
+	committed = true
 	return resp, nil
 }
 
@@ -505,7 +672,7 @@ func (c *DWNClient) memberNodeParentQueries() []memberNodeParentQuery {
 // loadNodeEntry parses a node record entry and adds it to the nodes map.
 // memberRecordID is the parent member record ID (empty for owner-provisioned nodes).
 // Caller must hold c.mu.
-func (c *DWNClient) loadNodeEntry(ctx context.Context, entry json.RawMessage, decryptor EntryDecryptor, memberRecordID string) {
+func (c *DWNClient) loadNodeEntry(ctx context.Context, entry json.RawMessage, decryptor EntryDecryptor, memberRecordID string) error {
 	meta := extractEntryMetadata(entry)
 	nodeDID := meta.Recipient
 
@@ -531,7 +698,7 @@ func (c *DWNClient) loadNodeEntry(ctx context.Context, entry json.RawMessage, de
 			node.MemberRecordID = memberRecordID
 			c.nodes[nodeDID] = &node
 		}
-		return
+		return err
 	}
 	node.NormalizeOwnerDID()
 	node.DID = nodeDID
@@ -540,6 +707,7 @@ func (c *DWNClient) loadNodeEntry(ctx context.Context, entry json.RawMessage, de
 	if nodeDID != "" {
 		c.nodes[nodeDID] = &node
 	}
+	return nil
 }
 
 type nodeChildRecordQuery struct {
@@ -579,67 +747,87 @@ func (c *DWNClient) nodeChildRecordQueries(childType string) []nodeChildRecordQu
 	return queries
 }
 
-func (c *DWNClient) loadNodeChildRecords(ctx context.Context, childType string, role string, handler func(ctx context.Context, entry json.RawMessage, decryptor EntryDecryptor)) {
+type nodeChildRecordHandler func(ctx context.Context, entry json.RawMessage, decryptor EntryDecryptor) error
+
+func (c *DWNClient) loadNodeChildRecords(ctx context.Context, childType string, role string, handler nodeChildRecordHandler) error {
 	total := 0
 	for _, query := range c.nodeChildRecordQueries(childType) {
-		total += c.loadChildRecords(ctx, query.ProtocolPath, query.ParentContextID, role, handler)
+		count, err := c.loadChildRecords(ctx, query.ProtocolPath, query.ParentContextID, role, handler)
+		if err != nil {
+			return fmt.Errorf("%s under %s: %w", query.ProtocolPath, query.ParentContextID, err)
+		}
+		total += count
 	}
 	c.logger.DebugContext(ctx, "loaded node child records",
 		slog.String("type", childType),
 		slog.Int("count", total),
 	)
+	return nil
 }
 
 // loadChildRecords queries child records at the given protocol path under a
 // direct parent context and processes each entry with the provided handler.
-func (c *DWNClient) loadChildRecords(ctx context.Context, protocolPath string, parentContextID string, role string, handler func(ctx context.Context, entry json.RawMessage, decryptor EntryDecryptor)) int {
+func (c *DWNClient) loadChildRecords(ctx context.Context, protocolPath string, parentContextID string, role string, handler nodeChildRecordHandler) (int, error) {
 	resp, err := c.anchorDWN.RecordsQueryWithAuth(ctx, c.anchorTenant, dwn.RecordsFilter{
 		Protocol:     protocols.MeshProtocolURI,
 		ProtocolPath: protocolPath,
 		ContextID:    parentContextID,
 	}, "createdDescending", nil, c.readAuth(role))
 	if err != nil {
+		if shouldAbortStateLoad(ctx, err) {
+			return 0, fmt.Errorf("querying child records: %w", err)
+		}
 		c.logger.DebugContext(ctx, "querying child records failed",
 			slog.String("path", protocolPath),
 			slog.String("parentContextId", parentContextID),
 			slog.Any("error", err),
 		)
-		return 0
+		return 0, nil
 	}
 
 	entries, err := dwn.QueryResult(resp)
 	if err != nil {
+		if shouldAbortStateLoad(ctx, err) {
+			return 0, fmt.Errorf("parsing child record results: %w", err)
+		}
 		c.logger.DebugContext(ctx, "parsing child record results",
 			slog.String("path", protocolPath),
 			slog.String("parentContextId", parentContextID),
 			slog.Any("error", err),
 		)
-		return 0
+		return 0, nil
 	}
 
 	decryptor := c.makeDecryptor(ctx, protocolPath)
+	var loadErr error
 	c.mu.Lock()
 	for _, entry := range entries {
-		handler(ctx, entry, decryptor)
+		if err := handler(ctx, entry, decryptor); shouldAbortStateLoad(ctx, err) {
+			loadErr = err
+			break
+		}
 	}
 	c.mu.Unlock()
+	if loadErr != nil {
+		return 0, loadErr
+	}
 
 	c.logger.DebugContext(ctx, "loaded child records",
 		slog.String("path", protocolPath),
 		slog.String("parentContextId", parentContextID),
 		slog.Int("count", len(entries)),
 	)
-	return len(entries)
+	return len(entries), nil
 }
 
 // loadNodeInfoEntry parses a nodeInfo entry and attaches it to the parent node.
 // Caller must hold c.mu.
-func (c *DWNClient) loadNodeInfoEntry(ctx context.Context, entry json.RawMessage, decryptor EntryDecryptor) {
+func (c *DWNClient) loadNodeInfoEntry(ctx context.Context, entry json.RawMessage, decryptor EntryDecryptor) error {
 	meta := extractEntryMetadata(entry)
 	var info NodeInfoData
 	if err := ParseEntryData(entry, &info, decryptor); err != nil {
 		c.logger.DebugContext(ctx, "parsing nodeInfo entry", slog.Any("error", err))
-		return
+		return err
 	}
 
 	// Attach to parent node by matching parentId to a node's recordID.
@@ -650,30 +838,67 @@ func (c *DWNClient) loadNodeInfoEntry(ctx context.Context, entry json.RawMessage
 			break
 		}
 	}
+	return nil
 }
 
 // loadEndpointEntry parses an endpoint entry and attaches it to the parent node.
 // Caller must hold c.mu.
-func (c *DWNClient) loadEndpointEntry(ctx context.Context, entry json.RawMessage, decryptor EntryDecryptor) {
+func (c *DWNClient) loadEndpointEntry(ctx context.Context, entry json.RawMessage, decryptor EntryDecryptor) error {
 	meta := extractEntryMetadata(entry)
-	var ep EndpointData
-	if err := ParseEntryData(entry, &ep, decryptor); err != nil {
-		c.logger.DebugContext(ctx, "parsing endpoint entry", slog.Any("error", err))
-		return
+	failureKey := meta.RecordID
+	if failureKey == "" {
+		failureKey = meta.ParentID
 	}
 
-	// Attach to parent node by matching parentId to a node's recordID.
-	parentID := meta.ParentID
+	var parentNode *NodeRecord
 	for _, node := range c.nodes {
-		if node.RecordID != "" && node.RecordID == parentID {
-			node.Endpoints = append(node.Endpoints, ep)
+		if node.RecordID != "" && node.RecordID == meta.ParentID {
+			parentNode = node
 			break
 		}
 	}
+
+	var ep EndpointData
+	if err := ParseEntryData(entry, &ep, decryptor); err != nil {
+		c.unreadableEndpoints.Add(1)
+		if c.endpointFailures == nil {
+			c.endpointFailures = make(map[string]string)
+		}
+		failureClass := endpointFailureClass(err)
+		if previous, warned := c.endpointFailures[failureKey]; !warned || previous != failureClass {
+			nodeDID := meta.Recipient
+			if parentNode != nil && parentNode.DID != "" {
+				nodeDID = parentNode.DID
+			}
+			c.logger.WarnContext(ctx, "endpoint record could not be loaded; peer connectivity may be degraded",
+				slog.Any("error", err),
+				slog.String("failureClass", failureClass),
+				slog.String("nodeDID", nodeDID),
+				slog.String("recordId", meta.RecordID),
+				slog.String("parentId", meta.ParentID),
+			)
+		}
+		c.endpointFailures[failureKey] = failureClass
+		return err
+	}
+
+	if _, recovering := c.endpointFailures[failureKey]; recovering {
+		delete(c.endpointFailures, failureKey)
+		c.logger.InfoContext(ctx, "endpoint record is readable again",
+			slog.String("recordId", meta.RecordID),
+			slog.String("parentId", meta.ParentID),
+		)
+	}
+	if parentNode != nil {
+		parentNode.Endpoints = append(parentNode.Endpoints, ep)
+	}
+	return nil
 }
 
 // ACLPolicy returns the loaded ACL policy, or nil if none is configured.
 func (c *DWNClient) ACLPolicy() *ACLPolicyData {
+	c.loadMu.Lock()
+	defer c.loadMu.Unlock()
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.acl
@@ -681,16 +906,20 @@ func (c *DWNClient) ACLPolicy() *ACLPolicyData {
 
 // Members returns the loaded member records, keyed by member DID.
 func (c *DWNClient) Members() map[string]*MemberRecord {
+	c.loadMu.Lock()
+	defer c.loadMu.Unlock()
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.members
+	return cloneRecordMap(c.members)
 }
 
 // Nodes returns the loaded node records, keyed by node DID.
 func (c *DWNClient) Nodes() map[string]*NodeRecord {
+	c.loadMu.Lock()
+	defer c.loadMu.Unlock()
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.nodes
+	return cloneRecordMap(c.nodes)
 }
 
 // BuildStaticMapResponse creates a MapResponse from explicitly provided
@@ -1488,19 +1717,31 @@ func (c *DWNClient) decryptRoleAudience(ctx context.Context, ciphertext []byte, 
 // The delivery record is encrypted to this node's OWN role-path key, derived
 // from its encryption root.
 func (c *DWNClient) decryptViaDelivery(ctx context.Context, ciphertext []byte, enc *dwncrypto.Encryption, info *dwncrypto.RoleAudienceInfo) ([]byte, error) {
+	privateKey, err := c.deliveredAudienceKeys.get(ctx, audienceKeyCacheKey{
+		protocol: info.Protocol,
+		rolePath: info.RolePath,
+		keyID:    info.KeyID,
+	}, func(ctx context.Context) ([]byte, error) {
+		return c.queryDeliveryAudiencePrivateKey(ctx, info)
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer clear(privateKey)
+
+	dec, err := dwncrypto.NewRoleAudienceDecrypter(privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("using delivered audience key: %w", err)
+	}
+	defer dec.Close()
+	return dec.Decrypt(ciphertext, enc)
+}
+
+func (c *DWNClient) queryDeliveryAudiencePrivateKey(ctx context.Context, info *dwncrypto.RoleAudienceInfo) ([]byte, error) {
 	if c.encManager == nil {
 		return nil, fmt.Errorf("no encryption root available for delivery records")
 	}
-	reply, err := c.anchorDWN.RecordsQueryWithAuth(ctx, c.anchorTenant, dwn.RecordsFilter{
-		Protocol:     info.Protocol,
-		ProtocolPath: dwncrypto.EncryptionControlDeliveryPath,
-		Recipient:    c.selfDID,
-		Tags: map[string]any{
-			"protocol": info.Protocol,
-			"rolePath": info.RolePath,
-			"keyId":    info.KeyID,
-		},
-	}, "createdDescending", nil, dwn.MessageAuth{}) // recipient-readable, plain query
+	reply, err := c.queryDeliveryRecordsWithRetry(ctx, info)
 	if err != nil {
 		return nil, fmt.Errorf("querying delivery records: %w", err)
 	}
@@ -1521,22 +1762,56 @@ func (c *DWNClient) decryptViaDelivery(ctx context.Context, ciphertext []byte, e
 		if payload.KeyID != info.KeyID {
 			continue
 		}
-		audiencePriv, err := base64.RawURLEncoding.DecodeString(payload.KeyMaterial.PrivateKeyJwk.D)
+		privateKey, err := base64.RawURLEncoding.DecodeString(payload.KeyMaterial.PrivateKeyJwk.D)
 		if err != nil {
 			continue
 		}
-		dec, err := dwncrypto.NewRoleAudienceDecrypter(audiencePriv)
-		clear(audiencePriv)
-		if err != nil {
-			continue
-		}
-		plaintext, err := dec.Decrypt(ciphertext, enc)
-		dec.Close()
-		if err == nil {
-			return plaintext, nil
-		}
+		return privateKey, nil
 	}
 	return nil, fmt.Errorf("no delivery record for keyId %s at %s", info.KeyID, info.RolePath)
+}
+
+// queryDeliveryRecordsWithRetry makes at most one bounded retry of this
+// read-only query. The outer control poll remains the long-lived retry path.
+func (c *DWNClient) queryDeliveryRecordsWithRetry(ctx context.Context, info *dwncrypto.RoleAudienceInfo) (*dwn.DwnReply, error) {
+	query := func() (*dwn.DwnReply, error) {
+		return c.anchorDWN.RecordsQueryWithAuth(ctx, c.anchorTenant, dwn.RecordsFilter{
+			Protocol:     info.Protocol,
+			ProtocolPath: dwncrypto.EncryptionControlDeliveryPath,
+			Recipient:    c.selfDID,
+			Tags: map[string]any{
+				"protocol": info.Protocol,
+				"rolePath": info.RolePath,
+				"keyId":    info.KeyID,
+			},
+		}, "createdDescending", nil, dwn.MessageAuth{})
+	}
+
+	reply, err := query()
+	if err == nil || !errors.Is(err, dwn.ErrRateLimited) {
+		return reply, err
+	}
+
+	delay := time.Second
+	var rateLimitErr *dwn.RateLimitError
+	if errors.As(err, &rateLimitErr) {
+		delay = rateLimitErr.RetryAfter
+	}
+	if delay < 250*time.Millisecond {
+		delay = 250 * time.Millisecond
+	}
+	if delay > 5*time.Second {
+		return nil, err
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-timer.C:
+	}
+	return query()
 }
 
 // entryEncryptionAndData extracts the encryption envelope and decoded data

--- a/internal/control/observability_rate_test.go
+++ b/internal/control/observability_rate_test.go
@@ -1,0 +1,160 @@
+package control
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/enboxorg/meshd/internal/did"
+	"github.com/enboxorg/meshd/internal/dwn"
+	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
+)
+
+func TestLoadEndpointEntryWarnsWhenFailureClassChanges(t *testing.T) {
+	handler := &captureHandler{}
+	const (
+		peerDID      = "did:jwk:endpoint-class-transition"
+		nodeRecordID = "node-record"
+	)
+	client := &DWNClient{
+		logger: slog.New(handler),
+		nodes: map[string]*NodeRecord{
+			peerDID: {DID: peerDID, RecordID: nodeRecordID},
+		},
+	}
+
+	entry := json.RawMessage(`{"recordsWrite":{"recordId":"endpoint-record","descriptor":{"recipient":"` +
+		peerDID + `","parentId":"` + nodeRecordID + `"},"encodedData":"AAAA","encryption":{}}}`)
+	parseErr := errors.New("delivery query failed")
+	parseFailure := func([]byte, *dwncrypto.Encryption) ([]byte, error) {
+		return nil, parseErr
+	}
+	if err := client.loadEndpointEntry(context.Background(), entry, parseFailure); !errors.Is(err, parseErr) {
+		t.Fatalf("loadEndpointEntry parse error = %v, want %v", err, parseErr)
+	}
+
+	keyErr := errors.New("no delivery record for keyId changed at network/member")
+	keyFailure := func([]byte, *dwncrypto.Encryption) ([]byte, error) {
+		return nil, keyErr
+	}
+	if err := client.loadEndpointEntry(context.Background(), entry, keyFailure); !errors.Is(err, keyErr) {
+		t.Fatalf("loadEndpointEntry key error = %v, want %v", err, keyErr)
+	}
+
+	if got := client.UnreadableEndpointCount(); got != 2 {
+		t.Fatalf("UnreadableEndpointCount = %d, want 2", got)
+	}
+	if got := handler.count(slog.LevelWarn, "endpoint record could not be loaded; peer connectivity may be degraded"); got != 2 {
+		t.Fatalf("endpoint warnings = %d, want 2 after failure class changes", got)
+	}
+
+	recovered := func([]byte, *dwncrypto.Encryption) ([]byte, error) {
+		return []byte(`{"localEndpoints":["192.0.2.1:1234"],"discoKey":"disco","updatedAt":"2026-07-11T00:00:00Z"}`), nil
+	}
+	if err := client.loadEndpointEntry(context.Background(), entry, recovered); err != nil {
+		t.Fatalf("recovered loadEndpointEntry: %v", err)
+	}
+	if got := len(client.nodes[peerDID].Endpoints); got != 1 {
+		t.Fatalf("peer endpoints = %d, want 1 after recovery", got)
+	}
+	if got := handler.count(slog.LevelInfo, "endpoint record is readable again"); got != 1 {
+		t.Fatalf("endpoint recovery logs = %d, want 1", got)
+	}
+}
+
+func TestLoadChildRecordsPropagatesContextAbort(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		sealedMockReply(t, w, "query", dwn.Status{Code: http.StatusOK, Detail: "OK"}, []json.RawMessage{
+			json.RawMessage(`{"recordId":"endpoint-record"}`),
+			json.RawMessage(`{"recordId":"second-endpoint-record"}`),
+		})
+	}))
+	defer server.Close()
+
+	identity, err := did.Generate()
+	if err != nil {
+		t.Fatalf("generate query signer: %v", err)
+	}
+	signer := &dwn.Signer{DID: identity.URI, PrivateKey: identity.SigningKey}
+	client := NewDWNClient(
+		server.URL,
+		identity.URI,
+		"network-record",
+		identity.URI,
+		signer,
+	)
+
+	t.Run("handler deadline", func(t *testing.T) {
+		wantErr := fmt.Errorf("delivery lookup: %w", context.DeadlineExceeded)
+		count, err := client.loadChildRecords(
+			context.Background(),
+			"network/node/endpoint",
+			"network-record/node-record",
+			"",
+			func(context.Context, json.RawMessage, EntryDecryptor) error {
+				return wantErr
+			},
+		)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("loadChildRecords error = %v, want context.DeadlineExceeded", err)
+		}
+		if count != 0 {
+			t.Fatalf("loadChildRecords count = %d, want 0 for incomplete snapshot", count)
+		}
+	})
+
+	t.Run("pre-canceled query context", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		count, err := client.loadChildRecords(
+			ctx,
+			"network/node/endpoint",
+			"network-record/node-record",
+			"",
+			func(context.Context, json.RawMessage, EntryDecryptor) error {
+				t.Fatal("handler called for a pre-canceled query")
+				return nil
+			},
+		)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("loadChildRecords error = %v, want context.Canceled", err)
+		}
+		if count != 0 {
+			t.Fatalf("loadChildRecords count = %d, want 0 for canceled query", count)
+		}
+	})
+
+	t.Run("ctx error aborts generic handler failure", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		genericErr := errors.New("generic parse failure")
+		calls := 0
+		count, err := client.loadChildRecords(
+			ctx,
+			"network/node/endpoint",
+			"network-record/node-record",
+			"",
+			func(context.Context, json.RawMessage, EntryDecryptor) error {
+				calls++
+				cancel()
+				return genericErr
+			},
+		)
+		if !errors.Is(err, genericErr) {
+			t.Fatalf("loadChildRecords error = %v, want %v", err, genericErr)
+		}
+		if !errors.Is(ctx.Err(), context.Canceled) {
+			t.Fatalf("context error = %v, want context.Canceled", ctx.Err())
+		}
+		if calls != 1 {
+			t.Fatalf("handler calls = %d, want 1 before cancellation aborts the remaining entry", calls)
+		}
+		if count != 0 {
+			t.Fatalf("loadChildRecords count = %d, want 0 for incomplete snapshot", count)
+		}
+	})
+}

--- a/internal/control/observability_test.go
+++ b/internal/control/observability_test.go
@@ -4,11 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
 
+	"github.com/enboxorg/meshd/internal/did"
+	"github.com/enboxorg/meshd/internal/dwn"
 	dwncrypto "github.com/enboxorg/meshd/internal/dwn/crypto"
 )
 
@@ -29,7 +34,7 @@ func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
 }
 
 func (h *captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
-func (h *captureHandler) WithGroup(string) slog.Handler       { return h }
+func (h *captureHandler) WithGroup(string) slog.Handler      { return h }
 
 // warnFor reports whether a WARN record was emitted whose attributes include
 // nodeDID/did == wantDID.
@@ -131,5 +136,105 @@ func TestBuildMapResponseCountsDroppedPeer(t *testing.T) {
 	}
 	if !strings.HasPrefix(resp.Node.DID, "did:jwk:self") {
 		t.Fatalf("self node = %+v, want self retained", resp.Node)
+	}
+}
+
+func (h *captureHandler) count(level slog.Level, message string) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	count := 0
+	for _, record := range h.records {
+		if record.Level == level && record.Message == message {
+			count++
+		}
+	}
+	return count
+}
+
+func TestLoadEndpointEntryWarnsOnceAndReportsRecovery(t *testing.T) {
+	handler := &captureHandler{}
+	const (
+		peerDID      = "did:jwk:endpoint-peer"
+		nodeRecordID = "node-record"
+	)
+	c := &DWNClient{
+		logger: slog.New(handler),
+		nodes: map[string]*NodeRecord{
+			peerDID: {DID: peerDID, RecordID: nodeRecordID},
+		},
+	}
+
+	entry := json.RawMessage(`{"recordsWrite":{"recordId":"endpoint-record","descriptor":{"recipient":"` +
+		peerDID + `","parentId":"` + nodeRecordID + `"},"encodedData":"AAAA","encryption":{}}}`)
+	wantErr := errors.New("delivery query failed")
+	failing := func([]byte, *dwncrypto.Encryption) ([]byte, error) {
+		return nil, wantErr
+	}
+
+	for range 2 {
+		if err := c.loadEndpointEntry(context.Background(), entry, failing); !errors.Is(err, wantErr) {
+			t.Fatalf("loadEndpointEntry error = %v, want %v", err, wantErr)
+		}
+	}
+	if got := c.UnreadableEndpointCount(); got != 2 {
+		t.Fatalf("UnreadableEndpointCount = %d, want 2", got)
+	}
+	if !handler.warnFor(peerDID) {
+		t.Fatalf("expected endpoint warning naming %q", peerDID)
+	}
+	if got := handler.count(slog.LevelWarn, "endpoint record could not be loaded; peer connectivity may be degraded"); got != 1 {
+		t.Fatalf("endpoint warnings = %d, want 1 for repeated identical failure", got)
+	}
+
+	recovered := func([]byte, *dwncrypto.Encryption) ([]byte, error) {
+		return []byte(`{"localEndpoints":["192.0.2.1:1234"],"discoKey":"disco","updatedAt":"2026-07-11T00:00:00Z"}`), nil
+	}
+	if err := c.loadEndpointEntry(context.Background(), entry, recovered); err != nil {
+		t.Fatalf("recovered loadEndpointEntry: %v", err)
+	}
+	if got := len(c.nodes[peerDID].Endpoints); got != 1 {
+		t.Fatalf("peer endpoints = %d, want 1 after recovery", got)
+	}
+	if got := handler.count(slog.LevelInfo, "endpoint record is readable again"); got != 1 {
+		t.Fatalf("endpoint recovery logs = %d, want 1", got)
+	}
+}
+
+func TestLoadChildRecordsPropagatesRateLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		sealedMockReply(t, w, "query", dwn.Status{Code: http.StatusOK, Detail: "OK"}, []json.RawMessage{
+			json.RawMessage(`{"recordId":"endpoint-record"}`),
+		})
+	}))
+	defer server.Close()
+
+	identity, err := did.Generate()
+	if err != nil {
+		t.Fatalf("generate query signer: %v", err)
+	}
+	signer := &dwn.Signer{DID: identity.URI, PrivateKey: identity.SigningKey}
+	client := NewDWNClient(
+		server.URL,
+		identity.URI,
+		"network-record",
+		identity.URI,
+		signer,
+	)
+	wantErr := fmt.Errorf("delivery lookup: %w", dwn.ErrRateLimited)
+	count, err := client.loadChildRecords(
+		context.Background(),
+		"network/node/endpoint",
+		"network-record/node-record",
+		"",
+		func(context.Context, json.RawMessage, EntryDecryptor) error {
+			return wantErr
+		},
+	)
+	if !errors.Is(err, dwn.ErrRateLimited) {
+		t.Fatalf("loadChildRecords error = %v, want ErrRateLimited", err)
+	}
+	if count != 0 {
+		t.Fatalf("loadChildRecords count = %d, want 0 for incomplete snapshot", count)
 	}
 }

--- a/internal/control/state_transaction_test.go
+++ b/internal/control/state_transaction_test.go
@@ -1,0 +1,158 @@
+package control
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/enboxorg/meshd/internal/dwn"
+)
+
+func TestLoadStateRollsBackCachedStateOnReplyRateLimit(t *testing.T) {
+	identity, signer, _, _ := sealedTestOwner(t)
+
+	oldNetwork := &NetworkConfig{Name: "old-network", MeshCIDR: "10.200.0.0/16"}
+	oldNode := &NodeRecord{DID: identity.URI, MeshIP: "10.200.0.2", Label: "old-node", RecordID: "old-node-record"}
+	oldMember := &MemberRecord{DID: "did:example:old-member", Label: "old-member", RecordID: "old-member-record"}
+	oldRelay := &RelayData{URL: "https://old-relay.example", Region: "old-region"}
+	oldACL := &ACLPolicyData{Version: 1, DefaultAction: "deny"}
+
+	newNetworkEntry := stateTransactionEntry(t, "", "", NetworkConfig{
+		Name:     "new-network",
+		MeshCIDR: "10.201.0.0/16",
+	})
+	newNodeEntry := stateTransactionEntry(t, "new-node-record", identity.URI, NodeRecord{
+		MeshIP: "10.201.0.2",
+		Label:  "new-node",
+	})
+	newMemberEntry := stateTransactionEntry(t, "new-member-record", "did:example:new-member", MemberRecord{
+		Label:   "new-member",
+		AddedAt: "2026-07-11T00:00:00Z",
+	})
+	newRelayEntry := stateTransactionEntry(t, "", "", RelayData{
+		URL:    "https://new-relay.example",
+		Region: "new-region",
+	})
+	newACLEntry := stateTransactionEntry(t, "", "", ACLPolicyData{
+		Version:       2,
+		DefaultAction: "accept",
+	})
+
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request dwn.JsonRpcRequest
+		if err := json.Unmarshal([]byte(r.Header.Get("dwn-request")), &request); err != nil {
+			t.Errorf("decode DWN request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		reply := &dwn.DwnReply{Status: dwn.Status{Code: http.StatusOK, Detail: "OK"}}
+		switch requestCount.Add(1) {
+		case 1: // Network record read.
+			reply.Entry = newNetworkEntry
+		case 2: // Owner node query.
+			reply.Entries = stateTransactionEntries(t, newNodeEntry)
+		case 3: // Member query.
+			reply.Entries = stateTransactionEntries(t, newMemberEntry)
+		case 4: // Member-associated node query.
+			reply.Entries = stateTransactionEntries(t)
+		case 5: // Relay query.
+			reply.Entries = stateTransactionEntries(t, newRelayEntry)
+		case 6: // ACL policy query.
+			reply.Entries = stateTransactionEntries(t, newACLEntry)
+		case 7: // First node child query, after every cached state field changed.
+			reply.Status = dwn.Status{
+				Code:   http.StatusTooManyRequests,
+				Detail: "RateLimitExceeded: tenant rate limit exceeded, retry after 6s",
+			}
+		default:
+			t.Errorf("unexpected DWN request %d", requestCount.Load())
+			reply.Status = dwn.Status{Code: http.StatusInternalServerError, Detail: "unexpected request"}
+		}
+
+		if err := json.NewEncoder(w).Encode(dwn.JsonRpcResponse{
+			JSONRPC: "2.0",
+			ID:      request.ID,
+			Result:  &dwn.JsonRpcResult{Reply: reply},
+		}); err != nil {
+			t.Errorf("encode DWN response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client := NewDWNClient(server.URL, identity.URI, "network-record", identity.URI, signer)
+	client.network = oldNetwork
+	client.nodes = map[string]*NodeRecord{oldNode.DID: oldNode}
+	client.members = map[string]*MemberRecord{oldMember.DID: oldMember}
+	client.relays = []*RelayData{oldRelay}
+	client.acl = oldACL
+
+	_, err := client.LoadState(context.Background())
+	if !errors.Is(err, dwn.ErrRateLimited) {
+		t.Fatalf("LoadState error = %v, want ErrRateLimited", err)
+	}
+	var rateErr *dwn.RateLimitError
+	if !errors.As(err, &rateErr) {
+		t.Fatalf("LoadState error = %T %v, want *dwn.RateLimitError", err, err)
+	}
+	if rateErr.RetryAfter != 6*time.Second {
+		t.Fatalf("retry delay = %v, want 6s", rateErr.RetryAfter)
+	}
+	if got := requestCount.Load(); got != 7 {
+		t.Fatalf("DWN request count = %d, want 7", got)
+	}
+
+	client.mu.RLock()
+	defer client.mu.RUnlock()
+	if client.network != oldNetwork {
+		t.Errorf("network = %#v, want original cached pointer %#v", client.network, oldNetwork)
+	}
+	if len(client.nodes) != 1 || client.nodes[oldNode.DID] != oldNode {
+		t.Errorf("nodes = %#v, want only original cached node %#v", client.nodes, oldNode)
+	}
+	if len(client.members) != 1 || client.members[oldMember.DID] != oldMember {
+		t.Errorf("members = %#v, want only original cached member %#v", client.members, oldMember)
+	}
+	if len(client.relays) != 1 || client.relays[0] != oldRelay {
+		t.Errorf("relays = %#v, want only original cached relay %#v", client.relays, oldRelay)
+	}
+	if client.acl != oldACL {
+		t.Errorf("ACL = %#v, want original cached pointer %#v", client.acl, oldACL)
+	}
+}
+
+func stateTransactionEntry(t *testing.T, recordID, recipient string, value any) json.RawMessage {
+	t.Helper()
+
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal entry data: %v", err)
+	}
+	entry, err := json.Marshal(map[string]any{
+		"recordId": recordID,
+		"descriptor": map[string]any{
+			"recipient": recipient,
+		},
+		"encodedData": base64.RawURLEncoding.EncodeToString(data),
+	})
+	if err != nil {
+		t.Fatalf("marshal entry: %v", err)
+	}
+	return entry
+}
+
+func stateTransactionEntries(t *testing.T, entries ...json.RawMessage) json.RawMessage {
+	t.Helper()
+	encoded, err := json.Marshal(entries)
+	if err != nil {
+		t.Fatalf("marshal entries: %v", err)
+	}
+	return encoded
+}

--- a/internal/dwn/client.go
+++ b/internal/dwn/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -158,6 +159,9 @@ func (c *Client) RecordsQueryWithAuth(ctx context.Context, target string, filter
 	if err != nil {
 		return nil, err
 	}
+	if result.Reply != nil && result.Reply.Status.Code == http.StatusTooManyRequests {
+		return nil, queryRateLimitError(result.Reply.Status)
+	}
 
 	return result.Reply, nil
 }
@@ -221,6 +225,9 @@ func QueryEntries(reply *DwnReply) ([]json.RawMessage, error) {
 	if reply == nil {
 		return nil, fmt.Errorf("nil reply")
 	}
+	if reply.Status.Code == http.StatusTooManyRequests {
+		return nil, queryRateLimitError(reply.Status)
+	}
 	if reply.Status.Code != 200 {
 		return nil, fmt.Errorf("query failed: %d %s", reply.Status.Code, reply.Status.Detail)
 	}
@@ -233,6 +240,38 @@ func QueryEntries(reply *DwnReply) ([]json.RawMessage, error) {
 		return nil, fmt.Errorf("unmarshaling entries: %w", err)
 	}
 	return entries, nil
+}
+
+func queryRateLimitError(status Status) *RateLimitError {
+	retryAfter := defaultRateLimitRetryAfter
+	if parsed, ok := retryAfterFromStatusDetail(status.Detail); ok {
+		retryAfter = parsed
+	}
+	detail := fmt.Sprintf("query failed: %d", status.Code)
+	if trimmed := strings.TrimSpace(status.Detail); trimmed != "" {
+		detail += " " + trimmed
+	}
+	return &RateLimitError{RetryAfter: retryAfter, Detail: detail}
+}
+
+func retryAfterFromStatusDetail(detail string) (time.Duration, bool) {
+	const marker = "retry after "
+	lowerDetail := strings.ToLower(detail)
+	markerIndex := strings.LastIndex(lowerDetail, marker)
+	if markerIndex < 0 {
+		return 0, false
+	}
+	tail := strings.TrimSpace(detail[markerIndex+len(marker):])
+	fields := strings.Fields(tail)
+	if len(fields) == 0 {
+		return 0, false
+	}
+	durationText := strings.TrimRight(fields[0], ".,;")
+	retryAfter, err := time.ParseDuration(durationText)
+	if err != nil || retryAfter < 0 {
+		return 0, false
+	}
+	return retryAfter, true
 }
 
 // ReadEntry extracts the entry from a read reply.

--- a/internal/dwn/client_test.go
+++ b/internal/dwn/client_test.go
@@ -1,0 +1,70 @@
+package dwn
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRecordsQueryWithAuthRateLimitedReply(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if err := json.NewEncoder(w).Encode(JsonRpcResponse{
+			JSONRPC: "2.0",
+			Result: &JsonRpcResult{
+				Reply: &DwnReply{Status: Status{Code: http.StatusTooManyRequests, Detail: "RateLimitExceeded: retry after 2s"}},
+			},
+		}); err != nil {
+			t.Errorf("encoding response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, newTestSigner(t))
+	_, err := client.RecordsQueryWithAuth(
+		context.Background(), "did:example:target", RecordsFilter{Protocol: "test"},
+		"", nil, MessageAuth{},
+	)
+	requireRateLimitError(t, err, 2*time.Second)
+}
+
+func TestQueryEntriesRateLimited(t *testing.T) {
+	tests := []struct {
+		name   string
+		detail string
+		want   time.Duration
+	}{
+		{name: "reported delay", detail: "RateLimitExceeded: tenant rate limit exceeded, retry after 3s", want: 3 * time.Second},
+		{name: "default delay", detail: "Too Many Requests", want: time.Second},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := QueryEntries(&DwnReply{Status: Status{Code: 429, Detail: tc.detail}})
+			requireRateLimitError(t, err, tc.want)
+		})
+	}
+}
+
+func TestQueryResultDelegatesRateLimited(t *testing.T) {
+	reply := &Response{Status: Status{Code: 429, Detail: "RateLimitExceeded: retry after 1s"}}
+	_, err := QueryResult(reply)
+	requireRateLimitError(t, err, time.Second)
+}
+
+func requireRateLimitError(t *testing.T, err error, wantRetryAfter time.Duration) {
+	t.Helper()
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("errors.Is(%v, ErrRateLimited) = false", err)
+	}
+	var rateErr *RateLimitError
+	if !errors.As(err, &rateErr) {
+		t.Fatalf("error = %T %v, want *RateLimitError", err, err)
+	}
+	if rateErr.RetryAfter != wantRetryAfter {
+		t.Errorf("RetryAfter = %v, want %v", rateErr.RetryAfter, wantRetryAfter)
+	}
+}

--- a/internal/dwn/transport.go
+++ b/internal/dwn/transport.go
@@ -16,6 +16,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -27,16 +29,37 @@ var (
 	ErrRateLimited = errors.New("rate limited")
 )
 
+// RateLimitError reports a DWN rate-limit response and carries the delay the
+// server asked the caller to observe before retrying.
+//
+// It unwraps to ErrRateLimited so callers can use errors.Is without depending
+// on transport-specific response details.
+type RateLimitError struct {
+	RetryAfter time.Duration
+	Detail     string
+}
+
+func (e *RateLimitError) Error() string {
+	if e == nil || e.Detail == "" {
+		return ErrRateLimited.Error()
+	}
+	return fmt.Sprintf("%s: %s", ErrRateLimited, e.Detail)
+}
+
+func (e *RateLimitError) Unwrap() error {
+	return ErrRateLimited
+}
+
 //
 // --- JSON-RPC 2.0 types ---
 //
 
 // JsonRpcRequest is a JSON-RPC 2.0 request per the DWN server wire protocol.
 type JsonRpcRequest struct {
-	JSONRPC      string              `json:"jsonrpc"`
-	ID           string              `json:"id,omitempty"`
-	Method       string              `json:"method"`
-	Params       *JsonRpcParams      `json:"params,omitempty"`
+	JSONRPC      string               `json:"jsonrpc"`
+	ID           string               `json:"id,omitempty"`
+	Method       string               `json:"method"`
+	Params       *JsonRpcParams       `json:"params,omitempty"`
 	Subscription *JsonRpcSubscription `json:"subscription,omitempty"`
 }
 
@@ -55,10 +78,10 @@ type JsonRpcSubscription struct {
 
 // JsonRpcResponse is a JSON-RPC 2.0 response.
 type JsonRpcResponse struct {
-	JSONRPC string           `json:"jsonrpc"`
-	ID      string           `json:"id,omitempty"`
-	Result  *JsonRpcResult   `json:"result,omitempty"`
-	Error   *JsonRpcError    `json:"error,omitempty"`
+	JSONRPC string         `json:"jsonrpc"`
+	ID      string         `json:"id,omitempty"`
+	Result  *JsonRpcResult `json:"result,omitempty"`
+	Error   *JsonRpcError  `json:"error,omitempty"`
 }
 
 // JsonRpcResult wraps the DWN reply.
@@ -97,7 +120,9 @@ func (e *JsonRpcError) Error() string {
 
 // JSON-RPC error codes matching the DWN server.
 const (
-	JsonRpcInvalidParams = -32602
+	JsonRpcInvalidParams       = -32602
+	JsonRpcTooManyRequests     = -50429
+	defaultRateLimitRetryAfter = time.Second
 )
 
 // JSON-RPC method names.
@@ -262,7 +287,7 @@ func (t *HTTPTransport) Send(ctx context.Context, target string, msg *Message, d
 
 	resp, err := t.httpClient.Do(httpReq)
 	if err != nil {
-		return nil, fmt.Errorf("%w: sending HTTP request: %v", ErrTransport, err)
+		return nil, fmt.Errorf("%w: sending HTTP request: %w", ErrTransport, err)
 	}
 	defer resp.Body.Close()
 
@@ -283,7 +308,13 @@ func (t *HTTPTransport) parseResponse(resp *http.Response) (*SendResult, error) 
 		}
 
 		if rpcResp.Error != nil {
+			if rpcResp.Error.Code == JsonRpcTooManyRequests || resp.StatusCode == http.StatusTooManyRequests {
+				return nil, newRateLimitError(resp, rpcResp.Error, "")
+			}
 			return nil, rpcResp.Error
+		}
+		if resp.StatusCode == http.StatusTooManyRequests {
+			return nil, newRateLimitError(resp, nil, "HTTP 429")
 		}
 
 		// Read the binary data from the body.
@@ -305,23 +336,32 @@ func (t *HTTPTransport) parseResponse(resp *http.Response) (*SendResult, error) 
 		return nil, fmt.Errorf("%w: reading response body: %v", ErrTransport, err)
 	}
 
-	// Handle non-JSON-RPC error responses (e.g., per-IP rate limit).
+	var rpcResp JsonRpcResponse
+	parseErr := json.Unmarshal(respBody, &rpcResp)
+
+	// HTTP 429 is authoritative even when a per-IP limiter returns plain JSON
+	// instead of a JSON-RPC envelope.
 	if resp.StatusCode == http.StatusTooManyRequests {
-		// Try to parse as JSON-RPC first.
-		var rpcResp JsonRpcResponse
-		if err := json.Unmarshal(respBody, &rpcResp); err == nil && rpcResp.Error != nil {
-			return nil, fmt.Errorf("%w: %s", ErrRateLimited, rpcResp.Error.Message)
+		var rpcErr *JsonRpcError
+		if parseErr == nil {
+			rpcErr = rpcResp.Error
 		}
-		return nil, fmt.Errorf("%w: HTTP 429: %s", ErrRateLimited, string(respBody))
+		detail := "HTTP 429"
+		if rpcErr == nil && len(strings.TrimSpace(string(respBody))) > 0 {
+			detail += ": " + strings.TrimSpace(string(respBody))
+		}
+		return nil, newRateLimitError(resp, rpcErr, detail)
 	}
 
-	var rpcResp JsonRpcResponse
-	if err := json.Unmarshal(respBody, &rpcResp); err != nil {
+	if parseErr != nil {
 		return nil, fmt.Errorf("%w: parsing response body (HTTP %d): %s: %v",
-			ErrTransport, resp.StatusCode, string(respBody), err)
+			ErrTransport, resp.StatusCode, string(respBody), parseErr)
 	}
 
 	if rpcResp.Error != nil {
+		if rpcResp.Error.Code == JsonRpcTooManyRequests {
+			return nil, newRateLimitError(resp, rpcResp.Error, "")
+		}
 		return nil, rpcResp.Error
 	}
 
@@ -330,4 +370,68 @@ func (t *HTTPTransport) parseResponse(resp *http.Response) (*SendResult, error) 
 		result.Reply = rpcResp.Result.Reply
 	}
 	return result, nil
+}
+
+func newRateLimitError(resp *http.Response, rpcErr *JsonRpcError, fallbackDetail string) *RateLimitError {
+	retryAfter, ok := parseRetryAfter(resp.Header.Get("Retry-After"), time.Now())
+	if !ok && rpcErr != nil {
+		retryAfter, ok = retryAfterFromRPCData(rpcErr.Data)
+	}
+	if !ok {
+		retryAfter = defaultRateLimitRetryAfter
+	}
+
+	detail := fallbackDetail
+	if rpcErr != nil && strings.TrimSpace(rpcErr.Message) != "" {
+		detail = strings.TrimSpace(rpcErr.Message)
+	}
+
+	return &RateLimitError{RetryAfter: retryAfter, Detail: detail}
+}
+
+// parseRetryAfter parses both Retry-After forms defined by HTTP: a decimal
+// delay in seconds or an HTTP date. Invalid and overflowing values are ignored.
+func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, false
+	}
+
+	if seconds, err := strconv.ParseUint(value, 10, 64); err == nil {
+		return retryAfterSeconds(seconds)
+	}
+
+	retryAt, err := http.ParseTime(value)
+	if err != nil {
+		return 0, false
+	}
+	delay := retryAt.Sub(now)
+	if delay < 0 {
+		return 0, true
+	}
+	return delay, true
+}
+
+func retryAfterFromRPCData(raw json.RawMessage) (time.Duration, bool) {
+	if len(raw) == 0 {
+		return 0, false
+	}
+	var data struct {
+		RetryAfterSec *int64 `json:"retryAfterSec"`
+	}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return 0, false
+	}
+	if data.RetryAfterSec == nil || *data.RetryAfterSec < 0 {
+		return 0, false
+	}
+	return retryAfterSeconds(uint64(*data.RetryAfterSec))
+}
+
+func retryAfterSeconds(seconds uint64) (time.Duration, bool) {
+	maxSeconds := uint64(time.Duration(1<<63-1) / time.Second)
+	if seconds > maxSeconds {
+		return 0, false
+	}
+	return time.Duration(seconds) * time.Second, true
 }

--- a/internal/dwn/transport_test.go
+++ b/internal/dwn/transport_test.go
@@ -3,11 +3,13 @@ package dwn
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewJsonRpcRequest(t *testing.T) {
@@ -393,11 +395,8 @@ func TestHTTPTransportSend(t *testing.T) {
 		}
 
 		var rpcErr *JsonRpcError
-		if ok := errorAs(err, &rpcErr); !ok {
-			// The error might not unwrap directly, check the message.
-			if !strings.Contains(err.Error(), "missing required field") {
-				t.Errorf("error = %v, should mention 'missing required field'", err)
-			}
+		if !errors.As(err, &rpcErr) {
+			t.Fatalf("error = %T %v, want *JsonRpcError", err, err)
 		}
 	})
 
@@ -416,8 +415,15 @@ func TestHTTPTransportSend(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for rate limit")
 		}
-		if !strings.Contains(err.Error(), "rate limit") {
-			t.Errorf("error = %v, should mention rate limit", err)
+		if !errors.Is(err, ErrRateLimited) {
+			t.Fatalf("errors.Is(%v, ErrRateLimited) = false", err)
+		}
+		var rateErr *RateLimitError
+		if !errors.As(err, &rateErr) {
+			t.Fatalf("error = %T %v, want *RateLimitError", err, err)
+		}
+		if rateErr.RetryAfter != 5*time.Second {
+			t.Errorf("RetryAfter = %v, want 5s", rateErr.RetryAfter)
 		}
 	})
 }
@@ -455,11 +461,6 @@ func TestHTTPTransportNoTenantInURL(t *testing.T) {
 	}
 }
 
-// errorAs is a helper to match errors.As with a pointer type.
-func errorAs(err error, target any) bool {
-	return false // JsonRpcError implements error interface but may not unwrap directly
-}
-
 func TestJsonRpcErrorInterface(t *testing.T) {
 	err := &JsonRpcError{
 		Code:    JsonRpcInvalidParams,
@@ -470,5 +471,119 @@ func TestJsonRpcErrorInterface(t *testing.T) {
 	var e error = err
 	if e.Error() != "JSON-RPC error -32602: test error" {
 		t.Errorf("Error() = %q", e.Error())
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	now := time.Date(2026, time.July, 11, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		value string
+		want  time.Duration
+		ok    bool
+	}{
+		{name: "delay seconds", value: "5", want: 5 * time.Second, ok: true},
+		{name: "trimmed delay seconds", value: " 5 ", want: 5 * time.Second, ok: true},
+		{name: "zero", value: "0", want: 0, ok: true},
+		{name: "HTTP date", value: now.Add(7 * time.Second).Format(http.TimeFormat), want: 7 * time.Second, ok: true},
+		{name: "past HTTP date", value: now.Add(-time.Second).Format(http.TimeFormat), want: 0, ok: true},
+		{name: "empty", value: "", ok: false},
+		{name: "negative", value: "-1", ok: false},
+		{name: "fraction", value: "1.5", ok: false},
+		{name: "malformed", value: "later", ok: false},
+		{name: "duration overflow", value: "9223372037", ok: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseRetryAfter(tc.value, now)
+			if ok != tc.ok {
+				t.Fatalf("parseRetryAfter(%q) ok = %v, want %v", tc.value, ok, tc.ok)
+			}
+			if tc.ok && got != tc.want {
+				t.Errorf("parseRetryAfter(%q) = %v, want %v", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHTTPTransportRateLimitClassification(t *testing.T) {
+	signer := newTestSigner(t)
+
+	tests := []struct {
+		name      string
+		status    int
+		header    string
+		rpcErr    *JsonRpcError
+		wantRetry time.Duration
+		wantRate  bool
+	}{
+		{name: "JSON-RPC retry data", status: http.StatusOK, rpcErr: &JsonRpcError{Code: JsonRpcTooManyRequests, Message: "tenant limited", Data: json.RawMessage(`{"retryAfterSec":2}`)}, wantRetry: 2 * time.Second, wantRate: true},
+		{name: "header overrides JSON-RPC data", status: http.StatusTooManyRequests, header: "5", rpcErr: &JsonRpcError{Code: JsonRpcTooManyRequests, Message: "tenant limited", Data: json.RawMessage(`{"retryAfterSec":2}`)}, wantRetry: 5 * time.Second, wantRate: true},
+		{name: "JSON-RPC default delay", status: http.StatusOK, rpcErr: &JsonRpcError{Code: JsonRpcTooManyRequests, Message: "tenant limited"}, wantRetry: time.Second, wantRate: true},
+		{name: "message text alone is not rate limit", status: http.StatusOK, rpcErr: &JsonRpcError{Code: JsonRpcInvalidParams, Message: "RateLimitExceeded: not actually a 429"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.header != "" {
+					w.Header().Set("Retry-After", tc.header)
+				}
+				w.WriteHeader(tc.status)
+				if err := json.NewEncoder(w).Encode(JsonRpcResponse{JSONRPC: "2.0", ID: "test", Error: tc.rpcErr}); err != nil {
+					t.Errorf("encoding response: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			transport := NewHTTPTransport(server.URL)
+			msg, _ := BuildRecordsQuery(signer, RecordsFilter{Protocol: "test"}, "", nil, "")
+
+			_, err := transport.Send(context.Background(), "did:dht:target", msg, nil)
+			if err == nil {
+				t.Fatal("expected transport error")
+			}
+
+			gotRate := errors.Is(err, ErrRateLimited)
+			if gotRate != tc.wantRate {
+				t.Fatalf("errors.Is(%v, ErrRateLimited) = %v, want %v", err, gotRate, tc.wantRate)
+			}
+			if !tc.wantRate {
+				var rpcErr *JsonRpcError
+				if !errors.As(err, &rpcErr) {
+					t.Fatalf("error = %T %v, want *JsonRpcError", err, err)
+				}
+				return
+			}
+
+			var rateErr *RateLimitError
+			if !errors.As(err, &rateErr) {
+				t.Fatalf("error = %T %v, want *RateLimitError", err, err)
+			}
+			if rateErr.RetryAfter != tc.wantRetry {
+				t.Errorf("RetryAfter = %v, want %v", rateErr.RetryAfter, tc.wantRetry)
+			}
+		})
+	}
+}
+
+func TestHTTPTransportPreservesCanceledContext(t *testing.T) {
+	signer := newTestSigner(t)
+	msg, err := BuildRecordsQuery(signer, RecordsFilter{Protocol: "test"}, "", nil, "")
+	if err != nil {
+		t.Fatalf("BuildRecordsQuery: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	transport := NewHTTPTransport("http://127.0.0.1:1")
+	_, err = transport.Send(ctx, "did:dht:target", msg, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Send error = %v, want context canceled", err)
+	}
+	if !errors.Is(err, ErrTransport) {
+		t.Fatalf("Send error = %v, want ErrTransport", err)
 	}
 }


### PR DESCRIPTION
## Summary

- cache validated role-audience delivery keys by protocol, role path, and key ID while coalescing concurrent misses
- classify HTTP, JSON-RPC, and embedded DWN 429 responses and honor one bounded retry with cancellation preserved
- make state refreshes transactional so a rate-limited lookup retains the last complete peer map instead of publishing a collapsed map
- add endpoint failure/recovery diagnostics and regression coverage for concurrency, cancellation, retries, and rollback

Closes #249.

## Validation

- go build ./...
- go vet ./...
- go test ./... -count=1 -race
- focused cache/retry/rollback tests repeated 20 times under the race detector